### PR TITLE
Hotfix v1.1.6

### DIFF
--- a/chip.wdl
+++ b/chip.wdl
@@ -358,7 +358,8 @@ workflow chip {
 		}
 	}
 
-	Array[File] tas_xcor = if length(xcor_scores)>0 then []
+	Array[File] tas_xcor = if length(fraglen)>0 then []
+		else if length(xcor_scores)>0 then []
 		else if length(bam2ta_no_filt_R1.ta)>0 then bam2ta_no_filt_R1.ta
 		else if length(bam2ta_no_filt.ta)>0 then bam2ta_no_filt.ta
 		else tas__

--- a/chip.wdl
+++ b/chip.wdl
@@ -361,7 +361,7 @@ workflow chip {
 	Array[File] tas_xcor = if length(xcor_scores)>0 then []
 		else if length(bam2ta_no_filt_R1.ta)>0 then bam2ta_no_filt_R1.ta
 		else if length(bam2ta_no_filt.ta)>0 then bam2ta_no_filt.ta
-		else flatten([bam2ta.ta, tas__])
+		else tas__
 	Boolean paired_end_xcor = paired_end && length(bam2ta_no_filt_R1.ta)<1
 	scatter(ta in tas_xcor) {
 		# use trimmed/unfilitered R1 tagAlign for paired end dataset 		

--- a/chip.wdl
+++ b/chip.wdl
@@ -936,7 +936,7 @@ workflow chip {
 		pipeline_type = pipeline_type,
 		peak_caller = peak_caller_,
 		macs2_cap_num_peak = macs2_cap_num_peak,
-		macs2_cap_num_peak = spp_cap_num_peak,		
+		spp_cap_num_peak = spp_cap_num_peak,		
 		idr_thresh = idr_thresh,
 
 		flagstat_qcs = flagstat_qcs_,

--- a/src/encode_macs2_chip.py
+++ b/src/encode_macs2_chip.py
@@ -18,6 +18,8 @@ def parse_arguments():
                         help='Path for TAGALIGN file (first) and control TAGALIGN file (second; optional).')
     parser.add_argument('--fraglen', type=int, required=True,
                         help='Fragment length.')
+    parser.add_argument('--shift', type=int, default=0,
+                        help='macs2 callpeak --shift.')
     parser.add_argument('--chrsz', type=str,
                         help='2-col chromosome sizes file.')
     parser.add_argument('--gensz', type=str,
@@ -46,7 +48,7 @@ def parse_arguments():
     log.info(sys.argv)
     return args
 
-def macs2(ta, ctl_ta, chrsz, gensz, pval_thresh, fraglen, cap_num_peak, 
+def macs2(ta, ctl_ta, chrsz, gensz, pval_thresh, shift, fraglen, cap_num_peak,
         make_signal, out_dir):
     basename_ta = os.path.basename(strip_ext_ta(ta))
     if ctl_ta:
@@ -194,7 +196,7 @@ def main():
     log.info('Calling peaks and generating signal tracks with MACS2...')
     npeak, fc_bigwig, pval_bigwig = macs2(
         args.tas[0], args.tas[1], args.chrsz, args.gensz, args.pval_thresh,
-        args.fraglen, args.cap_num_peak, args.make_signal, 
+        args.shift, args.fraglen, args.cap_num_peak, args.make_signal,
         args.out_dir)
 
     log.info('Blacklist-filtering peaks...')


### PR DESCRIPTION
* others
    - remove unnecessary xcor calls.
    - make MACS2 task compatible with chip-nexus pipeline.
    - skip cross-corr analysis when `chip.fraglen` is explicitly given in an input JSON.