### PR TITLE
hotfix for singularity 3.1

### DIFF
--- a/backends/backend.conf
+++ b/backends/backend.conf
@@ -44,9 +44,10 @@ backend {
           Int? memory_mb
           String singularity_container
           String? singularity_bindpath
+          String? singularity_ld_library_path
         """
         submit = """
-          ls ${singularity_container} $(echo ${singularity_bindpath} | tr , ' ') 1>/dev/null && (echo "chmod u+x ${script} && SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} ${script}" | qsub \
+          ls ${singularity_container} $(echo ${singularity_bindpath} | tr , ' ') 1>/dev/null && (echo "chmod u+x ${script} && LD_LIBRARY_PATH=${singularity_ld_library_path}:$LD_LIBRARY_PATH SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} ${script}" | qsub \
           -N ${job_name} \
           -o ${out} \
           -e ${err} \
@@ -76,6 +77,7 @@ backend {
           String? slurm_extra_param
           String singularity_container
           String? singularity_bindpath
+          String? singularity_ld_library_path
         """
         submit = """
           ls ${singularity_container} $(echo ${singularity_bindpath} | tr , ' ') 1>/dev/null && (sbatch \
@@ -93,7 +95,7 @@ backend {
           ${"--account " + slurm_account} \
           ${"--gres gpu:" + gpu} \
           ${slurm_extra_param} \
-          --wrap "chmod u+x ${script} && SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} ${script}")
+          --wrap "chmod u+x ${script} && LD_LIBRARY_PATH=${singularity_ld_library_path}:$LD_LIBRARY_PATH SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} ${script}")
         """
         kill = "scancel ${job_id}"
         check-alive = "squeue -j ${job_id}"
@@ -116,9 +118,10 @@ backend {
           String? sge_extra_param
           String singularity_container
           String? singularity_bindpath
+          String? singularity_ld_library_path
         """
         submit = """
-          ls ${singularity_container} $(echo ${singularity_bindpath} | tr , ' ') 1>/dev/null && (echo "chmod u+x ${script} && SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} ${script}" | qsub \
+          ls ${singularity_container} $(echo ${singularity_bindpath} | tr , ' ') 1>/dev/null && (echo "chmod u+x ${script} && LD_LIBRARY_PATH=${singularity_ld_library_path}:$LD_LIBRARY_PATH SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} ${script}" | qsub \
           -S /bin/sh \
           -terse \
           -b n \
@@ -151,9 +154,10 @@ backend {
           Int? gpu
           String singularity_container
           String? singularity_bindpath
+          String? singularity_ld_library_path
         """
         submit = """
-          ls ${singularity_container} $(echo ${singularity_bindpath} | tr , ' ') 1>/dev/null && (chmod u+x ${script} && SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} ${script} & echo $! && disown)
+          ls ${singularity_container} $(echo ${singularity_bindpath} | tr , ' ') 1>/dev/null && (chmod u+x ${script} && LD_LIBRARY_PATH=${singularity_ld_library_path}:$LD_LIBRARY_PATH SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} ${script} & echo $! && disown)
         """
         job-id-regex = "(\\d+)"
         check-alive = "ps -ef | grep -v grep | grep ${job_id}" 

--- a/workflow_opts/scg.json
+++ b/workflow_opts/scg.json
@@ -2,6 +2,7 @@
     "default_runtime_attributes" : {
         "slurm_account" : "YOUR_SLURM_ACCOUNT",
         "singularity_container" : "/reference/ENCODE/pipeline_singularity_images/chip-seq-pipeline-v1.1.6.simg",
+        "singularity_ld_library_path" : "/opt/intel/compilers_and_libraries_2018.0.128/linux/mkl/lib/intel64_lin:/usr/local/lib",
         "singularity_bindpath" : "/reference/ENCODE,/scratch,/srv/gsfs0"        
     }
 }

--- a/workflow_opts/sge.json
+++ b/workflow_opts/sge.json
@@ -1,6 +1,7 @@
 {
     "default_runtime_attributes" : {
         "sge_pe" : "shm",
-        "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.1.6.simg"
+        "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.1.6.simg",
+        "singularity_ld_library_path" : "/opt/intel/compilers_and_libraries_2018.0.128/linux/mkl/lib/intel64_lin:/usr/local/lib"
     }
 }

--- a/workflow_opts/sherlock.json
+++ b/workflow_opts/sherlock.json
@@ -2,6 +2,7 @@
     "default_runtime_attributes" : {
         "slurm_partition" : "normal",
         "singularity_container" : "/home/groups/cherry/encode/pipeline_singularity_images/chip-seq-pipeline-v1.1.6.simg",
+        "singularity_ld_library_path" : "/opt/intel/compilers_and_libraries_2018.0.128/linux/mkl/lib/intel64_lin:/usr/local/lib",
         "singularity_bindpath" : "/scratch,/lscratch,/oak/stanford,/home/groups/cherry/encode"
     }
 }

--- a/workflow_opts/singularity.json
+++ b/workflow_opts/singularity.json
@@ -1,5 +1,6 @@
 {
     "default_runtime_attributes" : {
-        "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.1.6.simg"
+        "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.1.6.simg",
+        "singularity_ld_library_path" : "/opt/intel/compilers_and_libraries_2018.0.128/linux/mkl/lib/intel64_lin:/usr/local/lib"
     }
 }

--- a/workflow_opts/slurm.json
+++ b/workflow_opts/slurm.json
@@ -2,6 +2,7 @@
     "default_runtime_attributes" : {
         "slurm_partition" : "YOUR_SLURM_PARTITION",
         "slurm_account" : "YOUR_SLURM_ACCOUNT",
-        "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.1.6.simg"
+        "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.1.6.simg",
+        "singularity_ld_library_path" : "/opt/intel/compilers_and_libraries_2018.0.128/linux/mkl/lib/intel64_lin:/usr/local/lib"
     }
 }


### PR DESCRIPTION
singularity 3.1 ignores `LD_LIBRARY_PATH` defined in `Dockerfile`.

This hotfix adds `String? singularity_ld_library_path` to a workflow options JSON file and passes it to a singularity backend. `LD_LIBRARY_PATH` defined in `Dockerfile` is `/opt/intel/compilers_and_libraries_2018.0.128/linux/mkl/lib/intel64_lin:/usr/local/lib` for ATAC-seq/ChIP-seq/ChIP-nexus.