### PR TITLE
Pip 774 updates for v1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,7 @@ This ChIP-Seq pipeline is based off the ENCODE (phase-3) transcription factor an
 
 ## Installation
 
-1) [Install Caper](https://github.com/ENCODE-DCC/caper#installation). Caper is a python wrapper for [Cromwell](https://github.com/broadinstitute/cromwell).
-
-	> **IMPORTANT**: Make sure that you have python3(> 3.4.1) installed on your system.
-
-	```bash
-	$ pip install caper  # use pip3 if it doesn't work
-	```
-
-2) Follow [Caper's README](https://github.com/ENCODE-DCC/caper) carefully. Find an instruction for your platform.
-	> **IMPORTANT**: Configure your Caper configuration file `~/.caper/default.conf` correctly for your platform.
-
-3) Git clone this pipeline.
+1) Git clone this pipeline.
 	> **IMPORTANT*: use `~/chip-seq-pipeline2/chip.wdl` as `[WDL]` in Caper's documentation.
 
 	```bash
@@ -32,8 +21,20 @@ This ChIP-Seq pipeline is based off the ENCODE (phase-3) transcription factor an
 	$ git clone https://github.com/ENCODE-DCC/chip-seq-pipeline2
 	```
 
-4) Install pipeline's [Conda environment](docs/install_conda.md) if you want to use Conda instead of Docker/Singularity. Conda is recommneded on local computer and HPCs (e.g. Stanford Sherlock/SCG). Use 
+2) Install pipeline's [Conda environment](docs/install_conda.md) if you want to use Conda instead of Docker/Singularity. Conda is recommneded on local computer and HPCs (e.g. Stanford Sherlock/SCG). Use 
 	> **IMPORTANT*: use `encode-chip-seq-pipeline` as `[PIPELINE_CONDA_ENV]` in Caper's documentation.
+
+3) **Skip this step if you have installed pipeline's Conda environment**. Caper is already included in the Conda environment. [Install Caper](https://github.com/ENCODE-DCC/caper#installation). Caper is a python wrapper for [Cromwell](https://github.com/broadinstitute/cromwell).
+
+	> **IMPORTANT**: Make sure that you have python3(> 3.4.1) installed on your system.
+
+	```bash
+	$ pip install caper  # use pip3 if it doesn't work
+	```
+
+4) Follow [Caper's README](https://github.com/ENCODE-DCC/caper) carefully. Find an instruction for your platform.
+	> **IMPORTANT**: Configure your Caper configuration file `~/.caper/default.conf` correctly for your platform.
+
 
 ## Test input JSON file
 
@@ -60,7 +61,7 @@ You can also run this pipeline on DNAnexus without using Caper or Cromwell. Ther
 
 ## How to organize outputs
 
-Install [Croo](https://github.com/ENCODE-DCC/croo#installation). Make sure that you have python3(> 3.4.1) installed on your system. Find a `metadata.json` on Caper's output directory.
+Install [Croo](https://github.com/ENCODE-DCC/croo#installation). **You can skip this installation if you have installed pipeline's Conda environment and activated it**. Make sure that you have python3(> 3.4.1) installed on your system. Find a `metadata.json` on Caper's output directory.
 
 ```bash
 $ pip install croo

--- a/chip.wdl
+++ b/chip.wdl
@@ -1,12 +1,12 @@
 # ENCODE TF/Histone ChIP-Seq pipeline
 # Author: Jin Lee (leepc12@gmail.com)
 
-#CAPER docker quay.io/encode-dcc/chip-seq-pipeline:v1.3.1
-#CAPER singularity docker://quay.io/encode-dcc/chip-seq-pipeline:v1.3.1
+#CAPER docker quay.io/encode-dcc/chip-seq-pipeline:dev-v1.3.2
+#CAPER singularity docker://quay.io/encode-dcc/chip-seq-pipeline:dev-v1.3.2
 #CROO out_def https://storage.googleapis.com/encode-pipeline-output-definition/chip.croo.json
 
 workflow chip {
-	String pipeline_ver = 'v1.3.1'
+	String pipeline_ver = 'dev-v1.3.2'
 	### sample name, description
 	String title = 'Untitled'
 	String description = 'No description'

--- a/chip.wdl
+++ b/chip.wdl
@@ -755,7 +755,7 @@ workflow chip {
 				pval_thresh = pval_thresh,
 				fraglen = fraglen_tmp[i],
 				blacklist = blacklist_,
-				keep_irregular_chr_in_bfilt_peak = keep_irregular_chr_in_bfilt_peak,
+				regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
 
 				cpu = call_peak_cpu,
 				mem_mb = call_peak_mem_mb,
@@ -796,7 +796,7 @@ workflow chip {
 				pval_thresh = pval_thresh,
 				fraglen = fraglen_tmp[i],
 				blacklist = blacklist_,
-				keep_irregular_chr_in_bfilt_peak = keep_irregular_chr_in_bfilt_peak,
+				regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
 	
 				cpu = call_peak_cpu,
 				mem_mb = call_peak_mem_mb,
@@ -822,7 +822,7 @@ workflow chip {
 				pval_thresh = pval_thresh,
 				fraglen = fraglen_tmp[i],
 				blacklist = blacklist_,
-				keep_irregular_chr_in_bfilt_peak = keep_irregular_chr_in_bfilt_peak,
+				regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
 
 				cpu = call_peak_cpu,
 				mem_mb = call_peak_mem_mb,
@@ -864,7 +864,7 @@ workflow chip {
 			pval_thresh = pval_thresh,
 			fraglen = fraglen_mean.rounded_mean,
 			blacklist = blacklist_,
-			keep_irregular_chr_in_bfilt_peak = keep_irregular_chr_in_bfilt_peak,
+			regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
 
 			cpu = call_peak_cpu,
 			mem_mb = call_peak_mem_mb,
@@ -905,7 +905,7 @@ workflow chip {
 			pval_thresh = pval_thresh,
 			fraglen = fraglen_mean.rounded_mean,
 			blacklist = blacklist_,
-			keep_irregular_chr_in_bfilt_peak = keep_irregular_chr_in_bfilt_peak,
+			regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
 
 			cpu = call_peak_cpu,
 			mem_mb = call_peak_mem_mb,
@@ -931,7 +931,7 @@ workflow chip {
 			pval_thresh = pval_thresh,
 			fraglen = fraglen_mean.rounded_mean,
 			blacklist = blacklist_,
-			keep_irregular_chr_in_bfilt_peak = keep_irregular_chr_in_bfilt_peak,
+			regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
 
 			cpu = call_peak_cpu,
 			mem_mb = call_peak_mem_mb,
@@ -965,7 +965,7 @@ workflow chip {
 				peak_type = peak_type_,
 				blacklist = blacklist_,
 				chrsz = chrsz_,
-				keep_irregular_chr_in_bfilt_peak = keep_irregular_chr_in_bfilt_peak,
+				regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
 				ta = pool_ta.ta_pooled,
 			}
 		}
@@ -987,7 +987,7 @@ workflow chip {
 				rank = idr_rank_,
 				blacklist = blacklist_,
 				chrsz = chrsz_,
-				keep_irregular_chr_in_bfilt_peak = keep_irregular_chr_in_bfilt_peak,
+				regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
 				ta = pool_ta.ta_pooled,
 			}
 		}
@@ -1005,7 +1005,7 @@ workflow chip {
 				peak_type = peak_type_,
 				blacklist = blacklist_,
 				chrsz = chrsz_,
-				keep_irregular_chr_in_bfilt_peak = keep_irregular_chr_in_bfilt_peak,
+				regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
 				ta = ta_[i],
 			}
 		}
@@ -1025,7 +1025,7 @@ workflow chip {
 				rank = idr_rank_,
 				blacklist = blacklist_,
 				chrsz = chrsz_,
-				keep_irregular_chr_in_bfilt_peak = keep_irregular_chr_in_bfilt_peak,
+				regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
 				ta = ta_[i],
 			}
 		}
@@ -1042,7 +1042,7 @@ workflow chip {
 			fraglen = fraglen_mean.rounded_mean,
 			blacklist = blacklist_,
 			chrsz = chrsz_,
-			keep_irregular_chr_in_bfilt_peak = keep_irregular_chr_in_bfilt_peak,
+			regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
 			ta = pool_ta.ta_pooled,
 		}
 	}
@@ -1060,7 +1060,7 @@ workflow chip {
 			rank = idr_rank_,
 			blacklist = blacklist_,
 			chrsz = chrsz_,
-			keep_irregular_chr_in_bfilt_peak = keep_irregular_chr_in_bfilt_peak,
+			regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
 			ta = pool_ta.ta_pooled,
 		}
 	}
@@ -1075,7 +1075,6 @@ workflow chip {
 			peak_ppr = overlap_ppr.bfilt_overlap_peak,
 			peak_type = peak_type_,
 			chrsz = chrsz_,
-			keep_irregular_chr_in_bfilt_peak = keep_irregular_chr_in_bfilt_peak,
 		}
 	}
 
@@ -1088,7 +1087,6 @@ workflow chip {
 			peak_ppr = idr_ppr.bfilt_idr_peak,
 			peak_type = peak_type_,
 			chrsz = chrsz_,
-			keep_irregular_chr_in_bfilt_peak = keep_irregular_chr_in_bfilt_peak,
 		}
 	}
 

--- a/chip.wdl
+++ b/chip.wdl
@@ -1189,6 +1189,8 @@ task align {
 	Array[Array[File]] tmp_fastqs = if paired_end then transpose([fastqs_R1, fastqs_R2])
 				else transpose([fastqs_R1])
 	command {
+		set -e
+
 		# check if pipeline dependencies can be found
 		if [[ -z "$(which encode_task_merge_fastq.py 2> /dev/null || true)" ]]
 		then
@@ -1198,7 +1200,7 @@ task align {
 		  echo 'GCP/AWS/Docker users: Did you add --docker flag to Caper command line arg?' 1>&2
 		  echo 'Singularity users: Did you add --singularity flag to Caper command line arg?' 1>&2
 		  echo -e "\n" 1>&2
-		  EXCEPTION_RAISED
+		  exit 3
 		fi
 		python3 $(which encode_task_merge_fastq.py) \
 			${write_tsv(tmp_fastqs)} \
@@ -1526,6 +1528,8 @@ task call_peak {
 	String disks
 
 	command {
+		set -e
+
 		if [ '${peak_caller}' == 'macs2' ]; then
 			python3 $(which encode_task_macs2_chip.py) \
 				${sep=' ' tas} \
@@ -1998,7 +2002,7 @@ task raise_exception {
 	String msg
 	command {
 		echo -e "\n* Error: ${msg}\n" >&2
-		EXCEPTION_RAISED
+		exit 2
 	}
 	output {
 		String error_msg = '${msg}'

--- a/dev/dev.md
+++ b/dev/dev.md
@@ -2,8 +2,8 @@
 
 ## Command line for version change
 ```bash
-PREV_VER=v1.3.1
-NEW_VER=v1.3.1
+PREV_VER=dev-v1.3.2
+NEW_VER=dev-v1.3.2
 for f in $(grep -rl ${PREV_VER} --include=*.{wdl,md,sh})
 do
   sed -i "s/${PREV_VER}/${NEW_VER}/g" ${f}
@@ -24,7 +24,7 @@ Run the following command line locally to build out DX workflows for this pipeli
 
 ```bash
 # version
-VER=v1.3.1
+VER=dev-v1.3.2
 DOCKER=quay.io/encode-dcc/chip-seq-pipeline:$VER
 
 # general

--- a/dev/examples/caper/ENCSR936XTK_subsampled_chr19_only.json
+++ b/dev/examples/caper/ENCSR936XTK_subsampled_chr19_only.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "https://storage.googleapis.com/encode-pipeline-genome-data/hg38_chr19_chrM_caper.tsv",
+    "chip.genome_tsv" : "https://storage.googleapis.com/encode-pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_caper.tsv",
     "chip.fastqs_rep1_R1" : ["https://storage.googleapis.com/encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq_subsampled/rep1-R1.subsampled.67.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["https://storage.googleapis.com/encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq_subsampled/rep1-R2.subsampled.67.fastq.gz"

--- a/dev/examples/caper/ENCSR936XTK_subsampled_chr19_only_rm_chrM.json
+++ b/dev/examples/caper/ENCSR936XTK_subsampled_chr19_only_rm_chrM.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "https://storage.googleapis.com/encode-pipeline-genome-data/hg38_chr19_chrM_caper.tsv",
+    "chip.genome_tsv" : "https://storage.googleapis.com/encode-pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_caper.tsv",
     "chip.fastqs_rep1_R1" : ["https://storage.googleapis.com/encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq_subsampled/rep1-R1.subsampled.67.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["https://storage.googleapis.com/encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq_subsampled/rep1-R2.subsampled.67.fastq.gz"

--- a/dev/examples/dx/ENCSR000DYI_dx.json
+++ b/dev/examples/dx/ENCSR000DYI_dx.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/hg38_dx.tsv",
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg38_dx.tsv",
     "chip.fastqs_rep1_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep1.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep2.fastq.gz"

--- a/dev/examples/dx/ENCSR000DYI_subsampled_chr19_only_dx.json
+++ b/dev/examples/dx/ENCSR000DYI_subsampled_chr19_only_dx.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/hg38_chr19_chrM_dx.tsv",
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_dx.tsv",
     "chip.fastqs_rep1_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep1.subsampled.25.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep2.subsampled.20.fastq.gz"

--- a/dev/examples/dx/ENCSR000DYI_subsampled_chr19_only_old_fraglen_dx.json
+++ b/dev/examples/dx/ENCSR000DYI_subsampled_chr19_only_old_fraglen_dx.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/hg38_chr19_chrM_dx.tsv",
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_dx.tsv",
     "chip.fastqs_rep1_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep1.subsampled.25.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep2.subsampled.20.fastq.gz"

--- a/dev/examples/dx/ENCSR000DYI_subsampled_chr19_only_rep1_dx.json
+++ b/dev/examples/dx/ENCSR000DYI_subsampled_chr19_only_rep1_dx.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/hg38_chr19_chrM_dx.tsv",
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_dx.tsv",
     "chip.fastqs_rep1_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep1.subsampled.25.fastq.gz"
     ],
     "chip.ctl_fastqs_rep1_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/ctl1.subsampled.25.fastq.gz"

--- a/dev/examples/dx/ENCSR000DYI_subsampled_dx.json
+++ b/dev/examples/dx/ENCSR000DYI_subsampled_dx.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/hg38_dx.tsv",
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg38_dx.tsv",
     "chip.fastqs_rep1_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep1.subsampled.25.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep2.subsampled.15.fastq.gz"

--- a/dev/examples/dx/ENCSR000DYI_subsampled_rep1_dx.json
+++ b/dev/examples/dx/ENCSR000DYI_subsampled_rep1_dx.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/hg38_dx.tsv",
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg38_dx.tsv",
     "chip.fastqs_rep1_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep1.subsampled.25.fastq.gz"
     ],
     "chip.ctl_fastqs_rep1_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/ctl1.subsampled.25.fastq.gz"

--- a/dev/examples/dx/ENCSR936XTK_dx.json
+++ b/dev/examples/dx/ENCSR936XTK_dx.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/hg38_dx.tsv",
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg38_dx.tsv",
 
     "chip.fastqs_rep1_R1" : [
       "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.fastq.gz"

--- a/dev/examples/dx/ENCSR936XTK_subsampled_chr19_only_dx.json
+++ b/dev/examples/dx/ENCSR936XTK_subsampled_chr19_only_dx.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/hg38_chr19_chrM_dx.tsv",
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_dx.tsv",
 
     "chip.fastqs_rep1_R1" : [
       "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq_subsampled/rep1-R1.subsampled.67.fastq.gz"

--- a/dev/examples/dx/ENCSR936XTK_subsampled_chr19_only_old_fraglen_dx.json
+++ b/dev/examples/dx/ENCSR936XTK_subsampled_chr19_only_old_fraglen_dx.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/hg38_chr19_chrM_dx.tsv",
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_dx.tsv",
 
     "chip.fastqs_rep1_R1" : [
       "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq_subsampled/rep1-R1.subsampled.67.fastq.gz"

--- a/dev/examples/dx/ENCSR936XTK_subsampled_chr19_only_single_rep_dx.json
+++ b/dev/examples/dx/ENCSR936XTK_subsampled_chr19_only_single_rep_dx.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/hg38_chr19_chrM_dx.tsv",
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_dx.tsv",
 
     "chip.fastqs_rep1_R1" : [
       "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq_subsampled/rep1-R1.subsampled.67.fastq.gz"

--- a/dev/examples/dx/ENCSR936XTK_subsampled_dx.json
+++ b/dev/examples/dx/ENCSR936XTK_subsampled_dx.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/hg38_dx.tsv",
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg38_dx.tsv",
 
     "chip.fastqs_rep1_R1" : [
       "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq_subsampled/rep1-R1.subsampled.67.fastq.gz"

--- a/dev/examples/dx/template_hg19.json
+++ b/dev/examples/dx/template_hg19.json
@@ -1,4 +1,4 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/hg19_dx.tsv"
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg19_dx.tsv"
 }

--- a/dev/examples/dx/template_hg38.json
+++ b/dev/examples/dx/template_hg38.json
@@ -1,4 +1,4 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/hg38_dx.tsv"
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg38_dx.tsv"
 }

--- a/dev/examples/dx/template_mm10.json
+++ b/dev/examples/dx/template_mm10.json
@@ -1,4 +1,4 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/mm10_dx.tsv"
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/mm10_dx.tsv"
 }

--- a/dev/examples/dx/template_mm9.json
+++ b/dev/examples/dx/template_mm9.json
@@ -1,4 +1,4 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/mm9_dx.tsv"
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/mm9_dx.tsv"
 }

--- a/dev/examples/dx_azure/ENCSR000DYI_dx_azure.json
+++ b/dev/examples/dx_azure/ENCSR000DYI_dx_azure.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/hg38_dx_azure.tsv",
+    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/hg38_dx_azure.tsv",
     "chip.fastqs_rep1_R1" : ["dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep1.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep2.fastq.gz"

--- a/dev/examples/dx_azure/ENCSR000DYI_subsampled_chr19_only_dx_azure.json
+++ b/dev/examples/dx_azure/ENCSR000DYI_subsampled_chr19_only_dx_azure.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/hg38_chr19_chrM_dx_azure.tsv",
+    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_dx_azure.tsv",
     "chip.fastqs_rep1_R1" : ["dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep1.subsampled.25.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep2.subsampled.15.fastq.gz"

--- a/dev/examples/dx_azure/ENCSR000DYI_subsampled_dx_azure.json
+++ b/dev/examples/dx_azure/ENCSR000DYI_subsampled_dx_azure.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/hg38_dx_azure.tsv",
+    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/hg38_dx_azure.tsv",
     "chip.fastqs_rep1_R1" : ["dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep1.subsampled.25.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep2.subsampled.15.fastq.gz"

--- a/dev/examples/dx_azure/ENCSR936XTK_dx_azure.json
+++ b/dev/examples/dx_azure/ENCSR936XTK_dx_azure.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/hg38_dx_azure.tsv",
+    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/hg38_dx_azure.tsv",
 
     "chip.fastqs_rep1_R1" : [
       "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.fastq.gz"

--- a/dev/examples/dx_azure/ENCSR936XTK_subsampled_chr19_only_dx_azure.json
+++ b/dev/examples/dx_azure/ENCSR936XTK_subsampled_chr19_only_dx_azure.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/hg38_chr19_chrM_dx_azure.tsv",
+    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_dx_azure.tsv",
 
     "chip.fastqs_rep1_R1" : [
       "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq_subsampled/rep1-R1.subsampled.67.fastq.gz"

--- a/dev/examples/dx_azure/ENCSR936XTK_subsampled_dx_azure.json
+++ b/dev/examples/dx_azure/ENCSR936XTK_subsampled_dx_azure.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/hg38_dx_azure.tsv",
+    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/hg38_dx_azure.tsv",
 
     "chip.fastqs_rep1_R1" : [
       "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq_subsampled/rep1-R1.subsampled.67.fastq.gz"

--- a/dev/examples/dx_azure/template_hg19.json
+++ b/dev/examples/dx_azure/template_hg19.json
@@ -1,4 +1,4 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/hg19_dx_azure.tsv"
+    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/hg19_dx_azure.tsv"
 }

--- a/dev/examples/dx_azure/template_hg38.json
+++ b/dev/examples/dx_azure/template_hg38.json
@@ -1,4 +1,4 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/hg38_dx_azure.tsv"
+    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/hg38_dx_azure.tsv"
 }

--- a/dev/examples/dx_azure/template_mm10.json
+++ b/dev/examples/dx_azure/template_mm10.json
@@ -1,4 +1,4 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/mm10_dx_azure.tsv"
+    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/mm10_dx_azure.tsv"
 }

--- a/dev/examples/dx_azure/template_mm9.json
+++ b/dev/examples/dx_azure/template_mm9.json
@@ -1,4 +1,4 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/mm9_dx_azure.tsv"
+    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/mm9_dx_azure.tsv"
 }

--- a/dev/examples/klab/ENCSR000DYI_klab.json
+++ b/dev/examples/klab/ENCSR000DYI_klab.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "/mnt/data/pipeline_genome_data/hg38/hg38_klab.tsv",
+    "chip.genome_tsv" : "/mnt/data/pipeline_genome_data/genome_tsv/v1/hg38/hg38_klab.tsv",
     "chip.fastqs_rep1_R1" : ["/mnt/data/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep1.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["/mnt/data/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep2.fastq.gz"

--- a/dev/examples/klab/ENCSR000DYI_subsampled_chr19_only_dx_style_fastq_input_klab.json
+++ b/dev/examples/klab/ENCSR000DYI_subsampled_chr19_only_dx_style_fastq_input_klab.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "/mnt/data/pipeline_genome_data/hg38_chr19_chrM/hg38_chr19_chrM_klab.tsv",
+    "chip.genome_tsv" : "/mnt/data/pipeline_genome_data/genome_tsv/v1/hg38_chr19_chrM/hg38_chr19_chrM_klab.tsv",
     "chip.fastqs_rep1_R1" : [
         "/mnt/data/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep1.subsampled.25.fastq.gz"
     ],

--- a/dev/examples/klab/ENCSR000DYI_subsampled_chr19_only_keep_irregular_chr_klab.json
+++ b/dev/examples/klab/ENCSR000DYI_subsampled_chr19_only_keep_irregular_chr_klab.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "/mnt/data/pipeline_genome_data/hg38_chr19_chrM/hg38_chr19_chrM_klab.tsv",
+    "chip.genome_tsv" : "/mnt/data/pipeline_genome_data/genome_tsv/v1/hg38_chr19_chrM/hg38_chr19_chrM_klab.tsv",
     "chip.fastqs_rep1_R1" : ["/mnt/data/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep1.subsampled.25.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["/mnt/data/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep2.subsampled.20.fastq.gz"

--- a/dev/examples/klab/ENCSR000DYI_subsampled_chr19_only_klab.json
+++ b/dev/examples/klab/ENCSR000DYI_subsampled_chr19_only_klab.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "/mnt/data/pipeline_genome_data/hg38_chr19_chrM/hg38_chr19_chrM_klab.tsv",
+    "chip.genome_tsv" : "/mnt/data/pipeline_genome_data/genome_tsv/v1/hg38_chr19_chrM/hg38_chr19_chrM_klab.tsv",
     "chip.fastqs_rep1_R1" : ["/mnt/data/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep1.subsampled.25.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["/mnt/data/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep2.subsampled.20.fastq.gz"

--- a/dev/examples/klab/ENCSR000DYI_subsampled_klab.json
+++ b/dev/examples/klab/ENCSR000DYI_subsampled_klab.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "/mnt/data/pipeline_genome_data/hg38/hg38_klab.tsv",
+    "chip.genome_tsv" : "/mnt/data/pipeline_genome_data/genome_tsv/v1/hg38/hg38_klab.tsv",
     "chip.fastqs_rep1_R1" : ["/mnt/data/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep1.subsampled.25.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["/mnt/data/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep2.subsampled.15.fastq.gz"

--- a/dev/examples/klab/ENCSR936XTK_klab.json
+++ b/dev/examples/klab/ENCSR936XTK_klab.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "/mnt/data/pipeline_genome_data/hg38/hg38_klab.tsv",
+    "chip.genome_tsv" : "/mnt/data/pipeline_genome_data/genome_tsv/v1/hg38/hg38_klab.tsv",
     "chip.fastqs_rep1_R1" : ["/mnt/data/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["/mnt/data/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R2.fastq.gz"

--- a/dev/examples/klab/ENCSR936XTK_subsampled_chr19_only_klab.json
+++ b/dev/examples/klab/ENCSR936XTK_subsampled_chr19_only_klab.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "/mnt/data/pipeline_genome_data/hg38_chr19_chrM/hg38_chr19_chrM_klab.tsv",
+    "chip.genome_tsv" : "/mnt/data/pipeline_genome_data/genome_tsv/v1/hg38_chr19_chrM/hg38_chr19_chrM_klab.tsv",
     "chip.fastqs_rep1_R1" : ["/mnt/data/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.subsampled.67.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["/mnt/data/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R2.subsampled.67.fastq.gz"

--- a/dev/examples/klab/ENCSR936XTK_subsampled_chr19_only_single_rep_klab.json
+++ b/dev/examples/klab/ENCSR936XTK_subsampled_chr19_only_single_rep_klab.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "/mnt/data/pipeline_genome_data/hg38_chr19_chrM/hg38_chr19_chrM_klab.tsv",
+    "chip.genome_tsv" : "/mnt/data/pipeline_genome_data/genome_tsv/v1/hg38_chr19_chrM/hg38_chr19_chrM_klab.tsv",
     "chip.fastqs_rep1_R1" : ["/mnt/data/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.subsampled.67.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["/mnt/data/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R2.subsampled.67.fastq.gz"

--- a/dev/examples/klab/ENCSR936XTK_subsampled_klab.json
+++ b/dev/examples/klab/ENCSR936XTK_subsampled_klab.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "/mnt/data/pipeline_genome_data/hg38/hg38_klab.tsv",
+    "chip.genome_tsv" : "/mnt/data/pipeline_genome_data/genome_tsv/v1/hg38/hg38_klab.tsv",
     "chip.fastqs_rep1_R1" : ["/mnt/data/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.subsampled.67.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["/mnt/data/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R2.subsampled.67.fastq.gz"

--- a/dev/examples/scg/ENCSR936XTK_subsampled_chr19_only_scg.json
+++ b/dev/examples/scg/ENCSR936XTK_subsampled_chr19_only_scg.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "/reference/ENCODE/pipeline_genome_data/hg38_chr19_chrM_scg.tsv",
+    "chip.genome_tsv" : "/reference/ENCODE/pipeline_genome_data/genome_tsv/v1/hg38_chr19_chrM_scg.tsv",
     "chip.fastqs_rep1_R1" : ["/reference/ENCODE/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.subsampled.67.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["/reference/ENCODE/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R2.subsampled.67.fastq.gz"

--- a/dev/examples/scg/ENCSR936XTK_subsampled_scg.json
+++ b/dev/examples/scg/ENCSR936XTK_subsampled_scg.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "/reference/ENCODE/pipeline_genome_data/hg38_scg.tsv",
+    "chip.genome_tsv" : "/reference/ENCODE/pipeline_genome_data/genome_tsv/v1/hg38_scg.tsv",
     "chip.fastqs_rep1_R1" : ["/reference/ENCODE/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.subsampled.67.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["/reference/ENCODE/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R2.subsampled.67.fastq.gz"

--- a/dev/examples/sherlock/ENCSR936XTK_subsampled_chr19_only_sherlock.json
+++ b/dev/examples/sherlock/ENCSR936XTK_subsampled_chr19_only_sherlock.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "/home/groups/cherry/encode/pipeline_genome_data/hg38_chr19_chrM_sherlock.tsv",
+    "chip.genome_tsv" : "/home/groups/cherry/encode/pipeline_genome_data/genome_tsv/v1/hg38_chr19_chrM_sherlock.tsv",
     "chip.fastqs_rep1_R1" : ["/home/groups/cherry/encode/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.subsampled.67.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["/home/groups/cherry/encode/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R2.subsampled.67.fastq.gz"

--- a/dev/examples/sherlock/ENCSR936XTK_subsampled_sherlock.json
+++ b/dev/examples/sherlock/ENCSR936XTK_subsampled_sherlock.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "/home/groups/cherry/encode/pipeline_genome_data/hg38_sherlock.tsv",
+    "chip.genome_tsv" : "/home/groups/cherry/encode/pipeline_genome_data/genome_tsv/v1/hg38_sherlock.tsv",
     "chip.fastqs_rep1_R1" : ["/home/groups/cherry/encode/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.subsampled.67.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["/home/groups/cherry/encode/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R2.subsampled.67.fastq.gz"

--- a/dev/examples/test_bowtie2/ENCSR000DYI_bowtie2_google.json
+++ b/dev/examples/test_bowtie2/ENCSR000DYI_bowtie2_google.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.1.5/ENCSR000DYI/qc.json",
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_google.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_google.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep1.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep2.fastq.gz"

--- a/dev/examples/test_bowtie2/ENCSR000DYI_google.json
+++ b/dev/examples/test_bowtie2/ENCSR000DYI_google.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.1.5/ENCSR000DYI/qc.json",
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_google.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_google.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep1.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep2.fastq.gz"

--- a/dev/examples/test_bowtie2/ENCSR936XTK_bowtie2_google.json
+++ b/dev/examples/test_bowtie2/ENCSR936XTK_bowtie2_google.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.1.5/ENCSR936XTK/qc.json",
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_google.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_google.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R2.fastq.gz"

--- a/dev/examples/test_bowtie2/ENCSR936XTK_google.json
+++ b/dev/examples/test_bowtie2/ENCSR936XTK_google.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.1.5/ENCSR936XTK/qc.json",
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_google.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_google.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R2.fastq.gz"

--- a/dev/examples/test_bowtie2/ENCSR936XTK_subsampled_chr19_only_bowtie2_klab.json
+++ b/dev/examples/test_bowtie2/ENCSR936XTK_subsampled_chr19_only_bowtie2_klab.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "/mnt/data/pipeline_genome_data/hg38_chr19_chrM/hg38_chr19_chrM_klab.tsv",
+    "chip.genome_tsv" : "/mnt/data/pipeline_genome_data/genome_tsv/v1/hg38_chr19_chrM/hg38_chr19_chrM_klab.tsv",
     "chip.fastqs_rep1_R1" : ["/mnt/data/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.subsampled.67.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["/mnt/data/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R2.subsampled.67.fastq.gz"

--- a/dev/test/test_task/test.sh
+++ b/dev/test/test_task/test.sh
@@ -12,7 +12,7 @@ INPUT=$2
 if [ $# -gt 2 ]; then
   DOCKER_IMAGE=$3
 else
-  DOCKER_IMAGE=quay.io/encode-dcc/chip-seq-pipeline:v1.3.1
+  DOCKER_IMAGE=quay.io/encode-dcc/chip-seq-pipeline:dev-v1.3.2
 fi
 if [ $# -gt 3 ]; then
   NUM_TASK=$4

--- a/dev/test/test_task/test_idr.wdl
+++ b/dev/test/test_task/test_idr.wdl
@@ -18,6 +18,8 @@ workflow test_idr {
 	String se_blacklist
 	String se_chrsz
 
+	String regex_bfilt_peak_chr_name = 'chr[\\dXY]+'
+
 	Int fraglen
 
 	call chip.idr as se_idr { input : 
@@ -31,7 +33,8 @@ workflow test_idr {
 		chrsz = se_chrsz,
 		fraglen = fraglen,
 		blacklist = se_blacklist,
-		keep_irregular_chr_in_bfilt_peak = false,
+		regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name,
+
 		ta = se_ta_pooled,
 	}
 

--- a/dev/test/test_task/test_macs2.wdl
+++ b/dev/test/test_task/test_macs2.wdl
@@ -20,6 +20,8 @@ workflow test_macs2 {
 	String se_chrsz
 	String se_gensz
 
+	String regex_bfilt_peak_chr_name = 'chr[\\dXY]+'
+
 	Int macs2_mem_mb = 16000
 	Int macs2_time_hr = 24
 	String macs2_disks = 'local-disk 100 HDD'	
@@ -34,7 +36,7 @@ workflow test_macs2 {
 		cap_num_peak = cap_num_peak,
 		pval_thresh = pval_thresh,
 		blacklist = se_blacklist,
-		keep_irregular_chr_in_bfilt_peak = false,
+		regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name,
 
 		cpu = 1,
 		mem_mb = macs2_mem_mb,

--- a/dev/test/test_task/test_overlap.wdl
+++ b/dev/test/test_task/test_overlap.wdl
@@ -16,6 +16,8 @@ workflow test_overlap {
 	String se_blacklist
 	String se_chrsz
 
+	String regex_bfilt_peak_chr_name = 'chr[\\dXY]+'
+
 	Int fraglen
 
 	call chip.overlap as se_overlap { input :
@@ -25,7 +27,8 @@ workflow test_overlap {
 		peak_pooled = se_peak_pooled,
 		peak_type = 'regionPeak',
 		blacklist = se_blacklist,
-		keep_irregular_chr_in_bfilt_peak = false,
+		regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name,
+
 		chrsz = se_chrsz,
 		fraglen = fraglen,
 		ta = se_ta_pooled,

--- a/dev/test/test_task/test_reproducibility.wdl
+++ b/dev/test/test_task/test_reproducibility.wdl
@@ -19,7 +19,6 @@ workflow test_reproducibility {
 		peak_ppr = se_overlap_peak_ppr,
 		peak_type = 'regionPeak',		
 		chrsz = se_chrsz,		
-		keep_irregular_chr_in_bfilt_peak = false,
 	}
 
 	call compare_md5sum.compare_md5sum { input :

--- a/dev/test/test_task/test_spp.wdl
+++ b/dev/test/test_task/test_spp.wdl
@@ -18,6 +18,8 @@ workflow test_spp {
 	String se_blacklist
 	String se_chrsz
 
+	String regex_bfilt_peak_chr_name = 'chr[\\dXY]+'
+
 	Int spp_cpu = 1
 	Int spp_mem_mb = 16000
 	Int spp_time_hr = 72
@@ -33,7 +35,7 @@ workflow test_spp {
 		fraglen = fraglen,
 		cap_num_peak = cap_num_peak,
 		blacklist = se_blacklist,
-		keep_irregular_chr_in_bfilt_peak = false,
+		regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name,
 
 		cpu = spp_cpu,
 		mem_mb = spp_mem_mb,

--- a/dev/test/test_workflow/ENCSR000DYI.json
+++ b/dev/test/test_workflow/ENCSR000DYI.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.1.5/ENCSR000DYI/qc.json",
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep1.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep2.fastq.gz"

--- a/dev/test/test_workflow/ENCSR000DYI_subsampled.json
+++ b/dev/test/test_workflow/ENCSR000DYI_subsampled.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.1.5/ENCSR000DYI_subsampled/qc.json",
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep1.subsampled.25.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep2.subsampled.15.fastq.gz"

--- a/dev/test/test_workflow/ENCSR000DYI_subsampled_chr19_only.json
+++ b/dev/test/test_workflow/ENCSR000DYI_subsampled_chr19_only.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.3.0/ENCSR000DYI_subsampled_chr19_only/qc.json",
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_chr19_chrM_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep1.subsampled.25.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep2.subsampled.20.fastq.gz"

--- a/dev/test/test_workflow/ENCSR000DYI_subsampled_chr19_only_hist.json
+++ b/dev/test/test_workflow/ENCSR000DYI_subsampled_chr19_only_hist.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.3.0/ENCSR000DYI_subsampled_chr19_only_hist/qc.json",
     "chip.pipeline_type" : "histone",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_chr19_chrM_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep1.subsampled.25.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep2.subsampled.20.fastq.gz"

--- a/dev/test/test_workflow/ENCSR000DYI_subsampled_chr19_only_hist_unrep.json
+++ b/dev/test/test_workflow/ENCSR000DYI_subsampled_chr19_only_hist_unrep.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.3.0/ENCSR000DYI_subsampled_chr19_only_hist_unrep/qc.json",
     "chip.pipeline_type" : "histone",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_chr19_chrM_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep1.subsampled.25.fastq.gz"
     ],
     "chip.ctl_fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/ctl1.subsampled.25.fastq.gz"

--- a/dev/test/test_workflow/ENCSR000DYI_subsampled_chr19_only_unrep.json
+++ b/dev/test/test_workflow/ENCSR000DYI_subsampled_chr19_only_unrep.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.3.0/ENCSR000DYI_subsampled_chr19_only_unrep/qc.json",
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_chr19_chrM_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep1.subsampled.25.fastq.gz"
     ],
     "chip.ctl_fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/ctl1.subsampled.25.fastq.gz"

--- a/dev/test/test_workflow/ENCSR203KEU.json
+++ b/dev/test/test_workflow/ENCSR203KEU.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.1.5/ENCSR936XTK/qc.json",
     "chip.pipeline_type" : "histone",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR203KEU/fastq/rep1/pair1/ENCFF950OXW.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR203KEU/fastq/rep1/pair2/ENCFF054HVM.fastq.gz"

--- a/dev/test/test_workflow/ENCSR400WEK.json
+++ b/dev/test/test_workflow/ENCSR400WEK.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.1.5/ENCSR936XTK/qc.json",
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR400WEK/fastq/rep1/pair1/ENCFF251IZE.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR400WEK/fastq/rep1/pair2/ENCFF871SZT.fastq.gz"

--- a/dev/test/test_workflow/ENCSR878KIY.json
+++ b/dev/test/test_workflow/ENCSR878KIY.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.1.5/ENCSR936XTK/qc.json",
     "chip.pipeline_type" : "histone",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_gcp.tsv",
     "chip.fastqs_rep1_R1" : [
         "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR878KIY/fastq/rep1/ENCFF846MLZ.fastq.gz",
         "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR878KIY/fastq/rep1/ENCFF153OYB.fastq.gz"

--- a/dev/test/test_workflow/ENCSR936XTK.json
+++ b/dev/test/test_workflow/ENCSR936XTK.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.1.5/ENCSR936XTK/qc.json",
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R2.fastq.gz"

--- a/dev/test/test_workflow/ENCSR936XTK_subsampled.json
+++ b/dev/test/test_workflow/ENCSR936XTK_subsampled.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.1.5/ENCSR936XTK_subsampled/qc.json",
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq_subsampled/rep1-R1.subsampled.50.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq_subsampled/rep1-R2.subsampled.50.fastq.gz"

--- a/dev/test/test_workflow/ENCSR936XTK_subsampled_chr19_only.json
+++ b/dev/test/test_workflow/ENCSR936XTK_subsampled_chr19_only.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.3.0/ENCSR936XTK_subsampled_chr19_only/qc.json",
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_chr19_chrM_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq_subsampled/rep1-R1.subsampled.50.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq_subsampled/rep1-R2.subsampled.50.fastq.gz"

--- a/dev/test/test_workflow/ENCSR936XTK_subsampled_chr19_only_hist.json
+++ b/dev/test/test_workflow/ENCSR936XTK_subsampled_chr19_only_hist.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.3.0/ENCSR936XTK_subsampled_chr19_only_hist/qc.json",
     "chip.pipeline_type" : "histone",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_chr19_chrM_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq_subsampled/rep1-R1.subsampled.50.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq_subsampled/rep1-R2.subsampled.50.fastq.gz"

--- a/dev/test/test_workflow/ENCSR970FPM.json
+++ b/dev/test/test_workflow/ENCSR970FPM.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.1.5/ENCSR936XTK/qc.json",
     "chip.pipeline_type" : "histone",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR970FPM/fastq/rep1/ENCFF774JBP.fastq.gz"
     ],
     "chip.paired_end" : false,

--- a/dev/test/test_workflow/benchmark/ENCSR000DYI_bwa.json
+++ b/dev/test/test_workflow/benchmark/ENCSR000DYI_bwa.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.1.5/ENCSR000DYI/qc.json",
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep1.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep2.fastq.gz"

--- a/dev/test/test_workflow/benchmark/ENCSR000DYI_m0_q255.json
+++ b/dev/test/test_workflow/benchmark/ENCSR000DYI_m0_q255.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.1.5/ENCSR000DYI/qc.json",
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep1.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep2.fastq.gz"

--- a/dev/test/test_workflow/benchmark/ENCSR000DYI_m0_q30.json
+++ b/dev/test/test_workflow/benchmark/ENCSR000DYI_m0_q30.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.1.5/ENCSR000DYI/qc.json",
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep1.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep2.fastq.gz"

--- a/dev/test/test_workflow/benchmark/ENCSR000DYI_m0_q40.json
+++ b/dev/test/test_workflow/benchmark/ENCSR000DYI_m0_q40.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.1.5/ENCSR000DYI/qc.json",
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep1.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep2.fastq.gz"

--- a/dev/test/test_workflow/benchmark/ENCSR000DYI_m4_q255.json
+++ b/dev/test/test_workflow/benchmark/ENCSR000DYI_m4_q255.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.1.5/ENCSR000DYI/qc.json",
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep1.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep2.fastq.gz"

--- a/dev/test/test_workflow/benchmark/ENCSR000DYI_m4_q30.json
+++ b/dev/test/test_workflow/benchmark/ENCSR000DYI_m4_q30.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.1.5/ENCSR000DYI/qc.json",
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep1.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep2.fastq.gz"

--- a/dev/test/test_workflow/benchmark/ENCSR000DYI_m4_q40.json
+++ b/dev/test/test_workflow/benchmark/ENCSR000DYI_m4_q40.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.1.5/ENCSR000DYI/qc.json",
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep1.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep2.fastq.gz"

--- a/dev/test/test_workflow/benchmark/ENCSR936XTK_bwa.json
+++ b/dev/test/test_workflow/benchmark/ENCSR936XTK_bwa.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.1.5/ENCSR936XTK/qc.json",
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R2.fastq.gz"

--- a/dev/test/test_workflow/benchmark/ENCSR936XTK_m0_q255.json
+++ b/dev/test/test_workflow/benchmark/ENCSR936XTK_m0_q255.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.1.5/ENCSR936XTK/qc.json",
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R2.fastq.gz"

--- a/dev/test/test_workflow/benchmark/ENCSR936XTK_m0_q30.json
+++ b/dev/test/test_workflow/benchmark/ENCSR936XTK_m0_q30.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.1.5/ENCSR936XTK/qc.json",
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R2.fastq.gz"

--- a/dev/test/test_workflow/benchmark/ENCSR936XTK_m0_q40.json
+++ b/dev/test/test_workflow/benchmark/ENCSR936XTK_m0_q40.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.1.5/ENCSR936XTK/qc.json",
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R2.fastq.gz"

--- a/dev/test/test_workflow/benchmark/ENCSR936XTK_m4_q255.json
+++ b/dev/test/test_workflow/benchmark/ENCSR936XTK_m4_q255.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.1.5/ENCSR936XTK/qc.json",
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R2.fastq.gz"

--- a/dev/test/test_workflow/benchmark/ENCSR936XTK_m4_q30.json
+++ b/dev/test/test_workflow/benchmark/ENCSR936XTK_m4_q30.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.1.5/ENCSR936XTK/qc.json",
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R2.fastq.gz"

--- a/dev/test/test_workflow/benchmark/ENCSR936XTK_m4_q40.json
+++ b/dev/test/test_workflow/benchmark/ENCSR936XTK_m4_q40.json
@@ -1,7 +1,7 @@
 {
     "chip.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ref_output/v1.1.5/ENCSR936XTK/qc.json",
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R2.fastq.gz"

--- a/dev/test/test_workflow/test_chip.sh
+++ b/dev/test/test_workflow/test_chip.sh
@@ -8,7 +8,7 @@ fi
 if [ $# -gt 2 ]; then
   DOCKER_IMAGE=$3
 else
-  DOCKER_IMAGE=quay.io/encode-dcc/chip-seq-pipeline:v1.3.1
+  DOCKER_IMAGE=quay.io/encode-dcc/chip-seq-pipeline:dev-v1.3.2
 fi
 INPUT=$1
 GCLOUD_SERVICE_ACCOUNT_SECRET_JSON_FILE=$2

--- a/dev/workflow_opts/docker.json
+++ b/dev/workflow_opts/docker.json
@@ -1,6 +1,6 @@
 {
     "default_runtime_attributes" : {
-        "docker" : "quay.io/encode-dcc/chip-seq-pipeline:v1.3.1",
+        "docker" : "quay.io/encode-dcc/chip-seq-pipeline:dev-v1.3.2",
         "zones": "us-west1-a us-west1-b us-west1-c us-central1-c us-central1-b",
         "failOnStderr" : false,
         "continueOnReturnCode" : 0,

--- a/dev/workflow_opts/scg.json
+++ b/dev/workflow_opts/scg.json
@@ -1,7 +1,7 @@
 {
     "default_runtime_attributes" : {
         "slurm_account" : "YOUR_SLURM_ACCOUNT",
-        "singularity_container" : "/reference/ENCODE/pipeline_singularity_images/chip-seq-pipeline-v1.3.1.simg",
+        "singularity_container" : "/reference/ENCODE/pipeline_singularity_images/chip-seq-pipeline-dev-v1.3.2.simg",
         "singularity_bindpath" : "/reference/ENCODE,/scratch,/srv/gsfs0"        
     }
 }

--- a/dev/workflow_opts/sge.json
+++ b/dev/workflow_opts/sge.json
@@ -1,6 +1,6 @@
 {
     "default_runtime_attributes" : {
         "sge_pe" : "shm",
-        "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.3.1.simg"
+        "singularity_container" : "~/.singularity/chip-seq-pipeline-dev-v1.3.2.simg"
     }
 }

--- a/dev/workflow_opts/sherlock.json
+++ b/dev/workflow_opts/sherlock.json
@@ -1,7 +1,7 @@
 {
     "default_runtime_attributes" : {
         "slurm_partition" : "normal",
-        "singularity_container" : "/home/groups/cherry/encode/pipeline_singularity_images/chip-seq-pipeline-v1.3.1.simg",
+        "singularity_container" : "/home/groups/cherry/encode/pipeline_singularity_images/chip-seq-pipeline-dev-v1.3.2.simg",
         "singularity_bindpath" : "/scratch,/lscratch,/oak/stanford,/home/groups/cherry/encode"
     }
 }

--- a/dev/workflow_opts/singularity.json
+++ b/dev/workflow_opts/singularity.json
@@ -1,5 +1,5 @@
 {
     "default_runtime_attributes" : {
-        "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.3.1.simg"
+        "singularity_container" : "~/.singularity/chip-seq-pipeline-dev-v1.3.2.simg"
     }
 }

--- a/dev/workflow_opts/slurm.json
+++ b/dev/workflow_opts/slurm.json
@@ -2,6 +2,6 @@
     "default_runtime_attributes" : {
         "slurm_partition" : "YOUR_SLURM_PARTITION",
         "slurm_account" : "YOUR_SLURM_ACCOUNT",
-        "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.3.1.simg"
+        "singularity_container" : "~/.singularity/chip-seq-pipeline-dev-v1.3.2.simg"
     }
 }

--- a/docs/build_genome_database.md
+++ b/docs/build_genome_database.md
@@ -16,14 +16,14 @@
 
 2. Install pipeline's Conda environment.
     ```bash
-    $ bash conda/uninstall_conda_env.sh  # to remove any existing pipeline env
-    $ bash conda/install_conda_env.sh
+    $ bash scripts/uninstall_conda_env.sh  # to remove any existing pipeline env
+    $ bash scripts/install_conda_env.sh
     ```
 
 2. Choose `GENOME` from `hg19`, `hg38`, `mm9` and `mm10` and specify a destination directory. This will take several hours. We recommend not to run this installer on a login node of your cluster. It will take >8GB memory and >2h time.
     ```bash
     $ conda activate encode-chip-seq-pipeline
-    $ bash conda/build_genome_data.sh [GENOME] [DESTINATION_DIR]
+    $ bash scripts/build_genome_data.sh [GENOME] [DESTINATION_DIR]
     ```
 
 3. Find a TSV file on the destination directory and use it for `"chip.genome_tsv"` in your input JSON.
@@ -42,12 +42,13 @@
 
 3. Get a URL for a gzipped blacklist BED file for your genome. If you don't have one then skip this step. An example blacklist for hg38 is [here](http://mitra.stanford.edu/kundaje/genome_data/hg38/hg38.blacklist.bed.gz).
 
-4. Find the following lines in `conda/build_genome_data.sh` and modify it. Give a good name `[YOUR_OWN_GENOME]` for your genome.
+4. Find the following lines in `scripts/build_genome_data.sh` and modify it. Give a good name `[YOUR_OWN_GENOME]` for your genome. For `MITO_CHR_NAME` use a correct mitochondrial chromosome name of your genome (e.g. `chrM` and `MT`).
     ```bash
     ...
 
     elif [[ $GENOME == "YOUR_OWN_GENOME" ]]; then
       REF_FA="URL_FOR_YOUR_FASTA_OR_2BIT"
+      MITO_CHR_NAME="chrM"
       BLACKLIST= # leave it empty if you don't have it
 
     ...
@@ -55,7 +56,7 @@
 
 5. Specify a destination directory for your genome database and run the installer. This will take several hours.
     ```bash
-    $ bash conda/build_genome_data.sh [YOUR_OWN_GENOME] [DESTINATION_DIR]
+    $ bash scripts/build_genome_data.sh [YOUR_OWN_GENOME] [DESTINATION_DIR]
     ```
 
 6. Find a TSV file in the destination directory and use it for `"chip.genome_tsv"` in your input JSON.

--- a/docs/build_genome_database.md
+++ b/docs/build_genome_database.md
@@ -42,7 +42,7 @@
 
 3. Get a URL for a gzipped blacklist BED file for your genome. If you don't have one then skip this step. An example blacklist for hg38 is [here](http://mitra.stanford.edu/kundaje/genome_data/hg38/hg38.blacklist.bed.gz).
 
-4. Find the following lines in `scripts/build_genome_data.sh` and modify it. Give a good name `[YOUR_OWN_GENOME]` for your genome. For `MITO_CHR_NAME` use a correct mitochondrial chromosome name of your genome (e.g. `chrM` or `MT`). For `REGEX_BFILT_PEAK_CHR_NAME` Perl style regular expression must be used to keep regular chromosome names only in a blacklist filtered (`.bfilt.`) peaks files. This `.bfilt.` peak files are considered final peaks output of the pipeline and peaks BED files for genome browser tracks (`.bigBed` and `.hammock.gz`) are converted from these `.bfilt.` peaks files. Chromosome name filtering with `REGEX_BFILT_PEAK_CHR_NAME` will be done even without the blacklist itself.
+4. Find the following lines in `scripts/build_genome_data.sh` and modify them as follows. Give a good name `[YOUR_OWN_GENOME]` for your genome. For `MITO_CHR_NAME` use a correct mitochondrial chromosome name of your genome (e.g. `chrM` or `MT`). For `REGEX_BFILT_PEAK_CHR_NAME` Perl style regular expression must be used to keep regular chromosome names only in a blacklist filtered (`.bfilt.`) peaks files. This `.bfilt.` peak files are considered final peaks output of the pipeline and peaks BED files for genome browser tracks (`.bigBed` and `.hammock.gz`) are converted from these `.bfilt.` peaks files. Chromosome name filtering with `REGEX_BFILT_PEAK_CHR_NAME` will be done even without the blacklist itself.
     ```bash
     ...
 

--- a/docs/build_genome_database.md
+++ b/docs/build_genome_database.md
@@ -42,15 +42,24 @@
 
 3. Get a URL for a gzipped blacklist BED file for your genome. If you don't have one then skip this step. An example blacklist for hg38 is [here](http://mitra.stanford.edu/kundaje/genome_data/hg38/hg38.blacklist.bed.gz).
 
-4. Find the following lines in `scripts/build_genome_data.sh` and modify it. Give a good name `[YOUR_OWN_GENOME]` for your genome. For `MITO_CHR_NAME` use a correct mitochondrial chromosome name of your genome (e.g. `chrM` and `MT`).
+4. Find the following lines in `scripts/build_genome_data.sh` and modify it. Give a good name `[YOUR_OWN_GENOME]` for your genome. For `MITO_CHR_NAME` use a correct mitochondrial chromosome name of your genome (e.g. `chrM` or `MT`). For `REGEX_BFILT_PEAK_CHR_NAME` Perl style regular expression must be used to keep regular chromosome names only in a blacklist filtered (`.bfilt.`) peaks files. This `.bfilt.` peak files are considered final peaks output of the pipeline and peaks BED files for genome browser tracks (`.bigBed` and `.hammock.gz`) are converted from these `.bfilt.` peaks files. Chromosome name filtering with `REGEX_BFILT_PEAK_CHR_NAME` will be done even without the blacklist itself.
     ```bash
     ...
 
     elif [[ $GENOME == "YOUR_OWN_GENOME" ]]; then
-      REF_FA="URL_FOR_YOUR_FASTA_OR_2BIT"
+      # Perl style regular expression to keep regular chromosomes only.
+      # this reg-ex will be applied to peaks after blacklist filtering (b-filt) with "grep -P".
+      # so that b-filt peak file (.bfilt.*Peak.gz) will only have chromosomes matching with this pattern
+      # this reg-ex will work even without a blacklist.
+      # you will still be able to find a .bfilt. peak file
+      REGEX_BFILT_PEAK_CHR_NAME="chr[\dXY]+"
+      # mitochondrial chromosome name (e.g. chrM, MT)
       MITO_CHR_NAME="chrM"
-      BLACKLIST= # leave it empty if you don't have it
-
+      # URL for your reference FASTA (fasta, fasta.gz, fa, fa.gz, 2bit)
+      REF_FA="https://some.where.com/your.genome.fa.gz"
+      # 3-col blacklist BED file to filter out overlapping peaks from b-filt peak file (.bfilt.*Peak.gz file).
+      # leave it empty if you don't have one
+      BLACKLIST=
     ...
     ```
 

--- a/docs/deprecated/tutorial_local_singularity.md
+++ b/docs/deprecated/tutorial_local_singularity.md
@@ -33,7 +33,7 @@
 
 6. Pull a singularity container for the pipeline. This will pull pipeline's docker container first and build a singularity one on `~/.singularity`.
     ```bash
-    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name chip-seq-pipeline-v1.3.1.simg -F docker://quay.io/encode-dcc/chip-seq-pipeline:v1.3.1
+    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name chip-seq-pipeline-dev-v1.3.2.simg -F docker://quay.io/encode-dcc/chip-seq-pipeline:dev-v1.3.2
     ```
 
 7. Run a pipeline for the test sample.
@@ -53,7 +53,7 @@
     ```javascript
     {
         "default_runtime_attributes" : {
-            "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.3.1.simg",
+            "singularity_container" : "~/.singularity/chip-seq-pipeline-dev-v1.3.2.simg",
             "singularity_bindpath" : "/your/,YOUR_OWN_DATA_DIR1,YOUR_OWN_DATA_DIR2,..."
         }
     }

--- a/docs/deprecated/tutorial_scg.md
+++ b/docs/deprecated/tutorial_scg.md
@@ -63,7 +63,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
     ```javascript
     {
         "default_runtime_attributes" : {
-            "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.3.1.simg",
+            "singularity_container" : "~/.singularity/chip-seq-pipeline-dev-v1.3.2.simg",
             "singularity_bindpath" : "/reference/ENCODE,/scratch,/srv/gsfs0,YOUR_OWN_DATA_DIR1,YOUR_OWN_DATA_DIR1,..."
         }
     }

--- a/docs/deprecated/tutorial_scg_backend.md
+++ b/docs/deprecated/tutorial_scg_backend.md
@@ -58,7 +58,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
 5. Pull a singularity container for the pipeline. This will pull pipeline's docker container first and build a singularity one on `~/.singularity`.
     ```bash
     $ sdev    # SCG cluster does not allow building a container on login node
-    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name chip-seq-pipeline-v1.3.1.simg -F docker://quay.io/encode-dcc/chip-seq-pipeline:v1.3.1
+    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name chip-seq-pipeline-dev-v1.3.2.simg -F docker://quay.io/encode-dcc/chip-seq-pipeline:dev-v1.3.2
     $ exit
     ```
 
@@ -77,7 +77,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
     ```javascript
     {
         "default_runtime_attributes" : {
-            "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.3.1.simg",
+            "singularity_container" : "~/.singularity/chip-seq-pipeline-dev-v1.3.2.simg",
             "singularity_bindpath" : "/scratch/users,/srv/gsfs0,/your/,YOUR_OWN_DATA_DIR1,YOUR_OWN_DATA_DIR1,..."
         }
     }

--- a/docs/deprecated/tutorial_sge.md
+++ b/docs/deprecated/tutorial_sge.md
@@ -61,7 +61,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
 
 7. Pull a singularity container for the pipeline. This will pull pipeline's docker container first and build a singularity one on `~/.singularity`.
     ```bash
-    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name chip-seq-pipeline-v1.3.1.simg -F docker://quay.io/encode-dcc/chip-seq-pipeline:v1.3.1
+    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name chip-seq-pipeline-dev-v1.3.2.simg -F docker://quay.io/encode-dcc/chip-seq-pipeline:dev-v1.3.2
     ```
 
 8. Run a pipeline for the test sample. If your parallel environment (PE) found from step 5) has a different name from `shm` then edit the following shell script to change the PE name.
@@ -83,7 +83,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
     ```javascript
     {
         "default_runtime_attributes" : {
-            "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.3.1.simg",
+            "singularity_container" : "~/.singularity/chip-seq-pipeline-dev-v1.3.2.simg",
             "singularity_bindpath" : "/your/,YOUR_OWN_DATA_DIR1,YOUR_OWN_DATA_DIR2,..."
         }
     }

--- a/docs/deprecated/tutorial_sge_backend.md
+++ b/docs/deprecated/tutorial_sge_backend.md
@@ -68,7 +68,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
 
 7. Pull a singularity container for the pipeline. This will pull pipeline's docker container first and build a singularity one on `~/.singularity`.
     ```bash
-    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name chip-seq-pipeline-v1.3.1.simg -F docker://quay.io/encode-dcc/chip-seq-pipeline:v1.1
+    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name chip-seq-pipeline-dev-v1.3.2.simg -F docker://quay.io/encode-dcc/chip-seq-pipeline:v1.1
     ```
 
 8. Run a pipeline for the test sample.

--- a/docs/deprecated/tutorial_sherlock.md
+++ b/docs/deprecated/tutorial_sherlock.md
@@ -68,7 +68,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
     ```javascript
     {
         "default_runtime_attributes" : {
-            "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.3.1.simg",
+            "singularity_container" : "~/.singularity/chip-seq-pipeline-dev-v1.3.2.simg",
             "singularity_bindpath" : "/scratch,/lscratch,/oak/stanford,/home/groups/cherry/encode,/your/,YOUR_OWN_DATA_DIR1,YOUR_OWN_DATA_DIR1,..."
         }
     }

--- a/docs/deprecated/tutorial_sherlock_backend.md
+++ b/docs/deprecated/tutorial_sherlock_backend.md
@@ -63,7 +63,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
 6. Pull a singularity container for the pipeline. This will pull pipeline's docker container first and build a singularity one on `~/.singularity`. Stanford Sherlock does not allow building a container on login nodes. Wait until you get a command prompt after `sdev`.
     ```bash
     $ sdev    # sherlock cluster does not allow building a container on login node
-    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name chip-seq-pipeline-v1.3.1.simg -F docker://quay.io/encode-dcc/chip-seq-pipeline:v1.3.1
+    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name chip-seq-pipeline-dev-v1.3.2.simg -F docker://quay.io/encode-dcc/chip-seq-pipeline:dev-v1.3.2
     $ exit    # exit from an interactive node
     ```
 
@@ -82,7 +82,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
     ```javascript
     {
         "default_runtime_attributes" : {
-            "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.3.1.simg",
+            "singularity_container" : "~/.singularity/chip-seq-pipeline-dev-v1.3.2.simg",
             "singularity_bindpath" : "/scratch,/oak/stanford,/your/,YOUR_OWN_DATA_DIR1,YOUR_OWN_DATA_DIR1,..."
         }
     }

--- a/docs/deprecated/tutorial_slurm.md
+++ b/docs/deprecated/tutorial_slurm.md
@@ -56,7 +56,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
 
 7. Pull a singularity container for the pipeline. This will pull pipeline's docker container first and build a singularity one on `~/.singularity`.
     ```bash
-    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name chip-seq-pipeline-v1.3.1.simg -F docker://quay.io/encode-dcc/chip-seq-pipeline:v1.3.1
+    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name chip-seq-pipeline-dev-v1.3.2.simg -F docker://quay.io/encode-dcc/chip-seq-pipeline:dev-v1.3.2
     ```
 
 8. Run a pipeline for the test sample. If your cluster requires to specify any of them then add one to the command line.
@@ -78,7 +78,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
     ```javascript
     {
         "default_runtime_attributes" : {
-            "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.3.1.simg",
+            "singularity_container" : "~/.singularity/chip-seq-pipeline-dev-v1.3.2.simg",
             "singularity_bindpath" : "/your/,YOUR_OWN_DATA_DIR1,YOUR_OWN_DATA_DIR2,..."
         }
     }

--- a/docs/deprecated/tutorial_slurm_backend.md
+++ b/docs/deprecated/tutorial_slurm_backend.md
@@ -68,7 +68,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
 
 7. Pull a singularity container for the pipeline. This will pull pipeline's docker container first and build a singularity one on `~/.singularity`.
     ```bash
-    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name chip-seq-pipeline-v1.3.1.simg -F docker://quay.io/encode-dcc/chip-seq-pipeline:v1.3.1
+    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name chip-seq-pipeline-dev-v1.3.2.simg -F docker://quay.io/encode-dcc/chip-seq-pipeline:dev-v1.3.2
     ```
 
 8. Run a pipeline for the test sample.
@@ -86,7 +86,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
     ```javascript
       {
           "default_runtime_attributes" : {
-              "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.3.1.simg",
+              "singularity_container" : "~/.singularity/chip-seq-pipeline-dev-v1.3.2.simg",
               "singularity_bindpath" : "/your/,YOUR_OWN_DATA_DIR1,YOUR_OWN_DATA_DIR2,..."
           }
       }

--- a/docs/input.md
+++ b/docs/input.md
@@ -39,6 +39,7 @@ Parameter|Type|Description
 `chip.blacklist`| File | 3-col BED file. Peaks overlapping these regions will be filtered out
 `chip.gensz`| String | MACS2's genome sizes (hs for human, mm for mouse or sum of 2nd col in chrsz)
 `chip.mito_chr_name`| String | Name of mitochondrial chromosome (e.g. chrM)
+`chip.regex_bfilt_peak_chr_name`| String | Perl style reg-ex to keep peaks on selected chromosomes only matching with this pattern (default: `chr[\dXY]+`. This will keep chr1, chr2, ... chrX and chrY in `.bfilt.` peaks file. chrM is not included here)
 
 We currently provide TSV files for 4 genomes as shown in the below table. `GENOME` should be `hg38`, `mm10`, `hg19` or `mm9`. You can [download/build](build_genome_database.md) it on your local computer. You can also [build a genome database for your own genome](build_genome_database.md).
 
@@ -180,7 +181,6 @@ Parameter|Default|Description
 `chip.enable_jsd` | true | Enable deeptools fingerprint (JS distance)
 `chip.enable_gc_bias` | true | Enable GC bias calculation
 `chip.enable_count_signal_track` | false | Enable count signal track generation
-`chip.keep_irregular_chr_in_bfilt_peak` | false | Keep irregular chromosome names. Use this for custom genomes without canonical chromosome names (chr1, chrX, ...)
 
 ## Other optional parameters
 

--- a/docs/input.md
+++ b/docs/input.md
@@ -44,14 +44,14 @@ We currently provide TSV files for 4 genomes as shown in the below table. `GENOM
 
 Platform|Path/URI
 -|-
-Google Cloud Platform|`gs://encode-pipeline-genome-data/[GENOME]_gcp.tsv`
-Stanford Sherlock|`/home/groups/cherry/encode/pipeline_genome_data/[GENOME]_sherlock.tsv`
-Stanford SCG|`/reference/ENCODE/pipeline_genome_data/[GENOME]_scg.tsv`
+Google Cloud Platform|`gs://encode-pipeline-genome-data/genome_tsv/v1/[GENOME]_gcp.tsv`
+Stanford Sherlock|`/home/groups/cherry/encode/pipeline_genome_data/genome_tsv/v1/[GENOME]_sherlock.tsv`
+Stanford SCG|`/reference/ENCODE/pipeline_genome_data/genome_tsv/v1/[GENOME]_scg.tsv`
 Local/SLURM/SGE|You need to [build](build_genome_database.md) or [download]() a genome database]. 
-DNAnexus (CLI)|`dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/[GENOME]_dx.tsv`
-DNAnexus (CLI, Azure)|`dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/[GENOME]_dx_azure.tsv`
-DNAnexus (Web)|Choose `[GENOME]_dx.tsv` from [here](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/pipeline-genome-data)
-DNAnexus (Web, Azure)|Choose `[GENOME]_dx.tsv` from [here](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/pipeline-genome-data)
+DNAnexus (CLI)|`dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/[GENOME]_dx.tsv`
+DNAnexus (CLI, Azure)|`dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/[GENOME]_dx_azure.tsv`
+DNAnexus (Web)|Choose `[GENOME]_dx.tsv` from [here](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/pipeline-genome-data/genome_tsv/v1)
+DNAnexus (Web, Azure)|Choose `[GENOME]_dx.tsv` from [here](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/pipeline-genome-data/genome_tsv/v1)
 
 Additional information about each genome:
 

--- a/docs/tutorial_dx_cli.md
+++ b/docs/tutorial_dx_cli.md
@@ -45,7 +45,7 @@ This document describes instruction for the item 1).
     ```bash
     $ PROJECT=[YOUR_PROJECT_NAME]
     $ OUT_FOLDER=/test_sample_chip_ENCSR936XTK_subsampled_chr19_only
-    $ DOCKER=quay.io/encode-dcc/chip-seq-pipeline:v1.3.1
+    $ DOCKER=quay.io/encode-dcc/chip-seq-pipeline:dev-v1.3.2
 
     $ java -jar dxWDL-0.77.jar compile chip.wdl -project ${PROJECT} -f -folder ${OUT_FOLDER} -defaults ${INPUT} -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}")
     ```

--- a/docs/tutorial_dx_web.md
+++ b/docs/tutorial_dx_web.md
@@ -15,8 +15,8 @@ This document describes instruction for the item 2).
 
 3. Move to one of the following workflow directories according to the platform you have chosen for your project (AWS or Azure). These DX workflows are pre-built with all parameters defined.
 
-* [AWS test workflow](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ChIP-seq2/workflows/v1.3.1/test_ENCSR936XTK_subsampled_chr19_only)
-* [Azure test workflow](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ChIP-seq2/workflows/v1.3.1/test_ENCSR936XTK_subsampled_chr19_only)
+* [AWS test workflow](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ChIP-seq2/workflows/dev-v1.3.2/test_ENCSR936XTK_subsampled_chr19_only)
+* [Azure test workflow](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ChIP-seq2/workflows/dev-v1.3.2/test_ENCSR936XTK_subsampled_chr19_only)
 
 4. Copy it to your project by right-clicking on the DX workflow `chip` and choose "Copy". 
 
@@ -40,16 +40,16 @@ This document describes instruction for the item 2).
 1. DNAnexus allows only one copy of a workflow per project. The example workflow in the previous section is pre-built for the subsampled test sample [ENCSR936XTK](https://www.encodeproject.org/experiments/ENCSR936XTK/) with all parameters defined already.
 
 2. Copy one of the following workflows according to the platform you have chosen for your project (AWS or Azure).
-* [AWS general](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ChIP-seq2/workflows/v1.3.1/general) without pre-defined reference genome.
-* [AWS hg38](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ChIP-seq2/workflows/v1.3.1/hg38) with pre-defined hg38 reference genome.
-* [AWS hg19](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ChIP-seq2/workflows/v1.3.1/hg19) with pre-defined hg19 reference genome.
-* [AWS mm10](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ChIP-seq2/workflows/v1.3.1/mm10) with pre-defined mm10 reference genome.
-* [AWS mm9](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ChIP-seq2/workflows/v1.3.1/mm9) with pre-defined mm9 reference genome.
-* [Azure general](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ChIP-seq2/workflows/v1.3.1/general) without pre-defined reference genome.
-* [Azure hg38](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ChIP-seq2/workflows/v1.3.1/hg38) with pre-defined hg38 reference genome.
-* [Azure hg19](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ChIP-seq2/workflows/v1.3.1/hg19) with pre-defined hg19 reference genome.
-* [Azure mm10](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ChIP-seq2/workflows/v1.3.1/mm10) with pre-defined mm10 reference genome.
-* [Azure mm9](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ChIP-seq2/workflows/v1.3.1/mm9) with pre-defined mm9 reference genome.
+* [AWS general](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ChIP-seq2/workflows/dev-v1.3.2/general) without pre-defined reference genome.
+* [AWS hg38](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ChIP-seq2/workflows/dev-v1.3.2/hg38) with pre-defined hg38 reference genome.
+* [AWS hg19](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ChIP-seq2/workflows/dev-v1.3.2/hg19) with pre-defined hg19 reference genome.
+* [AWS mm10](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ChIP-seq2/workflows/dev-v1.3.2/mm10) with pre-defined mm10 reference genome.
+* [AWS mm9](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ChIP-seq2/workflows/dev-v1.3.2/mm9) with pre-defined mm9 reference genome.
+* [Azure general](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ChIP-seq2/workflows/dev-v1.3.2/general) without pre-defined reference genome.
+* [Azure hg38](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ChIP-seq2/workflows/dev-v1.3.2/hg38) with pre-defined hg38 reference genome.
+* [Azure hg19](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ChIP-seq2/workflows/dev-v1.3.2/hg19) with pre-defined hg19 reference genome.
+* [Azure mm10](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ChIP-seq2/workflows/dev-v1.3.2/mm10) with pre-defined mm10 reference genome.
+* [Azure mm9](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ChIP-seq2/workflows/dev-v1.3.2/mm9) with pre-defined mm9 reference genome.
 
 3. Click on the DX workflow `chip`.
 

--- a/example_input_json/caper/ENCSR000DYI_subsampled_chr19_only_caper.json
+++ b/example_input_json/caper/ENCSR000DYI_subsampled_chr19_only_caper.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "https://storage.googleapis.com/encode-pipeline-genome-data/hg38_chr19_chrM_caper.tsv",
+    "chip.genome_tsv" : "https://storage.googleapis.com/encode-pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_caper.tsv",
     "chip.fastqs_rep1_R1" : ["https://storage.googleapis.com/encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep1.subsampled.25.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["https://storage.googleapis.com/encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep2.subsampled.20.fastq.gz"

--- a/example_input_json/caper/ENCSR936XTK_subsampled_chr19_only_caper.json
+++ b/example_input_json/caper/ENCSR936XTK_subsampled_chr19_only_caper.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "https://storage.googleapis.com/encode-pipeline-genome-data/hg38_chr19_chrM_caper.tsv",
+    "chip.genome_tsv" : "https://storage.googleapis.com/encode-pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_caper.tsv",
     "chip.fastqs_rep1_R1" : ["https://storage.googleapis.com/encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq_subsampled/rep1-R1.subsampled.50.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["https://storage.googleapis.com/encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq_subsampled/rep1-R2.subsampled.50.fastq.gz"

--- a/example_input_json/dx/ENCSR000DYI_dx.json
+++ b/example_input_json/dx/ENCSR000DYI_dx.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/hg38_dx.tsv",
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg38_dx.tsv",
     "chip.fastqs_rep1_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep1.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep2.fastq.gz"

--- a/example_input_json/dx/ENCSR000DYI_subsampled_chr19_only_dx.json
+++ b/example_input_json/dx/ENCSR000DYI_subsampled_chr19_only_dx.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/hg38_chr19_chrM_dx.tsv",
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_dx.tsv",
     "chip.fastqs_rep1_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep1.subsampled.25.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep2.subsampled.20.fastq.gz"

--- a/example_input_json/dx/ENCSR000DYI_subsampled_chr19_only_rep1_dx.json
+++ b/example_input_json/dx/ENCSR000DYI_subsampled_chr19_only_rep1_dx.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/hg38_chr19_chrM_dx.tsv",
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_dx.tsv",
     "chip.fastqs_rep1_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep1.subsampled.25.fastq.gz"
     ],
     "chip.ctl_fastqs_rep1_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/ctl1.subsampled.25.fastq.gz"

--- a/example_input_json/dx/ENCSR936XTK_dx.json
+++ b/example_input_json/dx/ENCSR936XTK_dx.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/hg38_dx.tsv",
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg38_dx.tsv",
 
     "chip.fastqs_rep1_R1" : [
       "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.fastq.gz"

--- a/example_input_json/dx/template_hg19.json
+++ b/example_input_json/dx/template_hg19.json
@@ -1,4 +1,4 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/hg19_dx.tsv"
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg19_dx.tsv"
 }

--- a/example_input_json/dx/template_hg38.json
+++ b/example_input_json/dx/template_hg38.json
@@ -1,4 +1,4 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/hg38_dx.tsv"
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg38_dx.tsv"
 }

--- a/example_input_json/dx/template_mm10.json
+++ b/example_input_json/dx/template_mm10.json
@@ -1,4 +1,4 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/mm10_dx.tsv"
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/mm10_dx.tsv"
 }

--- a/example_input_json/dx/template_mm9.json
+++ b/example_input_json/dx/template_mm9.json
@@ -1,4 +1,4 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/mm9_dx.tsv"
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/mm9_dx.tsv"
 }

--- a/example_input_json/dx_azure/ENCSR000DYI_dx_azure.json
+++ b/example_input_json/dx_azure/ENCSR000DYI_dx_azure.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/hg38_dx_azure.tsv",
+    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/hg38_dx_azure.tsv",
     "chip.fastqs_rep1_R1" : ["dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep1.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep2.fastq.gz"

--- a/example_input_json/dx_azure/ENCSR000DYI_subsampled_chr19_only_dx_azure.json
+++ b/example_input_json/dx_azure/ENCSR000DYI_subsampled_chr19_only_dx_azure.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/hg38_chr19_chrM_dx_azure.tsv",
+    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_dx_azure.tsv",
     "chip.fastqs_rep1_R1" : ["dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep1.subsampled.25.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep2.subsampled.15.fastq.gz"

--- a/example_input_json/dx_azure/ENCSR936XTK_dx_azure.json
+++ b/example_input_json/dx_azure/ENCSR936XTK_dx_azure.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/hg38_dx_azure.tsv",
+    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/hg38_dx_azure.tsv",
 
     "chip.fastqs_rep1_R1" : [
       "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.fastq.gz"

--- a/example_input_json/dx_azure/template_hg19.json
+++ b/example_input_json/dx_azure/template_hg19.json
@@ -1,4 +1,4 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/hg19_dx_azure.tsv"
+    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/hg19_dx_azure.tsv"
 }

--- a/example_input_json/dx_azure/template_hg38.json
+++ b/example_input_json/dx_azure/template_hg38.json
@@ -1,4 +1,4 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/hg38_dx_azure.tsv"
+    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/hg38_dx_azure.tsv"
 }

--- a/example_input_json/dx_azure/template_mm10.json
+++ b/example_input_json/dx_azure/template_mm10.json
@@ -1,4 +1,4 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/mm10_dx_azure.tsv"
+    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/mm10_dx_azure.tsv"
 }

--- a/example_input_json/dx_azure/template_mm9.json
+++ b/example_input_json/dx_azure/template_mm9.json
@@ -1,4 +1,4 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/mm9_dx_azure.tsv"
+    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/mm9_dx_azure.tsv"
 }

--- a/example_input_json/gcp/ENCSR936XTK_subsampled_chr19_only_gcp.json
+++ b/example_input_json/gcp/ENCSR936XTK_subsampled_chr19_only_gcp.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_chr19_chrM_gcp.tsv",
+    "chip.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_gcp.tsv",
     "chip.fastqs_rep1_R1" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq_subsampled/rep1-R1.subsampled.50.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq_subsampled/rep1-R2.subsampled.50.fastq.gz"

--- a/example_input_json/klab/ENCSR000DYI_subsampled_chr19_only_klab.json
+++ b/example_input_json/klab/ENCSR000DYI_subsampled_chr19_only_klab.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "/mnt/data/pipeline_genome_data/hg38_chr19_chrM_klab.tsv",
+    "chip.genome_tsv" : "/mnt/data/pipeline_genome_data/genome_tsv/v1/hg38_chr19_chrM_klab.tsv",
     "chip.fastqs_rep1_R1" : ["/mnt/data/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep1.subsampled.25.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : ["/mnt/data/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep2.subsampled.20.fastq.gz"

--- a/example_input_json/klab/ENCSR936XTK_klab.json
+++ b/example_input_json/klab/ENCSR936XTK_klab.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "/mnt/data/pipeline_genome_data/hg38_klab.tsv",
+    "chip.genome_tsv" : "/mnt/data/pipeline_genome_data/genome_tsv/v1/hg38_klab.tsv",
     "chip.fastqs_rep1_R1" : ["/mnt/data/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["/mnt/data/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R2.fastq.gz"

--- a/example_input_json/klab/ENCSR936XTK_subsampled_chr19_only_klab.json
+++ b/example_input_json/klab/ENCSR936XTK_subsampled_chr19_only_klab.json
@@ -1,6 +1,6 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "/mnt/data/pipeline_genome_data/hg38_chr19_chrM_klab.tsv",
+    "chip.genome_tsv" : "/mnt/data/pipeline_genome_data/genome_tsv/v1/hg38_chr19_chrM_klab.tsv",
     "chip.fastqs_rep1_R1" : ["/mnt/data/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq_subsampled/rep1-R1.subsampled.50.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : ["/mnt/data/pipeline_test_samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq_subsampled/rep1-R2.subsampled.50.fastq.gz"

--- a/scripts/build_genome_data.sh
+++ b/scripts/build_genome_data.sh
@@ -22,6 +22,9 @@ BUILD_BWT2_IDX=1
 BUILD_BWT2_NTHREADS=2
 BUILD_BWA_IDX=0
 
+# parameters for genome database version (v1: <ENCODE4, v2: >=ENCODE4)
+VER=v1
+
 GENOME=$1
 DEST_DIR=$(cd $(dirname $2) && pwd -P)/$(basename $2)
 TSV=${DEST_DIR}/${GENOME}.tsv
@@ -58,9 +61,14 @@ elif [[ "${GENOME}" == "mm9" ]]; then
 elif [[ "${GENOME}" == "hg38" ]]; then
   MITO_CHR_NAME="chrM"
   REF_FA="https://www.encodeproject.org/files/GRCh38_no_alt_analysis_set_GCA_000001405.15/@@download/GRCh38_no_alt_analysis_set_GCA_000001405.15.fasta.gz"
-  BLACKLIST="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/hg38.blacklist.bed.gz"
+  if [[ "${VER}" == "v2" ]]; then
+    BLACKLIST="https://www.encodeproject.org/files/ENCFF419RSJ/@@download/ENCFF419RSJ.bed.gz"
+    TSS="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/tss.pc.gencode.v29.bed.gz"
+  else
+    BLACKLIST="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/hg38.blacklist.bed.gz"
+    TSS="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/hg38_gencode_tss_unique.bed.gz"
+  fi
   # optional data
-  TSS="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/hg38_gencode_tss_unique.bed.gz"
   DNASE="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/reg2map_honeybadger2_dnase_all_p10_ucsc.hg19_to_hg38.bed.gz"
   PROM="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/reg2map_honeybadger2_dnase_prom_p2.hg19_to_hg38.bed.gz"
   ENH="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/reg2map_honeybadger2_dnase_enh_p2.hg19_to_hg38.bed.gz"
@@ -71,7 +79,11 @@ elif [[ "${GENOME}" == "hg38" ]]; then
 elif [[ "${GENOME}" == "mm10" ]]; then
   MITO_CHR_NAME="chrM"
   REF_FA="https://www.encodeproject.org/files/mm10_no_alt_analysis_set_ENCODE/@@download/mm10_no_alt_analysis_set_ENCODE.fasta.gz"
-  BLACKLIST="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/mm10.blacklist.bed.gz"
+  if [[ "${VER}" == "v2" ]]; then
+    BLACKLIST="https://www.encodeproject.org/files/ENCFF547MET/@@download/ENCFF547MET.bed.gz"
+  else
+    BLACKLIST="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/mm10.blacklist.bed.gz"
+  fi
   # optional data
   TSS="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/ataqc/mm10_gencode_tss_unique.bed.gz"
   DNASE="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/ataqc/mm10_univ_dhs_ucsc.bed.gz"
@@ -84,9 +96,14 @@ elif [[ "${GENOME}" == "mm10" ]]; then
 elif [[ "${GENOME}" == "hg38_chr19_chrM" ]]; then
   MITO_CHR_NAME="chrM"
   REF_FA="https://storage.googleapis.com/encode-pipeline-genome-data/hg38_chr19_chrM/GRCh38_no_alt_analysis_set_GCA_000001405.15.chr19_chrM.fasta.gz"
-  BLACKLIST="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/hg38.blacklist.bed.gz"
+  if [[ "${VER}" == "v2" ]]; then
+    BLACKLIST="https://www.encodeproject.org/files/ENCFF419RSJ/@@download/ENCFF419RSJ.bed.gz"
+    TSS="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/tss.pc.gencode.v29.bed.gz"
+  else
+    BLACKLIST="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/hg38.blacklist.bed.gz"
+    TSS="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/hg38_gencode_tss_unique.bed.gz"
+  fi
   # optional data
-  TSS="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/hg38_gencode_tss_unique.bed.gz"
   DNASE="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/reg2map_honeybadger2_dnase_all_p10_ucsc.hg19_to_hg38.bed.gz"
   PROM="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/reg2map_honeybadger2_dnase_prom_p2.hg19_to_hg38.bed.gz"
   ENH="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/reg2map_honeybadger2_dnase_enh_p2.hg19_to_hg38.bed.gz"
@@ -97,7 +114,11 @@ elif [[ "${GENOME}" == "hg38_chr19_chrM" ]]; then
 elif [[ "${GENOME}" == "mm10_chr19_chrM" ]]; then
   MITO_CHR_NAME="chrM"
   REF_FA="https://storage.googleapis.com/encode-pipeline-genome-data/mm10_chr19_chrM/mm10_no_alt_analysis_set_ENCODE.chr19_chrM.fasta.gz"
-  BLACKLIST="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/mm10.blacklist.bed.gz"
+  if [[ "${VER}" == "v2" ]]; then
+    BLACKLIST="https://www.encodeproject.org/files/ENCFF547MET/@@download/ENCFF547MET.bed.gz"
+  else
+    BLACKLIST="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/mm10.blacklist.bed.gz"
+  fi
   # optional data
   TSS="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/ataqc/mm10_gencode_tss_unique.bed.gz"
   DNASE="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/ataqc/mm10_univ_dhs_ucsc.bed.gz"

--- a/scripts/download_genome_data.sh
+++ b/scripts/download_genome_data.sh
@@ -27,6 +27,8 @@ mkdir -p ${DEST_DIR}
 cd ${DEST_DIR}
 
 if [[ "${GENOME}" == "hg19" ]]; then
+  REGEX_BFILT_PEAK_CHR_NAME="chr[\dXY]+"
+  MITO_CHR_NAME="chrM"
   REF_FA="http://hgdownload.cse.ucsc.edu/goldenpath/hg19/encodeDCC/referenceSequences/male.hg19.fa.gz"
   REF_MITO_FA="https://storage.googleapis.com/encode-pipeline-genome-data/hg19/male.hg19.chrM.fa.gz"
   CHRSZ="https://storage.googleapis.com/encode-pipeline-genome-data/hg19/hg19.chrom.sizes"
@@ -35,7 +37,6 @@ if [[ "${GENOME}" == "hg19" ]]; then
   BWA_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/hg19/bwa_index/male.hg19.fa.tar"
   BWA_MITO_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/hg19/bwa_index/male.hg19.chrM.fa.tar"
   BLACKLIST="https://storage.googleapis.com/encode-pipeline-genome-data/hg19/wgEncodeDacMapabilityConsensusExcludable.bed.gz"
-  MITO_CHR_NAME="chrM"
 
   TSS="https://storage.googleapis.com/encode-pipeline-genome-data/hg19/ataqc/hg19_gencode_tss_unique.bed.gz"
   DNASE="https://storage.googleapis.com/encode-pipeline-genome-data/hg19/ataqc/reg2map_honeybadger2_dnase_all_p10_ucsc.bed.gz"
@@ -45,6 +46,8 @@ if [[ "${GENOME}" == "hg19" ]]; then
   ROADMAP_META="https://storage.googleapis.com/encode-pipeline-genome-data/hg19/ataqc/eid_to_mnemonic.txt"
 
 elif [[ "${GENOME}" == "mm9" ]]; then
+  REGEX_BFILT_PEAK_CHR_NAME="chr[\dXY]+"
+  MITO_CHR_NAME="chrM"
   REF_FA="https://storage.googleapis.com/encode-pipeline-genome-data/mm9/mm9.fa.gz"
   REF_MITO_FA="https://storage.googleapis.com/encode-pipeline-genome-data/mm9/mm9.chrM.fa.gz"
   CHRSZ="https://storage.googleapis.com/encode-pipeline-genome-data/mm9/mm9.chrom.sizes"
@@ -53,7 +56,6 @@ elif [[ "${GENOME}" == "mm9" ]]; then
   BWA_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/mm9/bwa_index/mm9.fa.tar"
   BWA_MITO_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/mm9/bwa_index/mm9.chrM.fa.tar"
   BLACKLIST="https://storage.googleapis.com/encode-pipeline-genome-data/mm9/mm9-blacklist.bed.gz"
-  MITO_CHR_NAME="chrM"
 
   TSS="https://storage.googleapis.com/encode-pipeline-genome-data/mm9/ataqc/mm9_gencode_tss_unique.bed.gz"
   DNASE="https://storage.googleapis.com/encode-pipeline-genome-data/mm9/ataqc/mm9_univ_dhs_ucsc.from_mm10.bed.gz"
@@ -64,12 +66,13 @@ elif [[ "${GENOME}" == "mm9" ]]; then
   ROADMAP_META="https://storage.googleapis.com/encode-pipeline-genome-data/mm9/ataqc/accession_to_name.txt"
 
 elif [[ "${GENOME}" == "hg38" ]]; then
+  REGEX_BFILT_PEAK_CHR_NAME="chr[\dXY]+"
+  MITO_CHR_NAME="chrM"
   REF_FA="https://www.encodeproject.org/files/GRCh38_no_alt_analysis_set_GCA_000001405.15/@@download/GRCh38_no_alt_analysis_set_GCA_000001405.15.fasta.gz"
   REF_MITO_FA="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/GRCh38_no_alt_analysis_set_GCA_000001405.15.chrM.fa.gz"
   CHRSZ="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/hg38.chrom.sizes"
   BWT2_MITO_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/bowtie2_index/GRCh38_no_alt_analysis_set_GCA_000001405.15.chrM.fa.tar"
   BWA_MITO_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/bwa_index/GRCh38_no_alt_analysis_set_GCA_000001405.15.chrM.fa.tar"
-  MITO_CHR_NAME="chrM"
   if [[ "${VER}" == "v2" ]]; then
     BWT2_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/bowtie2_index/ENCFF110MCL.tar.gz"
     BWA_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/bwa_index/ENCFF643CGH.tar.gz"
@@ -89,12 +92,13 @@ elif [[ "${GENOME}" == "hg38" ]]; then
   ROADMAP_META="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/hg38_dnase_avg_fseq_signal_metadata.txt"
 
 elif [[ "${GENOME}" == "mm10" ]]; then
+  REGEX_BFILT_PEAK_CHR_NAME="chr[\dXY]+"
+  MITO_CHR_NAME="chrM"
   REF_FA="https://www.encodeproject.org/files/mm10_no_alt_analysis_set_ENCODE/@@download/mm10_no_alt_analysis_set_ENCODE.fasta.gz"
   REF_MITO_FA="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/mm10_no_alt_analysis_set_ENCODE.chrM.fa.gz"
   CHRSZ="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/mm10.chrom.sizes"
   BWT2_MITO_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/bowtie2_index/mm10_no_alt_analysis_set_ENCODE.chrM.fa.tar"
   BWA_MITO_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/bwa_index/mm10_no_alt_analysis_set_ENCODE.chrM.fa.tar"
-  MITO_CHR_NAME="chrM"
   if [[ "${VER}" == "v2" ]]; then
     BWT2_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/bowtie2_index/ENCFF309GLL.tar.gz"
     BWA_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/bwa_index/ENCFF018NEO.tar.gz"
@@ -113,6 +117,8 @@ elif [[ "${GENOME}" == "mm10" ]]; then
   ROADMAP_META="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/ataqc/mm10_dnase_avg_fseq_signal_metadata.txt"
 
 elif [[ "${GENOME}" == "hg38_chr19_chrM" ]]; then
+  REGEX_BFILT_PEAK_CHR_NAME="chr[\dXY]+"
+  MITO_CHR_NAME="chrM"
   REF_FA="https://storage.googleapis.com/encode-pipeline-genome-data/hg38_chr19_chrM/GRCh38_no_alt_analysis_set_GCA_000001405.15.chr19_chrM.fasta.gz"
   REF_MITO_FA="https://storage.googleapis.com/encode-pipeline-genome-data/hg38_chr19_chrM/GRCh38_no_alt_analysis_set_GCA_000001405.15.chr19_chrM.chrM.fa.gz"
   CHRSZ="https://storage.googleapis.com/encode-pipeline-genome-data/hg38_chr19_chrM/hg38_chr19_chrM.chrom.sizes"
@@ -120,7 +126,6 @@ elif [[ "${GENOME}" == "hg38_chr19_chrM" ]]; then
   BWT2_MITO_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/hg38_chr19_chrM/bowtie2_index/GRCh38_no_alt_analysis_set_GCA_000001405.15.chr19_chrM.chrM.fa.tar"
   BWA_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/hg38_chr19_chrM/bwa_index/GRCh38_no_alt_analysis_set_GCA_000001405.15.chr19_chrM.fasta.tar"
   BWA_MITO_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/hg38_chr19_chrM/bwa_index/GRCh38_no_alt_analysis_set_GCA_000001405.15.chr19_chrM.chrM.fa.tar"
-  MITO_CHR_NAME="chrM"
   if [[ "${VER}" == "v2" ]]; then
     BLACKLIST="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ENCFF419RSJ.bed.gz"
     TSS="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/tss.pc.gencode.v29.bed.gz"
@@ -136,6 +141,8 @@ elif [[ "${GENOME}" == "hg38_chr19_chrM" ]]; then
   ROADMAP_META="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/hg38_dnase_avg_fseq_signal_metadata.txt"
 
 elif [[ "${GENOME}" == "mm10_chr19_chrM" ]]; then
+  REGEX_BFILT_PEAK_CHR_NAME="chr[\dXY]+"
+  MITO_CHR_NAME="chrM"
   REF_FA="https://storage.googleapis.com/encode-pipeline-genome-data/mm10_chr19_chrM/mm10_no_alt_analysis_set_ENCODE.chr19_chrM.fasta.gz"
   REF_MITO_FA="https://storage.googleapis.com/encode-pipeline-genome-data/mm10_chr19_chrM/mm10_no_alt_analysis_set_ENCODE.chr19_chrM.chrM.fa.gz"
   CHRSZ="https://storage.googleapis.com/encode-pipeline-genome-data/mm10_chr19_chrM/mm10_chr19_chrM.chrom.sizes"
@@ -143,7 +150,6 @@ elif [[ "${GENOME}" == "mm10_chr19_chrM" ]]; then
   BWT2_MITO_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/mm10_chr19_chrM/bowtie2_index/mm10_no_alt_analysis_set_ENCODE.chr19_chrM.chrM.fa.tar"
   BWA_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/mm10_chr19_chrM/bwa_index/mm10_no_alt_analysis_set_ENCODE.chr19_chrM.fasta.tar"
   BWA_MITO_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/mm10_chr19_chrM/bwa_index/mm10_no_alt_analysis_set_ENCODE.chr19_chrM.chrM.fa.tar"
-  MITO_CHR_NAME="chrM"
   if [[ "${VER}" == "v2" ]]; then
     BLACKLIST="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/ENCFF547MET.bed.gz"
   else
@@ -166,6 +172,11 @@ if [[ -z "${MITO_CHR_NAME}" ]]; then
   echo "Error: Mitochondrial chromosome name must be defined"
   exit 1
 fi
+if [[ -z "${REGEX_BFILT_PEAK_CHR_NAME}" ]]; then
+  echo "Error: Perl style reg-ex for filtering peaks must be defined"
+  exit 1
+fi
+
 
 echo "=== Downloading files..."
 wget -c -O $(basename ${REF_FA}) ${REF_FA}
@@ -208,6 +219,7 @@ echo -e "genome_name\t${GENOME}" >> ${TSV}
 echo -e "ref_fa\t${DEST_DIR}/$(basename $REF_FA_PREFIX)" >> ${TSV}
 echo -e "ref_mito_fa\t${DEST_DIR}/$(basename $REF_MITO_FA_PREFIX)" >> ${TSV}
 echo -e "mito_chr_name\t${MITO_CHR_NAME}" >> ${TSV}
+printf "regex_bfilt_peak_chr_name\t%s\n" "${REGEX_BFILT_PEAK_CHR_NAME}" >> ${TSV}
 echo -e "blacklist\t${DEST_DIR}/$(basename ${BLACKLIST})" >> ${TSV};
 echo -e "chrsz\t${DEST_DIR}/$(basename ${CHRSZ})" >> ${TSV}
 echo -e "gensz\t${GENSZ}" >> ${TSV}

--- a/scripts/download_genome_data.sh
+++ b/scripts/download_genome_data.sh
@@ -15,6 +15,9 @@ if [[ "$#" -lt 2 ]]; then
   exit 2
 fi
 
+# parameters for genome database version (v1: <ENCODE4, v2: >=ENCODE4)
+VER=v1
+
 GENOME=$1
 DEST_DIR=$(cd $(dirname $2) && pwd -P)/$(basename $2)
 TSV=${DEST_DIR}/${GENOME}.tsv
@@ -64,14 +67,20 @@ elif [[ "${GENOME}" == "hg38" ]]; then
   REF_FA="https://www.encodeproject.org/files/GRCh38_no_alt_analysis_set_GCA_000001405.15/@@download/GRCh38_no_alt_analysis_set_GCA_000001405.15.fasta.gz"
   REF_MITO_FA="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/GRCh38_no_alt_analysis_set_GCA_000001405.15.chrM.fa.gz"
   CHRSZ="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/hg38.chrom.sizes"
-  BWT2_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/bowtie2_index/GRCh38_no_alt_analysis_set_GCA_000001405.15.fasta.tar"
   BWT2_MITO_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/bowtie2_index/GRCh38_no_alt_analysis_set_GCA_000001405.15.chrM.fa.tar"
-  BWA_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/bwa_index/GRCh38_no_alt_analysis_set_GCA_000001405.15.fasta.tar"
   BWA_MITO_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/bwa_index/GRCh38_no_alt_analysis_set_GCA_000001405.15.chrM.fa.tar"
-  BLACKLIST="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/hg38.blacklist.bed.gz"
   MITO_CHR_NAME="chrM"
-
-  TSS="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/hg38_gencode_tss_unique.bed.gz"
+  if [[ "${VER}" == "v2" ]]; then
+    BWT2_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/bowtie2_index/ENCFF110MCL.tar.gz"
+    BWA_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/bwa_index/ENCFF643CGH.tar.gz"
+    BLACKLIST="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ENCFF419RSJ.bed.gz"
+    TSS="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/tss.pc.gencode.v29.bed.gz"
+  else
+    BWT2_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/bowtie2_index/GRCh38_no_alt_analysis_set_GCA_000001405.15.fasta.tar"
+    BWA_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/bwa_index/GRCh38_no_alt_analysis_set_GCA_000001405.15.fasta.tar"
+    BLACKLIST="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/hg38.blacklist.bed.gz"
+    TSS="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/hg38_gencode_tss_unique.bed.gz"
+  fi
   DNASE="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/reg2map_honeybadger2_dnase_all_p10_ucsc.hg19_to_hg38.bed.gz"
   PROM="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/reg2map_honeybadger2_dnase_prom_p2.hg19_to_hg38.bed.gz"
   ENH="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/reg2map_honeybadger2_dnase_enh_p2.hg19_to_hg38.bed.gz"
@@ -83,13 +92,18 @@ elif [[ "${GENOME}" == "mm10" ]]; then
   REF_FA="https://www.encodeproject.org/files/mm10_no_alt_analysis_set_ENCODE/@@download/mm10_no_alt_analysis_set_ENCODE.fasta.gz"
   REF_MITO_FA="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/mm10_no_alt_analysis_set_ENCODE.chrM.fa.gz"
   CHRSZ="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/mm10.chrom.sizes"
-  BWT2_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/bowtie2_index/mm10_no_alt_analysis_set_ENCODE.fasta.tar"
   BWT2_MITO_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/bowtie2_index/mm10_no_alt_analysis_set_ENCODE.chrM.fa.tar"
-  BWA_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/bwa_index/mm10_no_alt_analysis_set_ENCODE.fasta.tar"
   BWA_MITO_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/bwa_index/mm10_no_alt_analysis_set_ENCODE.chrM.fa.tar"
-  BLACKLIST="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/mm10.blacklist.bed.gz"
   MITO_CHR_NAME="chrM"
-
+  if [[ "${VER}" == "v2" ]]; then
+    BWT2_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/bowtie2_index/ENCFF309GLL.tar.gz"
+    BWA_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/bwa_index/ENCFF018NEO.tar.gz"
+    BLACKLIST="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/ENCFF547MET.bed.gz"
+  else
+    BWT2_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/bowtie2_index/mm10_no_alt_analysis_set_ENCODE.fasta.tar"
+    BWA_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/bwa_index/mm10_no_alt_analysis_set_ENCODE.fasta.tar"
+    BLACKLIST="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/mm10.blacklist.bed.gz"
+  fi
   TSS="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/ataqc/mm10_gencode_tss_unique.bed.gz"
   DNASE="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/ataqc/mm10_univ_dhs_ucsc.bed.gz"
   PROM="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/ataqc/tss_mm10_master.bed.gz"
@@ -106,10 +120,14 @@ elif [[ "${GENOME}" == "hg38_chr19_chrM" ]]; then
   BWT2_MITO_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/hg38_chr19_chrM/bowtie2_index/GRCh38_no_alt_analysis_set_GCA_000001405.15.chr19_chrM.chrM.fa.tar"
   BWA_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/hg38_chr19_chrM/bwa_index/GRCh38_no_alt_analysis_set_GCA_000001405.15.chr19_chrM.fasta.tar"
   BWA_MITO_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/hg38_chr19_chrM/bwa_index/GRCh38_no_alt_analysis_set_GCA_000001405.15.chr19_chrM.chrM.fa.tar"
-  BLACKLIST="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/hg38.blacklist.bed.gz"
   MITO_CHR_NAME="chrM"
-
-  TSS="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/hg38_gencode_tss_unique.bed.gz"
+  if [[ "${VER}" == "v2" ]]; then
+    BLACKLIST="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ENCFF419RSJ.bed.gz"
+    TSS="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/tss.pc.gencode.v29.bed.gz"
+  else
+    BLACKLIST="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/hg38.blacklist.bed.gz"
+    TSS="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/hg38_gencode_tss_unique.bed.gz"
+  fi
   DNASE="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/reg2map_honeybadger2_dnase_all_p10_ucsc.hg19_to_hg38.bed.gz"
   PROM="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/reg2map_honeybadger2_dnase_prom_p2.hg19_to_hg38.bed.gz"
   ENH="https://storage.googleapis.com/encode-pipeline-genome-data/hg38/ataqc/reg2map_honeybadger2_dnase_enh_p2.hg19_to_hg38.bed.gz"
@@ -125,9 +143,12 @@ elif [[ "${GENOME}" == "mm10_chr19_chrM" ]]; then
   BWT2_MITO_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/mm10_chr19_chrM/bowtie2_index/mm10_no_alt_analysis_set_ENCODE.chr19_chrM.chrM.fa.tar"
   BWA_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/mm10_chr19_chrM/bwa_index/mm10_no_alt_analysis_set_ENCODE.chr19_chrM.fasta.tar"
   BWA_MITO_IDX="https://storage.googleapis.com/encode-pipeline-genome-data/mm10_chr19_chrM/bwa_index/mm10_no_alt_analysis_set_ENCODE.chr19_chrM.chrM.fa.tar"
-  BLACKLIST="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/mm10.blacklist.bed.gz"
   MITO_CHR_NAME="chrM"
-
+  if [[ "${VER}" == "v2" ]]; then
+    BLACKLIST="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/ENCFF547MET.bed.gz"
+  else
+    BLACKLIST="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/mm10.blacklist.bed.gz"
+  fi
   TSS="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/ataqc/mm10_gencode_tss_unique.bed.gz"
   DNASE="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/ataqc/mm10_univ_dhs_ucsc.bed.gz"
   PROM="https://storage.googleapis.com/encode-pipeline-genome-data/mm10/ataqc/tss_mm10_master.bed.gz"

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -49,6 +49,7 @@ requests
 ncurses
 gnuplot
 ghostscript
+wget
 
 numpy
 scipy

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -50,6 +50,7 @@ ncurses
 gnuplot
 ghostscript
 wget
+pyopenssl  # for caper/croo to presign bucket URIs
 
 numpy
 scipy

--- a/src/encode_lib_genomic.py
+++ b/src/encode_lib_genomic.py
@@ -279,7 +279,7 @@ def subsample_ta_pe(ta, subsample, non_mito, mito_chr_name, r1_only, out_dir):
 # convert encode peak file to hammock (for Wash U browser track)
 
 
-def peak_to_hammock(peak, keep_irregular_chr, out_dir):
+def peak_to_hammock(peak, out_dir):
     peak_type = get_peak_type(peak)
     prefix = os.path.join(out_dir, os.path.basename(
         strip_ext_peak(peak)))
@@ -295,8 +295,6 @@ def peak_to_hammock(peak, keep_irregular_chr, out_dir):
         cmd2 = 'touch {}'.format(hammock_gz_tbi)
     else:
         cmd = "zcat -f {} | "
-        if not keep_irregular_chr:
-            cmd += "sed '/^\(chr\)/!d' | "
         cmd += "LC_COLLATE=C sort -k1,1V -k2,2n > {}"
         cmd = cmd.format(peak, hammock_tmp)
         run_shell_cmd(cmd)
@@ -357,7 +355,7 @@ def peak_to_hammock(peak, keep_irregular_chr, out_dir):
     return (hammock_gz, hammock_gz_tbi)
 
 
-def peak_to_bigbed(peak, peak_type, chrsz, keep_irregular_chr, out_dir):
+def peak_to_bigbed(peak, peak_type, chrsz, out_dir):
     prefix = os.path.join(out_dir,
                           os.path.basename(strip_ext(peak)))
     bigbed = '{}.{}.bb'.format(prefix, peak_type)
@@ -428,11 +426,7 @@ def peak_to_bigbed(peak, peak_type, chrsz, keep_irregular_chr, out_dir):
     with open(as_file, 'w') as fp:
         fp.write(as_file_contents)
 
-    if not keep_irregular_chr:
-        cmd1 = "cat {} | grep -P 'chr[\\dXY]+\\b' > {}".format(
-            chrsz, chrsz_tmp)
-    else:
-        cmd1 = "cat {} > {}".format(chrsz, chrsz_tmp)
+    cmd1 = "cat {} > {}".format(chrsz, chrsz_tmp)
     run_shell_cmd(cmd1)
     cmd2 = "zcat -f {} | LC_COLLATE=C sort -k1,1 -k2,2n | "
     cmd2 += 'awk \'BEGIN{{OFS="\\t"}} {{if ($5>1000) $5=1000; '

--- a/src/encode_lib_log_parser.py
+++ b/src/encode_lib_log_parser.py
@@ -9,8 +9,8 @@ from collections import OrderedDict
 
 
 MAP_KEY_DESC_FRAC_MITO_QC = {
-    'non_mito_reads': 'Rm = Number of Non-mitochondrial Reads',
-    'mito_reads': 'Rn = Number of Mitochondrial Reads',
+    'non_mito_reads': 'Rn = Number of Non-mitochondrial Reads',
+    'mito_reads': 'Rm = Number of Mitochondrial Reads',
     'frac_mito_reads': 'Rm/(Rn+Rm) = Frac. of mitochondrial reads'
 }
 

--- a/src/encode_task_bowtie2.py
+++ b/src/encode_task_bowtie2.py
@@ -118,12 +118,14 @@ def find_bowtie2_index_prefix(d):
     Returns:
         prefix of BWA index. e.g. returns PREFIX if PREFIX.sa exists
     Args:
-        d: directory to search for .sa file
+        d: directory to search for .1.bt2 or .1.bt2l file
     """
     if d == '':
         d = '.'
     for f in os.listdir(d):
-        if f.endswith('.1.bt2') or f.endswith('.1.bt2l'):
+        if f.endswith('.rev.1.bt2') or f.endswith('.rev.1.bt2l'):
+            return re.sub('\.rev\.1\.(bt2|bt2l)$', '', f)
+        elif f.endswith('.1.bt2') or f.endswith('.1.bt2l'):
             return re.sub('\.1\.(bt2|bt2l)$', '', f)
     return None
 

--- a/src/encode_task_bwa.py
+++ b/src/encode_task_bwa.py
@@ -5,6 +5,7 @@
 
 import sys
 import os
+import re
 import argparse
 from encode_lib_common import (
     get_num_lines, log, ls_l, mkdir_p, rm_f, run_shell_cmd, strip_ext_fastq,
@@ -20,9 +21,8 @@ def parse_arguments():
                         help='Path for prefix (or a tarball .tar) \
                             for reference bwa index. \
                             Prefix must be like [PREFIX].sa. \
-                            Tar ball must be packed without compression \
-                            and directory by using command line \
-                            "tar cvf [TAR] [TAR_PREFIX].*".')
+                            TAR ball can have any [PREFIX] but it should not \
+                            have a directory structure in it.')
     parser.add_argument('fastqs', nargs='+', type=str,
                         help='List of FASTQs (R1 and R2). \
                             FASTQs must be compressed with gzip (with .gz).')
@@ -155,6 +155,21 @@ def chk_bwa_index(prefix):
                         "Prefix = {}".format(prefix))
 
 
+def find_bwa_index_prefix(d):
+    """
+    Returns:
+        prefix of BWA index. e.g. returns PREFIX if PREFIX.sa exists
+    Args:
+        d: directory to search for .sa file
+    """
+    if d == '':
+        d = '.'
+    for f in os.listdir(d):
+        if f.endswith('.sa'):
+            return re.sub('\.sa$', '', f)
+    return None
+
+
 def main():
     # read params
     args = parse_arguments()
@@ -172,9 +187,8 @@ def main():
         tar = args.bwa_index_prefix_or_tar
         # untar
         untar(tar, args.out_dir)
-        bwa_index_prefix = os.path.join(
-            args.out_dir, os.path.basename(strip_ext_tar(tar)))
-        temp_files.append('{}.*'.format(
+        bwa_index_prefix = find_bwa_index_prefix(args.out_dir)
+        temp_files.append('{}*'.format(
             bwa_index_prefix))
     else:
         bwa_index_prefix = args.bwa_index_prefix_or_tar

--- a/src/encode_task_idr.py
+++ b/src/encode_task_idr.py
@@ -36,10 +36,11 @@ def parse_arguments():
     parser.add_argument('--idr-rank', default='p.value', type=str,
                         choices=['p.value', 'q.value', 'signal.value'],
                         help='IDR ranking method.')
-    parser.add_argument('--blacklist', type=str, required=True,
+    parser.add_argument('--blacklist', type=str,
                         help='Blacklist BED file.')
-    parser.add_argument('--keep-irregular-chr', action="store_true",
-                        help='Keep reads with non-canonical chromosome names.')
+    parser.add_argument('--regex-bfilt-peak-chr-name',
+                        help='Keep chromosomes matching this pattern only '
+                             'in .bfilt. peak files.')
     parser.add_argument('--ta', type=str,
                         help='TAGALIGN file for FRiP.')
     parser.add_argument('--chrsz', type=str,
@@ -55,7 +56,7 @@ def parse_arguments():
                                  'CRITICAL'],
                         help='Log level')
     args = parser.parse_args()
-    if args.blacklist.endswith('/dev/null'):
+    if args.blacklist is None or args.blacklist.endswith('null'):
         args.blacklist = ''
 
     log.setLevel(args.log_level)
@@ -148,17 +149,17 @@ def main():
 
     log.info('Blacklist-filtering peaks...')
     bfilt_idr_peak = blacklist_filter(
-        idr_peak, args.blacklist, args.keep_irregular_chr, args.out_dir)
+        idr_peak, args.blacklist, args.regex_bfilt_peak_chr_name, args.out_dir)
 
     log.info('Checking if output is empty...')
     assert_file_not_empty(bfilt_idr_peak)
 
     log.info('Converting peak to bigbed...')
     peak_to_bigbed(bfilt_idr_peak, args.peak_type, args.chrsz,
-                   args.keep_irregular_chr, args.out_dir)
+                   args.out_dir)
 
     log.info('Converting peak to hammock...')
-    peak_to_hammock(bfilt_idr_peak, args.keep_irregular_chr, args.out_dir)
+    peak_to_hammock(bfilt_idr_peak, args.out_dir)
 
     if args.ta:  # if TAG-ALIGN is given
         if args.fraglen:  # chip-seq

--- a/src/encode_task_overlap.py
+++ b/src/encode_task_overlap.py
@@ -33,10 +33,11 @@ def parse_arguments():
                         help='bedtools intersect -nonamecheck. \
                         use this if you get bedtools intersect \
                         naming convenction warnings/errors).')
-    parser.add_argument('--blacklist', type=str, required=True,
+    parser.add_argument('--blacklist', type=str,
                         help='Blacklist BED file.')
-    parser.add_argument('--keep-irregular-chr', action="store_true",
-                        help='Keep reads with non-canonical chromosome names.')
+    parser.add_argument('--regex-bfilt-peak-chr-name',
+                        help='Keep chromosomes matching this pattern only '
+                             'in .bfilt. peak files.')
     parser.add_argument('--ta', type=str,
                         help='TAGALIGN file for FRiP.')
     parser.add_argument('--chrsz', type=str,
@@ -52,7 +53,7 @@ def parse_arguments():
                                  'CRITICAL'],
                         help='Log level')
     args = parser.parse_args()
-    if args.blacklist.endswith('/dev/null'):
+    if args.blacklist is None or args.blacklist.endswith('null'):
         args.blacklist = ''
 
     log.setLevel(args.log_level)
@@ -120,17 +121,17 @@ def main():
 
     log.info('Blacklist-filtering peaks...')
     bfilt_overlap_peak = blacklist_filter(
-        overlap_peak, args.blacklist, args.keep_irregular_chr, args.out_dir)
+        overlap_peak, args.blacklist, args.regex_bfilt_peak_chr_name, args.out_dir)
 
     log.info('Checking if output is empty...')
     assert_file_not_empty(bfilt_overlap_peak)
 
     log.info('Converting peak to bigbed...')
     peak_to_bigbed(bfilt_overlap_peak, args.peak_type,
-                   args.chrsz, args.keep_irregular_chr, args.out_dir)
+                   args.chrsz, args.out_dir)
 
     log.info('Converting peak to hammock...')
-    peak_to_hammock(bfilt_overlap_peak, args.keep_irregular_chr, args.out_dir)
+    peak_to_hammock(bfilt_overlap_peak, args.out_dir)
 
     if args.ta:  # if TAG-ALIGN is given
         if args.fraglen:  # chip-seq

--- a/src/encode_task_post_call_peak_atac.py
+++ b/src/encode_task_post_call_peak_atac.py
@@ -27,10 +27,11 @@ def parse_arguments():
                         help='Peak file type.')
     parser.add_argument('--chrsz', type=str,
                         help='2-col chromosome sizes file.')
-    parser.add_argument('--blacklist', type=str, required=True,
+    parser.add_argument('--blacklist', type=str,
                         help='Blacklist BED file.')
-    parser.add_argument('--keep-irregular-chr', action="store_true",
-                        help='Keep reads with non-canonical chromosome names.')
+    parser.add_argument('--regex-bfilt-peak-chr-name',
+                        help='Keep chromosomes matching this pattern only '
+                             'in .bfilt. peak files.')
     parser.add_argument('--out-dir', default='', type=str,
                         help='Output directory.')
     parser.add_argument('--log-level', default='INFO',
@@ -39,7 +40,7 @@ def parse_arguments():
                                  'CRITICAL'],
                         help='Log level')
     args = parser.parse_args()
-    if args.blacklist.endswith('/dev/null'):
+    if args.blacklist is None or args.blacklist.endswith('null'):
         args.blacklist = ''
 
     log.setLevel(args.log_level)
@@ -56,17 +57,17 @@ def main():
 
     log.info('Blacklist-filtering peaks...')
     bfilt_peak = blacklist_filter(
-        args.peak, args.blacklist, args.keep_irregular_chr, args.out_dir)
+        args.peak, args.blacklist, args.regex_bfilt_peak_chr_name, args.out_dir)
 
     log.info('Checking if output is empty...')
     assert_file_not_empty(bfilt_peak)
 
     log.info('Converting peak to bigbed...')
     peak_to_bigbed(bfilt_peak, args.peak_type, args.chrsz,
-                   args.keep_irregular_chr, args.out_dir)
+                   args.out_dir)
 
     log.info('Converting peak to hammock...')
-    peak_to_hammock(bfilt_peak, args.keep_irregular_chr, args.out_dir)
+    peak_to_hammock(bfilt_peak, args.out_dir)
 
     log.info('FRiP without fragment length...')
     frip(args.ta, bfilt_peak, args.out_dir)

--- a/src/encode_task_post_call_peak_chip.py
+++ b/src/encode_task_post_call_peak_chip.py
@@ -29,10 +29,11 @@ def parse_arguments():
                         help='Fragment length.')
     parser.add_argument('--chrsz', type=str,
                         help='2-col chromosome sizes file.')
-    parser.add_argument('--blacklist', type=str, required=True,
+    parser.add_argument('--blacklist', type=str,
                         help='Blacklist BED file.')
-    parser.add_argument('--keep-irregular-chr', action="store_true",
-                        help='Keep reads with non-canonical chromosome names.')
+    parser.add_argument('--regex-bfilt-peak-chr-name',
+                        help='Keep chromosomes matching this pattern only '
+                             'in .bfilt. peak files.')
     parser.add_argument('--out-dir', default='', type=str,
                         help='Output directory.')
     parser.add_argument('--log-level', default='INFO',
@@ -41,7 +42,7 @@ def parse_arguments():
                                  'CRITICAL'],
                         help='Log level')
     args = parser.parse_args()
-    if args.blacklist.endswith('/dev/null'):
+    if args.blacklist is None or args.blacklist.endswith('null'):
         args.blacklist = ''
 
     log.setLevel(args.log_level)
@@ -58,17 +59,17 @@ def main():
 
     log.info('Blacklist-filtering peaks...')
     bfilt_peak = blacklist_filter(
-        args.peak, args.blacklist, args.keep_irregular_chr, args.out_dir)
+        args.peak, args.blacklist, args.regex_bfilt_peak_chr_name, args.out_dir)
 
     log.info('Checking if output is empty...')
     assert_file_not_empty(bfilt_peak)
 
     log.info('Converting peak to bigbed...')
     peak_to_bigbed(bfilt_peak, args.peak_type, args.chrsz,
-                   args.keep_irregular_chr, args.out_dir)
+                   args.out_dir)
 
     log.info('Converting peak to hammock...')
-    peak_to_hammock(bfilt_peak, args.keep_irregular_chr, args.out_dir)
+    peak_to_hammock(bfilt_peak, args.out_dir)
 
     log.info('Shifted FRiP with fragment length...')
     frip_qc = frip_shifted(args.ta, bfilt_peak,

--- a/src/encode_task_qc_report.py
+++ b/src/encode_task_qc_report.py
@@ -291,7 +291,7 @@ def make_cat_align(args, cat_root):
 
     cat_align_samstat = QCCategory(
         'samstat',
-        html_head='<h2>SAMstat (raw BAM)</h2>',
+        html_head='<h2>SAMstat (raw unfiltered BAM)</h2>',
         parser=parse_flagstat_qc,
         map_key_desc=MAP_KEY_DESC_FLAGSTAT_QC,
         parent=cat_align
@@ -307,7 +307,7 @@ def make_cat_align(args, cat_root):
 
     cat_align_dup = QCCategory(
         'dup',
-        html_head='<h2>Marking duplicates (filtered BAMs)</h2>',
+        html_head='<h2>Marking duplicates (filtered BAM)</h2>',
         html_foot="""
             <div id='help-filter'>
             Filtered out (samtools view -F 1804):
@@ -334,7 +334,7 @@ def make_cat_align(args, cat_root):
 
     cat_align_frac_mito = QCCategory(
         'frac_mito',
-        html_head='<h2>Fraction of mitochondrial reads</h2>',
+        html_head='<h2>Fraction of mitochondrial reads (unfiltered BAM)</h2>',
         parser=parse_frac_mito_qc,
         map_key_desc=MAP_KEY_DESC_FRAC_MITO_QC,
         parent=cat_align
@@ -385,7 +385,7 @@ def make_cat_align(args, cat_root):
 
     cat_fraglen = QCCategory(
         'frag_len_stat',
-        html_head='<h2>Fragment length statistics</h2>',
+        html_head='<h2>Fragment length statistics (filtered/deduped BAM)</h2>',
         html_foot="""
             <p>Open chromatin assays show distinct fragment length enrichments, as the cut
             sites are only in open chromatin and not in nucleosomes. As such, peaks
@@ -413,7 +413,7 @@ def make_cat_align(args, cat_root):
 
     cat_gc_bias = QCCategory(
         'gc_bias',
-        html_head='<h2>Sequence quality metrics (GC bias)</h2>',
+        html_head='<h2>Sequence quality metrics (filtered/deduped BAM)</h2>',
         html_foot="""
             <p>Open chromatin assays are known to have significant GC bias. Please take this
             into consideration as necessary.</p><br>
@@ -634,6 +634,7 @@ def make_cat_align_enrich(args, cat_root):
     )
 
     if args.pipeline_type in ('tf', 'histone'):
+        html_head_xcor = '<h2>Strand cross-correlation measures (trimmed/filtered SE BAM)</h2>',
         html_foot_xcor = """
             <br><p>Performed on subsampled ({xcor_subsample_reads}) reads mapped from FASTQs that are trimmed to {xcor_pe_trim_bp}.
             Such FASTQ trimming and subsampling reads are for cross-corrleation analysis only. 
@@ -646,6 +647,7 @@ def make_cat_align_enrich(args, cat_root):
             xcor_pe_trim_bp=args.xcor_pe_trim_bp,
         )
     else:
+        html_head_xcor = '<h2>Strand cross-correlation measures (filtered BAM)</h2>',
         html_foot_xcor = """
             <br><p>Performed on subsampled ({xcor_subsample_reads}) reads.
             Such FASTQ trimming is for cross-corrleation analysis only.</p>
@@ -662,7 +664,7 @@ def make_cat_align_enrich(args, cat_root):
 
     cat_xcor = QCCategory(
         'xcor_score',
-        html_head='<h2>Strand cross-correlation measures</h2>',
+        html_head=html_head_xcor,
         html_foot=html_foot_xcor,
         parser=parse_xcor_score,
         map_key_desc=MAP_KEY_DESC_XCOR_SCORE,
@@ -684,7 +686,7 @@ def make_cat_align_enrich(args, cat_root):
 
     cat_tss_enrich = QCCategory(
         'tss_enrich',
-        html_head='<h2>TSS enrichment</h2>',
+        html_head='<h2>TSS enrichment (filtered/deduped BAM)</h2>',
         html_foot="""
             <p>Open chromatin assays should show enrichment in open chromatin sites, such as
             TSS's. An average TSS enrichment in human (hg19) is above 6. A strong TSS enrichment is
@@ -707,7 +709,7 @@ def make_cat_align_enrich(args, cat_root):
 
     cat_jsd = QCCategory(
         'jsd',
-        html_head='<h2>Jensen-Shannon distance</h2>',
+        html_head='<h2>Jensen-Shannon distance (filtered/deduped BAM)</h2>',
         parser=parse_jsd_qc,
         map_key_desc=MAP_KEY_DESC_JSD_QC,
         parent=cat_align_enrich

--- a/src/encode_task_qc_report.py
+++ b/src/encode_task_qc_report.py
@@ -634,7 +634,7 @@ def make_cat_align_enrich(args, cat_root):
     )
 
     if args.pipeline_type in ('tf', 'histone'):
-        html_head_xcor = '<h2>Strand cross-correlation measures (trimmed/filtered SE BAM)</h2>',
+        html_head_xcor = '<h2>Strand cross-correlation measures (trimmed/filtered SE BAM)</h2>'
         html_foot_xcor = """
             <br><p>Performed on subsampled ({xcor_subsample_reads}) reads mapped from FASTQs that are trimmed to {xcor_pe_trim_bp}.
             Such FASTQ trimming and subsampling reads are for cross-corrleation analysis only. 
@@ -647,7 +647,7 @@ def make_cat_align_enrich(args, cat_root):
             xcor_pe_trim_bp=args.xcor_pe_trim_bp,
         )
     else:
-        html_head_xcor = '<h2>Strand cross-correlation measures (filtered BAM)</h2>',
+        html_head_xcor = '<h2>Strand cross-correlation measures (filtered BAM)</h2>'
         html_foot_xcor = """
             <br><p>Performed on subsampled ({xcor_subsample_reads}) reads.
             Such FASTQ trimming is for cross-corrleation analysis only.</p>

--- a/src/encode_task_reproducibility.py
+++ b/src/encode_task_reproducibility.py
@@ -34,8 +34,6 @@ def parse_arguments():
                         help='Peak file type.')
     parser.add_argument('--chrsz', type=str,
                         help='2-col chromosome sizes file.')
-    parser.add_argument('--keep-irregular-chr', action="store_true",
-                        help='Keep reads with non-canonical chromosome names.')
     parser.add_argument('--prefix', type=str,
                         help='Basename prefix for reproducibility QC file.')
     parser.add_argument('--out-dir', default='', type=str,
@@ -129,15 +127,15 @@ def main():
     if args.chrsz:
         log.info('Converting peak to bigbed...')
         peak_to_bigbed(optimal_peak_file, args.peak_type,
-                       args.chrsz, args.keep_irregular_chr, args.out_dir)
+                       args.chrsz, args.out_dir)
         peak_to_bigbed(conservative_peak_file, args.peak_type,
-                       args.chrsz, args.keep_irregular_chr, args.out_dir)
+                       args.chrsz, args.out_dir)
 
         log.info('Converting peak to hammock...')
         peak_to_hammock(optimal_peak_file,
-                        args.keep_irregular_chr, args.out_dir)
+                        args.out_dir)
         peak_to_hammock(conservative_peak_file,
-                        args.keep_irregular_chr, args.out_dir)
+                        args.out_dir)
 
     log.info('Writing reproducibility QC log...')
     if args.prefix:


### PR DESCRIPTION
> **IMPORTANT**: Conda users must update pipeline's Conda environment (not a re-installation). This will just update pipeline's python task wrappers.
```bash
$ bash scripts/update_conda_env.sh
```

New feature
  - Removed a parameter `chip.keep_irregular_chr` from the pipeline.
  - Added a genome-specific parameter `regex_bfilt_peak_chr_name` instead (`chr[\dXY]+` by default, which means chr1, chr2, ... , chrX and chrY). You can define this either in a genome TSV (e.g. `keep_irregular_chr[TAB]chr[\dXY]`) or in your input JSON (e.g. `"chip.keep_irregular_chr": "chr[\\dXY]+") .
     - This parameter defines chromosomes to keep in the final (with `.bfilt.` suffix) peaks file. This filter is applied even without a blacklist.

Bug fixes
  - Pipeline can catch non-zero error code correctly at failed tasks (tasks `align` and `call_peak`).
  - Pipeline can run without a blacklist.

Dependencies
  - Added `wget` and `curl` to Conda environment.

Genome data
  - Genome database builder generates md5sum-same TAR balls.
  - Can use gzipped Bowtie2/BWA indices (`.tar.gz`) with arbitrary filenames.
     - Files in a TAR ball don't need to be prefixed with TAR ball's filename prefix.