### PR TITLE
hot fix for conda/genome-database installers: 1) wrong path for picar…

### DIFF
--- a/installers/install_dependencies.sh
+++ b/installers/install_dependencies.sh
@@ -48,10 +48,6 @@ source activate encode-chip-seq-pipeline
   # # install R-spp 1.4
   # Rscript -e "install.packages('phantompeakqualtools-1.2/spp_1.14.tar.gz')"
 
-  # decompress MACS2 python egg
-  cd $CONDA_LIB/python2.7/site-packages
-  unzip -o MACS2-2.1.1.20160309-py2.7-linux-x86_64.egg
-  
   # install picard 2.10.6
   wget -N -c https://github.com/broadinstitute/picard/releases/download/2.10.6/picard.jar
   chmod +x picard.jar
@@ -60,6 +56,10 @@ source activate encode-chip-seq-pipeline
   if [[ $(find $CONDA_LIB -name '*egg-info*' -not -perm -o+r | wc -l ) > 0 ]]; then
     find $CONDA_LIB -name '*egg-info*' -not -perm -o+r -exec dirname {} \; | xargs chmod o+r -R
   fi
+
+  # decompress MACS2 python egg
+  cd $CONDA_LIB/python2.7/site-packages
+  unzip -o MACS2-2.1.1.20160309-py2.7-linux-x86_64.egg
 
 source deactivate
 

--- a/installers/install_genome_data.sh
+++ b/installers/install_genome_data.sh
@@ -184,9 +184,9 @@ touch null
 
 if [[ ${TSS_ENRICH} != "" ]]; then
   wget -N -c ${TSS_ENRICH}
-  echo -e "tss\t${DEST_DIR}/ataqc/$(basename ${TSS_ENRICH})" >> ${TSV}
+  echo -e "tss_enrich\t${DEST_DIR}/ataqc/$(basename ${TSS_ENRICH})" >> ${TSV}
 else
-  echo -e "tss\t${DEST_DIR}/ataqc/null" >> ${TSV}
+  echo -e "tss_enrich\t${DEST_DIR}/ataqc/null" >> ${TSV}
 fi
 if [[ ${DNASE} != "" ]]; then
   wget -N -c ${DNASE}


### PR DESCRIPTION
hot fix for conda/genome-database installers:

sync with https://github.com/ENCODE-DCC/atac-seq-pipeline/pull/14