### PR TITLE
Pip 807 update for v1.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ This ChIP-Seq pipeline is based off the ENCODE (phase-3) transcription factor an
 4) Follow [Caper's README](https://github.com/ENCODE-DCC/caper) carefully. Find an instruction for your platform.
 	> **IMPORTANT**: Configure your Caper configuration file `~/.caper/default.conf` correctly for your platform.
 
-
 ## Test input JSON file
 
 Use `https://storage.googleapis.com/encode-pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI_subsampled_chr19_only_caper.json` as `[INPUT_JSON]` in Caper's documentation.
@@ -64,3 +63,16 @@ Install [Croo](https://github.com/ENCODE-DCC/croo#installation). **You can skip 
 $ pip install croo
 $ croo [METADATA_JSON_FILE]
 ```
+
+## How to make a spreadsheet of QC metrics
+
+Install [qc2tsv](https://github.com/ENCODE-DCC/qc2tsv#installation). Make sure that you have python3(> 3.4.1) installed on your system. 
+
+Once you have [organized output with Croo](#how-to-organize-outputs), you will be able to find pipeline's final output file `qc/qc.json` which has all QC metrics in it. Simply feed `qc2tsv` with multiple `qc.json` files. It can take various URIs like local path, `gs://` and `s3://`.
+
+```bash
+$ pip install qc2tsv
+$ qc2tsv /sample1/qc.json gs://sample2/qc.json s3://sample3/qc.json ... > spreadsheet.tsv
+```
+
+QC metrics for each experiment (`qc.json`) will be split into multiple rows (1 for overall experiment + 1 for each bio replicate) in a spreadsheet.

--- a/chip.croo.json
+++ b/chip.croo.json
@@ -895,195 +895,195 @@
     }
   },
   "inputs": {
-    "atac.fastqs_rep1_R1": {
+    "chip.fastqs_rep1_R1": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
       "subgraph": "cluster_rep1"
     },
-    "atac.fastqs_rep1_R2": {
+    "chip.fastqs_rep1_R2": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
       "subgraph": "cluster_rep1"
     },
-    "atac.fastqs_rep2_R1": {
+    "chip.fastqs_rep2_R1": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
       "subgraph": "cluster_rep2"
     },
-    "atac.fastqs_rep2_R2": {
+    "chip.fastqs_rep2_R2": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
       "subgraph": "cluster_rep2"
     },
-    "atac.fastqs_rep3_R1": {
+    "chip.fastqs_rep3_R1": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
       "subgraph": "cluster_rep3"
     },
-    "atac.fastqs_rep3_R2": {
+    "chip.fastqs_rep3_R2": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
       "subgraph": "cluster_rep3"
     },
-    "atac.fastqs_rep4_R1": {
+    "chip.fastqs_rep4_R1": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
       "subgraph": "cluster_rep4"
     },
-    "atac.fastqs_rep4_R2": {
+    "chip.fastqs_rep4_R2": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
       "subgraph": "cluster_rep4"
     },
-    "atac.fastqs_rep5_R1": {
+    "chip.fastqs_rep5_R1": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
       "subgraph": "cluster_rep5"
     },
-    "atac.fastqs_rep5_R2": {
+    "chip.fastqs_rep5_R2": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
       "subgraph": "cluster_rep5"
     },
-    "atac.fastqs_rep6_R1": {
+    "chip.fastqs_rep6_R1": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
       "subgraph": "cluster_rep6"
     },
-    "atac.fastqs_rep6_R2": {
+    "chip.fastqs_rep6_R2": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
       "subgraph": "cluster_rep6"
     },
-    "atac.fastqs_rep7_R1": {
+    "chip.fastqs_rep7_R1": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
       "subgraph": "cluster_rep7"
     },
-    "atac.fastqs_rep7_R2": {
+    "chip.fastqs_rep7_R2": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
       "subgraph": "cluster_rep7"
     },
-    "atac.fastqs_rep8_R1": {
+    "chip.fastqs_rep8_R1": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
       "subgraph": "cluster_rep8"
     },
-    "atac.fastqs_rep8_R2": {
+    "chip.fastqs_rep8_R2": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
       "subgraph": "cluster_rep8"
     },
-    "atac.fastqs_rep9_R1": {
+    "chip.fastqs_rep9_R1": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
       "subgraph": "cluster_rep9"
     },
-    "atac.fastqs_rep9_R2": {
+    "chip.fastqs_rep9_R2": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
       "subgraph": "cluster_rep9"
     },
-    "atac.fastqs_rep10_R1": {
+    "chip.fastqs_rep10_R1": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
       "subgraph": "cluster_rep10"
     },
-    "atac.fastqs_rep10_R2": {
+    "chip.fastqs_rep10_R2": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
       "subgraph": "cluster_rep10"
     },
-    "atac.ctl_fastqs_rep1_R1": {
+    "chip.ctl_fastqs_rep1_R1": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
       "subgraph": "cluster_ctl1"
     },
-    "atac.ctl_fastqs_rep1_R2": {
+    "chip.ctl_fastqs_rep1_R2": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
       "subgraph": "cluster_ctl1"
     },
-    "atac.ctl_fastqs_rep2_R1": {
+    "chip.ctl_fastqs_rep2_R1": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
       "subgraph": "cluster_ctl2"
     },
-    "atac.ctl_fastqs_rep2_R2": {
+    "chip.ctl_fastqs_rep2_R2": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
       "subgraph": "cluster_ctl2"
     },
-    "atac.ctl_fastqs_rep3_R1": {
+    "chip.ctl_fastqs_rep3_R1": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
       "subgraph": "cluster_ctl3"
     },
-    "atac.ctl_fastqs_rep3_R2": {
+    "chip.ctl_fastqs_rep3_R2": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
       "subgraph": "cluster_ctl3"
     },
-    "atac.ctl_fastqs_rep4_R1": {
+    "chip.ctl_fastqs_rep4_R1": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
       "subgraph": "cluster_ctl4"
     },
-    "atac.ctl_fastqs_rep4_R2": {
+    "chip.ctl_fastqs_rep4_R2": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
       "subgraph": "cluster_ctl4"
     },
-    "atac.ctl_fastqs_rep5_R1": {
+    "chip.ctl_fastqs_rep5_R1": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
       "subgraph": "cluster_ctl5"
     },
-    "atac.ctl_fastqs_rep5_R2": {
+    "chip.ctl_fastqs_rep5_R2": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
       "subgraph": "cluster_ctl5"
     },
-    "atac.ctl_fastqs_rep6_R1": {
+    "chip.ctl_fastqs_rep6_R1": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
       "subgraph": "cluster_ctl6"
     },
-    "atac.ctl_fastqs_rep6_R2": {
+    "chip.ctl_fastqs_rep6_R2": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
       "subgraph": "cluster_ctl6"
     },
-    "atac.ctl_fastqs_rep7_R1": {
+    "chip.ctl_fastqs_rep7_R1": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
       "subgraph": "cluster_ctl7"
     },
-    "atac.ctl_fastqs_rep7_R2": {
+    "chip.ctl_fastqs_rep7_R2": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
       "subgraph": "cluster_ctl7"
     },
-    "atac.ctl_fastqs_rep8_R1": {
+    "chip.ctl_fastqs_rep8_R1": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
       "subgraph": "cluster_ctl8"
     },
-    "atac.ctl_fastqs_rep8_R2": {
+    "chip.ctl_fastqs_rep8_R2": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
       "subgraph": "cluster_ctl8"
     },
-    "atac.ctl_fastqs_rep9_R1": {
+    "chip.ctl_fastqs_rep9_R1": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
       "subgraph": "cluster_ctl9"
     },
-    "atac.ctl_fastqs_rep9_R2": {
+    "chip.ctl_fastqs_rep9_R2": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
       "subgraph": "cluster_ctl9"
     },
-    "atac.ctl_fastqs_rep10_R1": {
+    "chip.ctl_fastqs_rep10_R1": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
       "subgraph": "cluster_ctl10"
     },
-    "atac.ctl_fastqs_rep10_R2": {
+    "chip.ctl_fastqs_rep10_R2": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
       "subgraph": "cluster_ctl10"
     },
-    "atac.bams": {
+    "chip.bams": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"BAM\"]",
       "subgraph": "cluster_rep${i+1}"
     },
-    "atac.nodup_bams": {
+    "chip.nodup_bams": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"Filt/deduped\nBAM\"]",
       "subgraph": "cluster_rep${i+1}"
     },
-    "atac.tas": {
+    "chip.tas": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"TAG-ALIGN\"]",
       "subgraph": "cluster_rep${i+1}"
     },
-    "atac.ctl_bams": {
+    "chip.ctl_bams": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"BAM\"]",
       "subgraph": "cluster_ctl${i+1}"
     },
-    "atac.ctl_nodup_bams": {
+    "chip.ctl_nodup_bams": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"Filt/deduped\nBAM\"]",
       "subgraph": "cluster_ctl${i+1}"
     },
-    "atac.ctl_tas": {
+    "chip.ctl_tas": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"TAG-ALIGN\"]",
       "subgraph": "cluster_ctl${i+1}"
     },
-    "atac.peaks": {
+    "chip.peaks": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"Peak\"]",
       "subgraph": "cluster_rep${i+1}"
     },
-    "atac.peak_pooled": {
+    "chip.peak_pooled": {
       "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"Peak\"]",
       "subgraph": "cluster_pooled_rep"
     }

--- a/chip.croo.json
+++ b/chip.croo.json
@@ -894,6 +894,200 @@
       "table": "QC and logs/Final QC JSON file"
     }
   },
+  "inputs": {
+    "atac.fastqs_rep1_R1": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
+      "subgraph": "cluster_rep1"
+    },
+    "atac.fastqs_rep1_R2": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
+      "subgraph": "cluster_rep1"
+    },
+    "atac.fastqs_rep2_R1": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
+      "subgraph": "cluster_rep2"
+    },
+    "atac.fastqs_rep2_R2": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
+      "subgraph": "cluster_rep2"
+    },
+    "atac.fastqs_rep3_R1": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
+      "subgraph": "cluster_rep3"
+    },
+    "atac.fastqs_rep3_R2": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
+      "subgraph": "cluster_rep3"
+    },
+    "atac.fastqs_rep4_R1": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
+      "subgraph": "cluster_rep4"
+    },
+    "atac.fastqs_rep4_R2": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
+      "subgraph": "cluster_rep4"
+    },
+    "atac.fastqs_rep5_R1": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
+      "subgraph": "cluster_rep5"
+    },
+    "atac.fastqs_rep5_R2": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
+      "subgraph": "cluster_rep5"
+    },
+    "atac.fastqs_rep6_R1": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
+      "subgraph": "cluster_rep6"
+    },
+    "atac.fastqs_rep6_R2": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
+      "subgraph": "cluster_rep6"
+    },
+    "atac.fastqs_rep7_R1": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
+      "subgraph": "cluster_rep7"
+    },
+    "atac.fastqs_rep7_R2": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
+      "subgraph": "cluster_rep7"
+    },
+    "atac.fastqs_rep8_R1": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
+      "subgraph": "cluster_rep8"
+    },
+    "atac.fastqs_rep8_R2": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
+      "subgraph": "cluster_rep8"
+    },
+    "atac.fastqs_rep9_R1": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
+      "subgraph": "cluster_rep9"
+    },
+    "atac.fastqs_rep9_R2": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
+      "subgraph": "cluster_rep9"
+    },
+    "atac.fastqs_rep10_R1": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
+      "subgraph": "cluster_rep10"
+    },
+    "atac.fastqs_rep10_R2": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
+      "subgraph": "cluster_rep10"
+    },
+    "atac.ctl_fastqs_rep1_R1": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
+      "subgraph": "cluster_ctl1"
+    },
+    "atac.ctl_fastqs_rep1_R2": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
+      "subgraph": "cluster_ctl1"
+    },
+    "atac.ctl_fastqs_rep2_R1": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
+      "subgraph": "cluster_ctl2"
+    },
+    "atac.ctl_fastqs_rep2_R2": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
+      "subgraph": "cluster_ctl2"
+    },
+    "atac.ctl_fastqs_rep3_R1": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
+      "subgraph": "cluster_ctl3"
+    },
+    "atac.ctl_fastqs_rep3_R2": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
+      "subgraph": "cluster_ctl3"
+    },
+    "atac.ctl_fastqs_rep4_R1": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
+      "subgraph": "cluster_ctl4"
+    },
+    "atac.ctl_fastqs_rep4_R2": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
+      "subgraph": "cluster_ctl4"
+    },
+    "atac.ctl_fastqs_rep5_R1": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
+      "subgraph": "cluster_ctl5"
+    },
+    "atac.ctl_fastqs_rep5_R2": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
+      "subgraph": "cluster_ctl5"
+    },
+    "atac.ctl_fastqs_rep6_R1": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
+      "subgraph": "cluster_ctl6"
+    },
+    "atac.ctl_fastqs_rep6_R2": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
+      "subgraph": "cluster_ctl6"
+    },
+    "atac.ctl_fastqs_rep7_R1": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
+      "subgraph": "cluster_ctl7"
+    },
+    "atac.ctl_fastqs_rep7_R2": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
+      "subgraph": "cluster_ctl7"
+    },
+    "atac.ctl_fastqs_rep8_R1": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
+      "subgraph": "cluster_ctl8"
+    },
+    "atac.ctl_fastqs_rep8_R2": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
+      "subgraph": "cluster_ctl8"
+    },
+    "atac.ctl_fastqs_rep9_R1": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
+      "subgraph": "cluster_ctl9"
+    },
+    "atac.ctl_fastqs_rep9_R2": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
+      "subgraph": "cluster_ctl9"
+    },
+    "atac.ctl_fastqs_rep10_R1": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR1 (${i+1})\"]",
+      "subgraph": "cluster_ctl10"
+    },
+    "atac.ctl_fastqs_rep10_R2": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"FASTQ\nR2 (${i+1})\"]",
+      "subgraph": "cluster_ctl10"
+    },
+    "atac.bams": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"BAM\"]",
+      "subgraph": "cluster_rep${i+1}"
+    },
+    "atac.nodup_bams": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"Filt/deduped\nBAM\"]",
+      "subgraph": "cluster_rep${i+1}"
+    },
+    "atac.tas": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"TAG-ALIGN\"]",
+      "subgraph": "cluster_rep${i+1}"
+    },
+    "atac.ctl_bams": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"BAM\"]",
+      "subgraph": "cluster_ctl${i+1}"
+    },
+    "atac.ctl_nodup_bams": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"Filt/deduped\nBAM\"]",
+      "subgraph": "cluster_ctl${i+1}"
+    },
+    "atac.ctl_tas": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"TAG-ALIGN\"]",
+      "subgraph": "cluster_ctl${i+1}"
+    },
+    "atac.peaks": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"Peak\"]",
+      "subgraph": "cluster_rep${i+1}"
+    },
+    "atac.peak_pooled": {
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=pink label=\"Peak\"]",
+      "subgraph": "cluster_pooled_rep"
+    }
+  },  
   "task_graph_template": {
     "graph [rankdir=LR nodesep=0.1 ranksep=0.3]": null,
     "node [shape=box fontsize=9 margin=0.05 penwidth=0.5 height=0 fillcolor=lightcyan color=darkgrey style=filled]": null,

--- a/chip.croo.json
+++ b/chip.croo.json
@@ -8,7 +8,8 @@
   "chip.jsd": {
     "plot": {
       "path": "qc/${basename}",
-      "table": "QC and logs/Jensen-Shannon distance plot"
+      "table": "QC and logs/Jensen-Shannon distance plot",
+      "node": "[shape=oval style=\"filled\" fillcolor=gainsboro fontsize=6 margin=0 label=\"JSD\nPlot\"]"
     }
   },
   "chip.bwa_ctl": {
@@ -24,17 +25,23 @@
   "chip.align_ctl": {
     "bam": {
       "path": "align/ctl${i+1}/${basename}",
-      "table": "Alignment/Control ${i+1}/Raw BAM from aligner"
+      "table": "Alignment/Control ${i+1}/Raw BAM from aligner",
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=lightyellow label=\"BAM\"]",
+      "subgraph": "cluster_ctl${i+1}"
     },
     "samstat_qc": {
       "path": "qc/ctl${i+1}/${basename}",
-      "table": "QC and logs/Control ${i+1}/SAMstats log for Raw BAM"
+      "table": "QC and logs/Control ${i+1}/SAMstats log for Raw BAM",
+      "node": "[shape=oval style=\"filled\" fillcolor=gainsboro fontsize=6 margin=0 label=\"SAMstats\nQC\"]",
+      "subgraph": "cluster_ctl${i+1}"
     }
   },
   "chip.filter_ctl": {
     "nodup_bam": {
       "path": "align/ctl${i+1}/${basename}",
-      "table": "Alignment/Control ${i+1}/Filtered BAM"
+      "table": "Alignment/Control ${i+1}/Filtered BAM",
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=lightyellow label=\"Filt/deduped\nBAM\"]",
+      "subgraph": "cluster_ctl${i+1}"
     },
     "flagstat_qc": {
       "path": "qc/ctl${i+1}/${basename}",
@@ -42,7 +49,9 @@
     },
     "samstat_qc": {
       "path": "qc/ctl${i+1}/${basename}",
-      "table": "QC and logs/Control ${i+1}/SAMstats log for filtered BAM"
+      "table": "QC and logs/Control ${i+1}/SAMstats log for filtered BAM",
+      "node": "[shape=oval style=\"filled\" fillcolor=gainsboro fontsize=6 margin=0 label=\"SAMstats\nQC\"]",
+      "subgraph": "cluster_ctl${i+1}"
     },
     "dup_qc": {
       "path": "qc/ctl${i+1}/${basename}",
@@ -54,7 +63,9 @@
     },
     "lib_complexity_qc": {
       "path": "qc/ctl${i+1}/${basename}",
-      "table": "QC and logs/Control ${i+1}/Library complexity QC for filtered BAM"
+      "table": "QC and logs/Control ${i+1}/Library complexity QC for filtered BAM",
+      "node": "[shape=oval style=\"filled\" fillcolor=gainsboro fontsize=6 margin=0 label=\"LibCmplx\nQC\"]",
+      "subgraph": "cluster_ctl${i+1}"
     },
     "mito_dup_log": {
       "path": "qc/ctl${i+1}/${basename}",
@@ -64,13 +75,17 @@
   "chip.bam2ta_ctl": {
     "ta": {
       "path": "align/ctl${i+1}/${basename}",
-      "table": "Alignment/Control ${i+1}/TAG-ALIGN"
+      "table": "Alignment/Control ${i+1}/TAG-ALIGN",
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=lightyellow label=\"TAG-ALIGN\"]",
+      "subgraph": "cluster_ctl${i+1}"
     }
   },
   "chip.pool_ta_ctl": {
     "ta_pooled": {
       "path": "align/pooled-ctl/${basename}",
-      "table": "Alignment/Pooled control/TAG-ALIGN"
+      "table": "Alignment/Pooled control/TAG-ALIGN",
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=lightyellow label=\"TAG-ALIGN\"]",
+      "subgraph": "cluster_pooled_ctl"
     }
   },
   "chip.bwa": {
@@ -86,17 +101,23 @@
   "chip.align": {
     "bam": {
       "path": "align/rep${i+1}/${basename}",
-      "table": "Alignment/Replicate ${i+1}/Raw BAM from aligner"
+      "table": "Alignment/Replicate ${i+1}/Raw BAM from aligner",
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=lightyellow label=\"BAM\"]",
+      "subgraph": "cluster_rep${i+1}"
     },
     "samstat_qc": {
       "path": "qc/rep${i+1}/${basename}",
-      "table": "QC and logs/Replicate ${i+1}/SAMstats log for Raw BAM"
+      "table": "QC and logs/Replicate ${i+1}/SAMstats log for Raw BAM",
+      "node": "[shape=oval style=\"filled\" fillcolor=gainsboro fontsize=6 margin=0 label=\"SAMstats\nQC\"]",
+      "subgraph": "cluster_rep${i+1}"
     }
   },
   "chip.filter": {
     "nodup_bam": {
       "path": "align/rep${i+1}/${basename}",
-      "table": "Alignment/Replicate ${i+1}/Filtered BAM"
+      "table": "Alignment/Replicate ${i+1}/Filtered BAM",
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=lightyellow label=\"Filt/deduped\nBAM\"]",
+      "subgraph": "cluster_rep${i+1}"
     },
     "flagstat_qc": {
       "path": "qc/rep${i+1}/${basename}",
@@ -104,7 +125,9 @@
     },
     "samstat_qc": {
       "path": "qc/rep${i+1}/${basename}",
-      "table": "QC and logs/Replicate ${i+1}/SAMstats log for filtered BAM"
+      "table": "QC and logs/Replicate ${i+1}/SAMstats log for filtered BAM",
+      "node": "[shape=oval style=\"filled\" fillcolor=gainsboro fontsize=6 margin=0 label=\"SAMstats\nQC\"]",
+      "subgraph": "cluster_rep${i+1}"
     },
     "dup_qc": {
       "path": "qc/rep${i+1}/${basename}",
@@ -116,7 +139,9 @@
     },
     "lib_complexity_qc": {
       "path": "qc/rep${i+1}/${basename}",
-      "table": "QC and logs/Replicate ${i+1}/Library complexity QC for filtered BAM"
+      "table": "QC and logs/Replicate ${i+1}/Library complexity QC for filtered BAM",
+      "node": "[shape=oval style=\"filled\" fillcolor=gainsboro fontsize=6 margin=0 label=\"LibCmplx\nQC\"]",
+      "subgraph": "cluster_rep${i+1}"
     },
     "mito_dup_log": {
       "path": "qc/rep${i+1}/${basename}",
@@ -126,7 +151,9 @@
   "chip.bam2ta": {
     "ta": {
       "path": "align/rep${i+1}/${basename}",
-      "table": "Alignment/Replicate ${i+1}/TAG-ALIGN"
+      "table": "Alignment/Replicate ${i+1}/TAG-ALIGN",
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=lightyellow label=\"TAG-ALIGN\"]",
+      "subgraph": "cluster_rep${i+1}"
     }
   },
   "chip.spr": {
@@ -142,7 +169,9 @@
   "chip.pool_ta": {
     "ta_pooled": {
       "path": "align/pooled-rep/${basename}",
-      "table": "Alignment/Pooled replicate/TAG-ALIGN"
+      "table": "Alignment/Pooled replicate/TAG-ALIGN",
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=lightyellow label=\"TAG-ALIGN\"]",
+      "subgraph": "cluster_pooled_rep"      
     }
   },
   "chip.pool_ta_pr1": {
@@ -160,7 +189,9 @@
   "chip.xcor": {
     "plot_png": {
       "path": "qc/rep${i+1}/${basename}",
-      "table": "QC and logs/Replicate ${i+1}/Cross-correlation Plot"
+      "table": "QC and logs/Replicate ${i+1}/Cross-correlation Plot",
+      "node": "[shape=oval style=\"filled\" fillcolor=gainsboro fontsize=6 margin=0 label=\"XCOR\nPlot\"]",
+      "subgraph": "cluster_rep${i+1}"      
     },
     "score": {
       "path": "qc/rep${i+1}/${basename}",
@@ -436,19 +467,23 @@
     }
   },
   "chip.call_peak": {
-    "npeak": {
+    "peak": {
       "path": "peak/rep${i+1}/${basename}",
-      "table": "Peak/Replicate ${i+1}/Raw narrowpeak"
+      "table": "Peak/Replicate ${i+1}/Raw narrowpeak",
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=lightyellow label=\"Peak\"]",
+      "subgraph": "cluster_rep${i+1}"
     },
-    "bfilt_npeak": {
+    "bfilt_peak": {
       "path": "peak/rep${i+1}/${basename}",
-      "table": "Peak/Replicate ${i+1}/Blacklist-filtered narrowpeak"
+      "table": "Peak/Replicate ${i+1}/Blacklist-filtered narrowpeak",
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=lightyellow label=\"Peak\n(bfilt)\"]",
+      "subgraph": "cluster_rep${i+1}"
     },
-    "bfilt_npeak_bb": {
+    "bfilt_peak_bb": {
       "path": "peak/rep${i+1}/${basename}",
       "table": "Peak/Replicate ${i+1}/Blacklist-filtered narrowpeak (BigBed)"
     },
-    "bfilt_npeak_hammock": {
+    "bfilt_peak_hammock": {
       "path": "peak/rep${i+1}/${basename}",
       "table": "Peak/Replicate ${i+1}/Blacklist-filtered narrowpeak (hammock)"
     },
@@ -458,19 +493,19 @@
     }
   },
   "chip.call_peak_pr1": {
-    "npeak": {
+    "peak": {
       "path": "peak/rep${i+1}/pseudorep1/${basename}",
       "table": "Peak/Replicate ${i+1}/Pseudoreplicate 1/Raw narrowpeak"
     },
-    "bfilt_npeak": {
+    "bfilt_peak": {
       "path": "peak/rep${i+1}/pseudorep1/${basename}",
       "table": "Peak/Replicate ${i+1}/Pseudoreplicate 1/Blacklist-filtered narrowpeak"
     },
-    "bfilt_npeak_bb": {
+    "bfilt_peak_bb": {
       "path": "peak/rep${i+1}/pseudorep1/${basename}",
       "table": "Peak/Replicate ${i+1}/Pseudoreplicate 1/Blacklist-filtered narrowpeak (BigBed)"
     },
-    "bfilt_npeak_hammock": {
+    "bfilt_peak_hammock": {
       "path": "peak/rep${i+1}/pseudorep1/${basename}",
       "table": "Peak/Replicate ${i+1}/Pseudoreplicate 1/Blacklist-filtered narrowpeak (hammock)"
     },
@@ -480,19 +515,19 @@
     }
   },
   "chip.call_peak_pr2": {
-    "npeak": {
+    "peak": {
       "path": "peak/rep${i+1}/pseudorep2/${basename}",
       "table": "Peak/Replicate ${i+1}/Pseudoreplicate 2/Raw narrowpeak"
     },
-    "bfilt_npeak": {
+    "bfilt_peak": {
       "path": "peak/rep${i+1}/pseudorep2/${basename}",
       "table": "Peak/Replicate ${i+1}/Pseudoreplicate 2/Blacklist-filtered narrowpeak"
     },
-    "bfilt_npeak_bb": {
+    "bfilt_peak_bb": {
       "path": "peak/rep${i+1}/pseudorep2/${basename}",
       "table": "Peak/Replicate ${i+1}/Pseudoreplicate 2/Blacklist-filtered narrowpeak (BigBed)"
     },
-    "bfilt_npeak_hammock": {
+    "bfilt_peak_hammock": {
       "path": "peak/rep${i+1}/pseudorep2/${basename}",
       "table": "Peak/Replicate ${i+1}/Pseudoreplicate 2/Blacklist-filtered narrowpeak (hammock)"
     },
@@ -502,19 +537,23 @@
     }
   },
   "chip.call_peak_pooled": {
-    "npeak": {
+    "peak": {
       "path": "peak/pooled-rep/${basename}",
-      "table": "Peak/Pooled replicate/Raw narrowpeak"
+      "table": "Peak/Pooled replicate/Raw narrowpeak",
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=lightyellow label=\"Peak\"]",
+      "subgraph": "cluster_pooled_rep"
     },
-    "bfilt_npeak": {
+    "bfilt_peak": {
       "path": "peak/pooled-rep/${basename}",
-      "table": "Peak/Pooled replicate/Blacklist-filtered narrowpeak"
+      "table": "Peak/Pooled replicate/Blacklist-filtered narrowpeak",
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=lightyellow label=\"Peak\n(bfilt)\"]",
+      "subgraph": "cluster_pooled_rep"
     },
-    "bfilt_npeak_bb": {
+    "bfilt_peak_bb": {
       "path": "peak/pooled-rep/${basename}",
       "table": "Peak/Pooled replicate/Blacklist-filtered narrowpeak (BigBed)"
     },
-    "bfilt_npeak_hammock": {
+    "bfilt_peak_hammock": {
       "path": "peak/pooled-rep/${basename}",
       "table": "Peak/Pooled replicate/Blacklist-filtered narrowpeak (hammock)"
     },
@@ -524,19 +563,19 @@
     }
   },
   "chip.call_peak_ppr1": {
-    "npeak": {
+    "peak": {
       "path": "peak/pooled-rep/pseudorep1/${basename}",
       "table": "Peak/Pooled replicate/Pseudoreplicate 1/Raw narrowpeak"
     },
-    "bfilt_npeak": {
+    "bfilt_peak": {
       "path": "peak/pooled-rep/pseudorep1/${basename}",
       "table": "Peak/Pooled replicate/Pseudoreplicate 1/Blacklist-filtered narrowpeak"
     },
-    "bfilt_npeak_bb": {
+    "bfilt_peak_bb": {
       "path": "peak/pooled-rep/pseudorep1/${basename}",
       "table": "Peak/Pooled replicate/Pseudoreplicate 1/Blacklist-filtered narrowpeak (BigBed)"
     },
-    "bfilt_npeak_hammock": {
+    "bfilt_peak_hammock": {
       "path": "peak/pooled-rep/pseudorep1/${basename}",
       "table": "Peak/Pooled replicate/Pseudoreplicate 1/Blacklist-filtered narrowpeak (hammock)"
     },
@@ -546,19 +585,19 @@
     }
   },
   "chip.call_peak_ppr2": {
-    "npeak": {
+    "peak": {
       "path": "peak/pooled-rep/pseudorep2/${basename}",
       "table": "Peak/Pooled replicate/Pseudoreplicate 2/Raw narrowpeak"
     },
-    "bfilt_npeak": {
+    "bfilt_peak": {
       "path": "peak/pooled-rep/pseudorep2/${basename}",
       "table": "Peak/Pooled replicate/Pseudoreplicate 2/Blacklist-filtered narrowpeak"
     },
-    "bfilt_npeak_bb": {
+    "bfilt_peak_bb": {
       "path": "peak/pooled-rep/pseudorep2/${basename}",
       "table": "Peak/Pooled replicate/Pseudoreplicate 2/Blacklist-filtered narrowpeak (BigBed)"
     },
-    "bfilt_npeak_hammock": {
+    "bfilt_peak_hammock": {
       "path": "peak/pooled-rep/pseudorep2/${basename}",
       "table": "Peak/Pooled replicate/Pseudoreplicate 2/Blacklist-filtered narrowpeak (hammock)"
     },
@@ -571,50 +610,67 @@
     "pval_bw": {
       "path": "signal/rep${i+1}/${basename}",
       "table": "Signal/Replicate ${i+1}/MACS2 signal track (p-val)",
-      "ucsc_track": "track type=bigWig name=\"MACS2 p-val (rep${i+1})\" priority=${i+1} smoothingWindow=off maxHeightPixels=80:60:40 color=255,0,0 autoScale=off viewLimits=0:40 visibility=full"
+      "ucsc_track": "track type=bigWig name=\"MACS2 p-val (rep${i+1})\" priority=${i+1} smoothingWindow=off maxHeightPixels=80:60:40 color=255,0,0 autoScale=off viewLimits=0:40 visibility=full",
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=lightyellow label=\"BW\np-val\"]",
+      "subgraph": "cluster_rep${i+1}"
     },
     "fc_bw": {
       "path": "signal/rep${i+1}/${basename}",
       "table": "Signal/Replicate ${i+1}/MACS2 signal track (fold-enrichment)",
-      "ucsc_track": "track type=bigWig name=\"MACS2 fc (rep${i+1})\" priority=${i+1} smoothingWindow=off maxHeightPixels=80:60:40 color=255,0,0 autoScale=off viewLimits=0:40 visibility=full"
+      "ucsc_track": "track type=bigWig name=\"MACS2 fc (rep${i+1})\" priority=${i+1} smoothingWindow=off maxHeightPixels=80:60:40 color=255,0,0 autoScale=off viewLimits=0:40 visibility=full",
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=lightyellow label=\"BW\nFC\"]",
+      "subgraph": "cluster_rep${i+1}"
     }
   },
   "chip.macs2_signal_track_pooled": {
     "pval_bw": {
       "path": "signal/pooled-rep/${basename}",
       "table": "Signal/Pooled replicate/MACS2 signal track (p-val)",
-      "ucsc_track": "track type=bigWig name=\"MACS2 p-val (pooled)\" priority=0 smoothingWindow=off maxHeightPixels=80:60:40 color=255,0,0 autoScale=off viewLimits=0:40 visibility=full"
+      "ucsc_track": "track type=bigWig name=\"MACS2 p-val (pooled)\" priority=0 smoothingWindow=off maxHeightPixels=80:60:40 color=255,0,0 autoScale=off viewLimits=0:40 visibility=full",
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=lightyellow label=\"BW\np-val\"]",
+      "subgraph": "cluster_pooled_rep"
     },
     "fc_bw": {
       "path": "signal/pooled-rep/${basename}",
       "table": "Signal/Pooled replicate/MACS2 signal track (fold-enrichment)",
-      "ucsc_track": "track type=bigWig name=\"MACS2 fc (pooled)\" priority=0 smoothingWindow=off maxHeightPixels=80:60:40 color=255,0,0 autoScale=off viewLimits=0:40 visibility=full"
+      "ucsc_track": "track type=bigWig name=\"MACS2 fc (pooled)\" priority=0 smoothingWindow=off maxHeightPixels=80:60:40 color=255,0,0 autoScale=off viewLimits=0:40 visibility=full",
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=lightyellow label=\"BW\nFC\"]",
+      "subgraph": "cluster_pooled_rep"
     }
   },
   "chip.count_signal_track": {
     "pos_bw": {
       "path": "signal/rep${i+1}/${basename}",
-      "table": "Signal/Replicate ${i+1}/Count signal track (positive)"
+      "table": "Signal/Replicate ${i+1}/Count signal track (positive)",
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=lightyellow label=\"Count +\nSignal\"]",
+      "subgraph": "cluster_rep${i+1}"
     },
     "neg_bw": {
       "path": "signal/rep${i+1}/${basename}",
-      "table": "Signal/Replicate ${i+1}/Count signal track (negative)"
+      "table": "Signal/Replicate ${i+1}/Count signal track (negative)",
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=lightyellow label=\"Count -\nSignal\"]",
+      "subgraph": "cluster_pooled_rep"
     }
   },
   "chip.count_signal_track_pooled": {
     "pos_bw": {
       "path": "signal/pooled-rep/${basename}",
-      "table": "Signal/Pooled replicate/Count signal track (positive)"
+      "table": "Signal/Pooled replicate/Count signal track (positive)",
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=lightyellow label=\"Count +\nSignal\"]",
+      "subgraph": "cluster_rep${i+1}"
     },
     "neg_bw": {
       "path": "signal/pooled-rep/${basename}",
-      "table": "Signal/Pooled replicate/Count signal track (negative)"
+      "table": "Signal/Pooled replicate/Count signal track (negative)",
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=lightyellow label=\"Count -\nSignal\"]",
+      "subgraph": "cluster_pooled_rep"
     }
   },
   "chip.idr": {
     "bfilt_idr_peak": {
       "path": "peak/${basename.split('.')[0].replace('_vs_','_').replace('_','_vs_').replace('-','_vs_')}/${basename}",
-      "table": "Peak/${basename.split('.')[0].replace('_vs_','_').replace('_',' vs. ').replace('-',' vs. ').capitalize()}/Blacklist-filtered IDR peak"
+      "table": "Peak/${basename.split('.')[0].replace('_vs_','_').replace('_',' vs. ').replace('-',' vs. ').capitalize()}/Blacklist-filtered IDR peak",
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=lightyellow label=\"IDR NPeak\n${basename.split('.')[0]}\"]"
     },
     "bfilt_idr_peak_bb": {
       "path": "peak/${basename.split('.')[0].replace('_vs_','_').replace('_','_vs_').replace('-','_vs_')}/${basename}",
@@ -630,7 +686,8 @@
     },
     "idr_plot": {
       "path": "qc/${basename.split('.')[0].replace('_vs_','_').replace('_','_vs_').replace('-','_vs_')}/${basename}",
-      "table": "QC and logs/${basename.split('.')[0].replace('_',' vs. ').replace('-',' vs. ').capitalize()}/IDR plot"
+      "table": "QC and logs/${basename.split('.')[0].replace('_',' vs. ').replace('-',' vs. ').capitalize()}/IDR plot",
+      "node": "[shape=oval style=\"filled\" fillcolor=gainsboro fontsize=6 margin=0 label=\"IDR Plot\n${basename.split('.')[0]}\"]"
     },
     "idr_log": {
       "path": "qc/${basename.split('.')[0].replace('_vs_','_').replace('_','_vs_').replace('-','_vs_')}/${basename}",
@@ -644,7 +701,8 @@
   "chip.idr_ppr": {
     "bfilt_idr_peak": {
       "path": "peak/pooled-pseudorep1_vs_2/${basename}",
-      "table": "Peak/Pooled pseudoreplicate 1 vs. 2/Blacklist-filtered IDR peak"
+      "table": "Peak/Pooled pseudoreplicate 1 vs. 2/Blacklist-filtered IDR peak",
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=lightyellow label=\"IDR Peak\nppr\"]"
     },
     "bfilt_idr_peak_bb": {
       "path": "peak/pooled-pseudorep1_vs_2/${basename}",
@@ -660,7 +718,8 @@
     },
     "idr_plot": {
       "path": "qc/pooled-pseudorep1_vs_2/${basename}",
-      "table": "QC and logs/Pooled pseudoreplicate 1 vs. 2/IDR plot"
+      "table": "QC and logs/Pooled pseudoreplicate 1 vs. 2/IDR plot",
+      "node": "[shape=oval style=\"filled\" fillcolor=gainsboro fontsize=6 margin=0 label=\"IDR Plot\nppr\"]"
     },
     "idr_log": {
       "path": "qc/pooled-pseudorep1_vs_2/${basename}",
@@ -704,7 +763,8 @@
   "chip.overlap": {
     "bfilt_overlap_peak": {
       "path": "peak/${basename.split('.')[0].replace('_vs_','_').replace('_','_vs_').replace('-','_vs_')}/${basename}",
-      "table": "Peak/${basename.split('.')[0].replace('_vs_','_').replace('_',' vs. ').replace('-',' vs. ').capitalize()}/Blacklist-filtered overlap peak"
+      "table": "Peak/${basename.split('.')[0].replace('_vs_','_').replace('_',' vs. ').replace('-',' vs. ').capitalize()}/Blacklist-filtered overlap peak",
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=lightyellow label=\"Overlap Peak\n${basename.split('.')[0]}\"]"      
     },
     "bfilt_overlap_peak_bb": {
       "path": "peak/${basename.split('.')[0].replace('_vs_','_').replace('_','_vs_').replace('-','_vs_')}/${basename}",
@@ -722,7 +782,8 @@
   "chip.overlap_ppr": {
     "bfilt_overlap_peak": {
       "path": "peak/pooled-pseudorep1_vs_2/${basename}",
-      "table": "Peak/Pooled pseudoreplicate 1 vs. 2/Blacklist-filtered overlap peak"
+      "table": "Peak/Pooled pseudoreplicate 1 vs. 2/Blacklist-filtered overlap peak",
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=lightyellow label=\"Overlap Peak\nppr\"]"
     },
     "bfilt_overlap_peak_bb": {
       "path": "peak/pooled-pseudorep1_vs_2/${basename}",
@@ -758,7 +819,8 @@
   "chip.reproducibility_idr": {
     "optimal_peak": {
       "path": "peak/idr_reproducibility/${basename}",
-      "table": "Peak/IDR reproducibility/Optimal peak"
+      "table": "Peak/IDR reproducibility/Optimal peak",
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=lightyellow label=\"IDR Peak\noptimal\"]"
     },
     "optimal_peak_bb": {
       "path": "peak/idr_reproducibility/${basename}",
@@ -784,13 +846,15 @@
     },
     "reproducibility_qc": {
       "path": "qc/${basename}",
-      "table": "QC and logs/Reproducibility QC for overlap peaks"
+      "table": "QC and logs/Reproducibility QC for overlap peaks",
+      "node": "[shape=oval style=\"filled\" fillcolor=gainsboro fontsize=6 margin=0 label=\"IDR\nreproducibility\"]"
     }
   },
   "chip.reproducibility_overlap": {
     "optimal_peak": {
       "path": "peak/overlap_reproducibility/${basename}",
-      "table": "Peak/Overlap reproducibility/Optimal peak"
+      "table": "Peak/Overlap reproducibility/Optimal peak",
+      "node": "[shape=box style=\"filled, rounded\" fillcolor=lightyellow label=\"Overlap Peak\noptimal\"]"
     },
     "optimal_peak_bb": {
       "path": "peak/overlap_reproducibility/${basename}",
@@ -816,7 +880,8 @@
     },
     "reproducibility_qc": {
       "path": "qc/${basename}",
-      "table": "QC and logs/Reproducibility QC for IDR peaks"
+      "table": "QC and logs/Reproducibility QC for IDR peaks",
+      "node": "[shape=oval style=\"filled\" fillcolor=gainsboro fontsize=6 margin=0 label=\"Overlap\nreproducibility\"]"
     }
   },
   "chip.qc_report": {
@@ -828,5 +893,32 @@
       "path": "qc/${basename}",
       "table": "QC and logs/Final QC JSON file"
     }
+  },
+  "task_graph_template": {
+    "graph [rankdir=LR nodesep=0.1 ranksep=0.3]": null,
+    "node [shape=box fontsize=9 margin=0.05 penwidth=0.5 height=0 fillcolor=lightcyan color=darkgrey style=filled]": null,
+    "edge [arrowsize=0.5 color=darkgrey penwidth=0.5]": null,
+    "subgraph cluster_pooled_rep":{"style": "\"filled, dashed\"", "fontsize": "9", "color": "darkgrey", "penwidth": "0.5", "fillcolor": "oldlace", "labeljust": "\"l\"", "label": "\"Pooled replicate\""},
+    "subgraph cluster_rep1":  {"style": "\"filled, dashed\"", "fontsize": "9", "color": "darkgrey", "penwidth": "0.5", "fillcolor": "honeydew", "labeljust": "\"l\"", "label": "\"Replicate 1\""},
+    "subgraph cluster_rep2":  {"style": "\"filled, dashed\"", "fontsize": "9", "color": "darkgrey", "penwidth": "0.5", "fillcolor": "honeydew", "labeljust": "\"l\"", "label": "\"Replicate 2\""},
+    "subgraph cluster_rep3":  {"style": "\"filled, dashed\"", "fontsize": "9", "color": "darkgrey", "penwidth": "0.5", "fillcolor": "honeydew", "labeljust": "\"l\"", "label": "\"Replicate 3\""},
+    "subgraph cluster_rep4":  {"style": "\"filled, dashed\"", "fontsize": "9", "color": "darkgrey", "penwidth": "0.5", "fillcolor": "honeydew", "labeljust": "\"l\"", "label": "\"Replicate 4\""},
+    "subgraph cluster_rep5":  {"style": "\"filled, dashed\"", "fontsize": "9", "color": "darkgrey", "penwidth": "0.5", "fillcolor": "honeydew", "labeljust": "\"l\"", "label": "\"Replicate 5\""},
+    "subgraph cluster_rep6":  {"style": "\"filled, dashed\"", "fontsize": "9", "color": "darkgrey", "penwidth": "0.5", "fillcolor": "honeydew", "labeljust": "\"l\"", "label": "\"Replicate 6\""},
+    "subgraph cluster_rep7":  {"style": "\"filled, dashed\"", "fontsize": "9", "color": "darkgrey", "penwidth": "0.5", "fillcolor": "honeydew", "labeljust": "\"l\"", "label": "\"Replicate 7\""},
+    "subgraph cluster_rep8":  {"style": "\"filled, dashed\"", "fontsize": "9", "color": "darkgrey", "penwidth": "0.5", "fillcolor": "honeydew", "labeljust": "\"l\"", "label": "\"Replicate 8\""},
+    "subgraph cluster_rep9":  {"style": "\"filled, dashed\"", "fontsize": "9", "color": "darkgrey", "penwidth": "0.5", "fillcolor": "honeydew", "labeljust": "\"l\"", "label": "\"Replicate 9\""},
+    "subgraph cluster_rep10": {"style": "\"filled, dashed\"", "fontsize": "9", "color": "darkgrey", "penwidth": "0.5", "fillcolor": "honeydew", "labeljust": "\"l\"", "label": "\"Replicate 10\""},
+    "subgraph cluster_pooled_ctl":{"style": "\"filled, dashed\"", "fontsize": "9", "color": "darkgrey", "penwidth": "0.5", "fillcolor": "oldlace", "labeljust": "\"l\"", "label": "\"Pooled control\""},
+    "subgraph cluster_ctl1":  {"style": "\"filled, dashed\"", "fontsize": "9", "color": "darkgrey", "penwidth": "0.5", "fillcolor": "honeydew", "labeljust": "\"l\"", "label": "\"Control 1\""},
+    "subgraph cluster_ctl2":  {"style": "\"filled, dashed\"", "fontsize": "9", "color": "darkgrey", "penwidth": "0.5", "fillcolor": "honeydew", "labeljust": "\"l\"", "label": "\"Control 2\""},
+    "subgraph cluster_ctl3":  {"style": "\"filled, dashed\"", "fontsize": "9", "color": "darkgrey", "penwidth": "0.5", "fillcolor": "honeydew", "labeljust": "\"l\"", "label": "\"Control 3\""},
+    "subgraph cluster_ctl4":  {"style": "\"filled, dashed\"", "fontsize": "9", "color": "darkgrey", "penwidth": "0.5", "fillcolor": "honeydew", "labeljust": "\"l\"", "label": "\"Control 4\""},
+    "subgraph cluster_ctl5":  {"style": "\"filled, dashed\"", "fontsize": "9", "color": "darkgrey", "penwidth": "0.5", "fillcolor": "honeydew", "labeljust": "\"l\"", "label": "\"Control 5\""},
+    "subgraph cluster_ctl6":  {"style": "\"filled, dashed\"", "fontsize": "9", "color": "darkgrey", "penwidth": "0.5", "fillcolor": "honeydew", "labeljust": "\"l\"", "label": "\"Control 6\""},
+    "subgraph cluster_ctl7":  {"style": "\"filled, dashed\"", "fontsize": "9", "color": "darkgrey", "penwidth": "0.5", "fillcolor": "honeydew", "labeljust": "\"l\"", "label": "\"Control 7\""},
+    "subgraph cluster_ctl8":  {"style": "\"filled, dashed\"", "fontsize": "9", "color": "darkgrey", "penwidth": "0.5", "fillcolor": "honeydew", "labeljust": "\"l\"", "label": "\"Control 8\""},
+    "subgraph cluster_ctl9":  {"style": "\"filled, dashed\"", "fontsize": "9", "color": "darkgrey", "penwidth": "0.5", "fillcolor": "honeydew", "labeljust": "\"l\"", "label": "\"Control 9\""},
+    "subgraph cluster_ctl10": {"style": "\"filled, dashed\"", "fontsize": "9", "color": "darkgrey", "penwidth": "0.5", "fillcolor": "honeydew", "labeljust": "\"l\"", "label": "\"Control 10\""}
   }
 }

--- a/chip.wdl
+++ b/chip.wdl
@@ -1184,8 +1184,6 @@ task align {
 	Int? multimapping
 	File? custom_align_py	
 	File? idx_tar			# reference index tar
-	File? fastq_R1 			# [read_end_id]
-	File? fastq_R2
 	Boolean paired_end
 	Boolean use_bwa_mem_for_pe
 

--- a/chip.wdl
+++ b/chip.wdl
@@ -120,7 +120,7 @@ workflow chip {
 
 	Int macs2_signal_track_mem_mb = 16000
 	Int macs2_signal_track_time_hr = 24
-	String macs2_signal_track_disks = 'local-disk 200 HDD'
+	String macs2_signal_track_disks = 'local-disk 400 HDD'
 
 	Int call_peak_cpu = 2
 	Int call_peak_mem_mb = 16000

--- a/chip.wdl
+++ b/chip.wdl
@@ -1595,6 +1595,7 @@ task call_peak {
 		memory : '${mem_mb} MB'
 		time : time_hr
 		disks : disks
+		preemptible: 0		
 	}
 }
 
@@ -1627,6 +1628,7 @@ task macs2_signal_track {
 		memory : '${mem_mb} MB'
 		time : time_hr
 		disks : disks
+		preemptible: 0
 	}
 }
 

--- a/docs/input.md
+++ b/docs/input.md
@@ -4,6 +4,8 @@ An input JSON file includes all genomic data files, parameters and metadata for 
 
 Please read through the following step-by-step instruction to compose a input JSON file.
 
+>**IMPORTANT**: ALWAYS USE ABSOLUTE PATHS.
+
 ## Pipeline metadata
 
 Parameter|Description

--- a/docs/input.md
+++ b/docs/input.md
@@ -254,7 +254,7 @@ Parameter|Default
 ---------|-------
 `chip.macs2_signal_track_mem_mb` | 16000
 `chip.macs2_signal_track_time_hr` | 24
-`chip.macs2_signal_track_disks` | `local-disk 200 HDD`
+`chip.macs2_signal_track_disks` | `local-disk 400 HDD`
 
 > **IMPORTANT**: If you see Java memory errors, check the following resource parameters.
 

--- a/docs/input_short.md
+++ b/docs/input_short.md
@@ -2,6 +2,8 @@
 
 An input JSON file includes all genomic data files, parameters and metadata for running pipelines. Our pipeline will use default values if they are not defined in an input JSON file. We provide a set of template JSON files: [minimum](../example_input_json/template.json) and [full](../example_input_json/template.full.json). We recommend to use a minimum template instead of full one. A full template includes all parameters of the pipeline with default values defined.
 
+>**IMPORTANT**: ALWAYS USE ABSOLUTE PATHS.
+
 # Checklist
 
 Mandatory parameters.

--- a/docs/input_short.md
+++ b/docs/input_short.md
@@ -232,7 +232,7 @@ Parameter|Default
 ---------|-------
 `chip.macs2_signal_track_mem_mb` | 16000
 `chip.macs2_signal_track_time_hr` | 24
-`chip.macs2_signal_track_disks` | `local-disk 200 HDD`
+`chip.macs2_signal_track_disks` | `local-disk 400 HDD`
 
 > **IMPORTANT**: If you see Java memory errors, check the following resource parameters.
 

--- a/docs/install_conda.md
+++ b/docs/install_conda.md
@@ -4,6 +4,11 @@
 
 > **WARNING**: DO NOT SKIP ANY OF THE FOLLOWING STEPS OR PIPELINE'S ENVIRONMENT WILL BE MESSED UP WITH YOUR LOCAL PYTHON/GLOBAL CONDA.
 
+0) MacOS users: **MAKE SURE THAT YOU HAVE GNU `grep` INSTALLED ON YOUR SYSTEM**. Check if your `grep` has a `-P` parameter.
+  ```bash
+  $ grep --help  # check if a parameter "-P" exists
+  ```
+
 1) Download [Miniconda installer](https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh). Use default answers to all questions except for the first and last.
   ```bash
   $ wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh

--- a/example_input_json/template.full.json
+++ b/example_input_json/template.full.json
@@ -10,10 +10,7 @@
     "chip.genome_tsv" : "/path_to_genome_data/hg38/hg38.tsv",
 
     "chip.paired_end" : true,
-    "chip.ctl_paired_end" : [true, true],
-
-    "chip.paired_ends" : true,
-    "chip.ctl_paired_ends" : [true, true],
+    "chip.ctl_paired_end" : true,
 
     "chip.fastqs_rep1_R1" : [ "rep1_R1_L1.fastq.gz", "rep1_R1_L2.fastq.gz", "rep1_R1_L3.fastq.gz" ],
     "chip.fastqs_rep1_R2" : [ "rep1_R2_L1.fastq.gz", "rep1_R2_L2.fastq.gz", "rep1_R2_L3.fastq.gz" ],
@@ -40,15 +37,14 @@
     "chip.ctl_depth_ratio" : 1.2,
 
     "chip.peak_caller" : null,
-    "chip.macs2_cap_num_peak" : 500000,
+    "chip.cap_num_peak_macs2" : 500000,
     "chip.pval_thresh" : 0.01,
     "chip.idr_thresh" : 0.05,
-    "chip.spp_cap_num_peak" : 300000,
+    "chip.cap_num_peak_spp" : 300000,
 
     "chip.enable_jsd" : true,
     "chip.enable_gc_bias" : true,
     "chip.enable_count_signal_track" : false,
-    "chip.keep_irregular_chr_in_bfilt_peak" : false,
 
     "chip.filter_chrs" : [],
 

--- a/example_input_json/template.full.json
+++ b/example_input_json/template.full.json
@@ -82,7 +82,7 @@
 
     "chip.macs2_signal_track_mem_mb" : 16000,
     "chip.macs2_signal_track_time_hr" : 24,
-    "chip.macs2_signal_track_disks" : "local-disk 200 HDD",
+    "chip.macs2_signal_track_disks" : "local-disk 400 HDD",
 
     "chip.filter_picard_java_heap" : "4G",
     "chip.gc_bias_picard_java_heap" : "6G"

--- a/src/encode_task_qc_report.py
+++ b/src/encode_task_qc_report.py
@@ -240,7 +240,7 @@ MAP_KEY_DESC_GENERAL = {
     'aligner': 'Aligner',
     'peak_caller': 'Peak caller',
     'genome': 'Genome',
-    'read_end': 'Read end'
+    'seq_endedness': 'Sequencing endedness'
 }
 
 
@@ -260,15 +260,15 @@ def make_cat_root(args):
         ('pipeline_type', args.pipeline_type),
         ('genome', args.genome),
         ('aligner', args.aligner),
-        ('read_end', OrderedDict()),
+        ('seq_endedness', OrderedDict()),
         ('peak_caller', args.peak_caller),
     ])
     if args.paired_ends is not None:
         for i, paired_end in enumerate(args.paired_ends):
-            d_general['read_end']['rep{}'.format(i + 1)] = {'paired_end': paired_end}
+            d_general['seq_endedness']['rep{}'.format(i + 1)] = {'paired_end': paired_end}
     if args.ctl_paired_ends is not None:
         for i, paired_end in enumerate(args.ctl_paired_ends):
-            d_general['read_end']['ctl{}'.format(i + 1)] = {'paired_end': paired_end}
+            d_general['seq_endedness']['ctl{}'.format(i + 1)] = {'paired_end': paired_end}
     cat_root.add_log(d_general, key='general')
 
     return cat_root

--- a/src/encode_task_qc_report.py
+++ b/src/encode_task_qc_report.py
@@ -191,21 +191,11 @@ def parse_arguments():
         if isinstance(value, list):
             setattr(args, a, split_entries_and_extend(value))
 
-    if args.paired_ends is None:
-        if args.paired_end:
-            args.paired_ends = [True]*20
-        else:
-            args.paired_ends = [False]*20
-    else:
+    if args.paired_ends is not None:
         for i, _ in enumerate(args.paired_ends):
             args.paired_ends[i] = str2bool(args.paired_ends[i])
 
-    if args.ctl_paired_ends is None:
-        if args.ctl_paired_end:
-            args.ctl_paired_ends = [True]*20
-        else:
-            args.ctl_paired_ends = args.paired_ends
-    else:
+    if args.ctl_paired_ends is not None:
         for i, _ in enumerate(args.ctl_paired_ends):
             args.ctl_paired_ends[i] = str2bool(args.ctl_paired_ends[i])
 
@@ -250,8 +240,7 @@ MAP_KEY_DESC_GENERAL = {
     'aligner': 'Aligner',
     'peak_caller': 'Peak caller',
     'genome': 'Genome',
-    'paired_end': 'Paired-end per replicate',
-    'ctl_paired_end': 'Control paired-end per replicate',
+    'read_end': 'Read end'
 }
 
 
@@ -270,13 +259,16 @@ def make_cat_root(args):
         ('pipeline_ver', args.pipeline_ver),
         ('pipeline_type', args.pipeline_type),
         ('genome', args.genome),
-        ('paired_end', args.paired_ends),
         ('aligner', args.aligner),
+        ('read_end', OrderedDict()),
         ('peak_caller', args.peak_caller),
     ])
-    if args.ctl_paired_ends \
-            and args.pipeline_type not in ('atac', 'dnase'):
-        d_general['ctl_paired_end'] = args.ctl_paired_ends
+    if args.paired_ends is not None:
+        for i, paired_end in enumerate(args.paired_ends):
+            d_general['read_end']['rep{}'.format(i + 1)] = {'paired_end': paired_end}
+    if args.ctl_paired_ends is not None:
+        for i, paired_end in enumerate(args.ctl_paired_ends):
+            d_general['read_end']['ctl{}'.format(i + 1)] = {'paired_end': paired_end}
     cat_root.add_log(d_general, key='general')
 
     return cat_root


### PR DESCRIPTION
> **IMPORTANT**: Conda users must update their environment.
```bash
$ bash scripts/update_conda_env.sh
```

Task graph on [Croo](https://github.com/ENCODE-DCC/croo) report.
  - updated the output definition JSON file on pipeline's side.

Default parameter changes
  - `chip.macs2_signal_track_disks`: 200 GB -> 400 GB
    - to prevent possible `PAPI error 10` error.

WDL
  - For a task `macs2_signal_track_disks` preemption is now allowed on GCP.

Bug fixes
  - updated documentation for Conda installation for OSX users.
    - OSX users need to install GNU `grep`.