### PR TITLE
Pip 880 update for v1.3.5.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ make_tag: &make_tag
   name: make docker image tag
   command: |
     echo "export TAG=quay.io/encode-dcc/chip-seq-pipeline:${CIRCLE_BRANCH}_${CIRCLE_WORKFLOW_ID}" > ${BASH_ENV}
+    echo "export TAG_DOCKERHUB=quay.io/encode-dcc/chip-seq-pipeline:${CIRCLE_BRANCH}_${CIRCLE_WORKFLOW_ID}" > ${BASH_ENV}
 
 install_singularity: &install_singularity
   name: install singularity
@@ -57,7 +58,7 @@ jobs:
             docker login -u=${QUAY_ROBOT_USER} -p=${QUAY_ROBOT_USER_TOKEN} quay.io
             docker build --cache-from quay.io/encode-dcc/chip-seq-pipeline:${DOCKER_CACHE_TAG} --build-arg GIT_COMMIT_HASH=${CIRCLE_SHA1} --build-arg BRANCH=${CIRCLE_BRANCH} --build-arg BUILD_TAG=${TAG} -t $TAG -f dev/docker_image/Dockerfile .
             docker push ${TAG}
-            # docker push quay.io/encode-dcc/chip-seq-pipeline:template
+            docker push ${TAG_DOCKERHUB}
             docker logout
   test_tasks:
     <<: *machine_defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ make_tag: &make_tag
   name: make docker image tag
   command: |
     echo "export TAG=quay.io/encode-dcc/chip-seq-pipeline:${CIRCLE_BRANCH}_${CIRCLE_WORKFLOW_ID}" > ${BASH_ENV}
-    echo "export TAG_DOCKERHUB=quay.io/encode-dcc/chip-seq-pipeline:${CIRCLE_BRANCH}_${CIRCLE_WORKFLOW_ID}" > ${BASH_ENV}
+    echo "export TAG_DOCKERHUB=quay.io/encode-dcc/chip-seq-pipeline:${CIRCLE_BRANCH}_${CIRCLE_WORKFLOW_ID}" >> ${BASH_ENV}
 
 install_singularity: &install_singularity
   name: install singularity

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ make_tag: &make_tag
   name: make docker image tag
   command: |
     echo "export TAG=quay.io/encode-dcc/chip-seq-pipeline:${CIRCLE_BRANCH}_${CIRCLE_WORKFLOW_ID}" > ${BASH_ENV}
-    echo "export TAG_DOCKERHUB=quay.io/encode-dcc/chip-seq-pipeline:${CIRCLE_BRANCH}_${CIRCLE_WORKFLOW_ID}" >> ${BASH_ENV}
+    echo "export TAG_DOCKERHUB=encodedcc/chip-seq-pipeline:${CIRCLE_BRANCH}_${CIRCLE_WORKFLOW_ID}" >> ${BASH_ENV}
 
 install_singularity: &install_singularity
   name: install singularity
@@ -58,7 +58,7 @@ jobs:
             docker login -u=${QUAY_ROBOT_USER} -p=${QUAY_ROBOT_USER_TOKEN} quay.io
             docker build --cache-from quay.io/encode-dcc/chip-seq-pipeline:${DOCKER_CACHE_TAG} --build-arg GIT_COMMIT_HASH=${CIRCLE_SHA1} --build-arg BRANCH=${CIRCLE_BRANCH} --build-arg BUILD_TAG=${TAG} -t $TAG -f dev/docker_image/Dockerfile .
             docker push ${TAG}
-            docker push ${TAG_DOCKERHUB}
+            #docker push ${TAG_DOCKERHUB}
             docker logout
   test_tasks:
     <<: *machine_defaults

--- a/chip.wdl
+++ b/chip.wdl
@@ -1792,7 +1792,7 @@ task gc_bias {
 	runtime {
 		cpu : 1
 		memory : '10000 MB'
-		time : 1
+		time : 6
 		disks : 'local-disk 100 HDD'
 	}
 }

--- a/chip.wdl
+++ b/chip.wdl
@@ -376,7 +376,7 @@ workflow chip {
 			msg = 'No genome database found in your input JSON. Did you define "chip.genome_tsv" correctly?'
 		}
 	}
-	if ( peak_caller_ == 'spp' && num_ctl == 0 ) {
+	if ( !align_only && peak_caller_ == 'spp' && num_ctl == 0 ) {
 		call raise_exception as error_control_required { input:
 			msg = 'SPP requires control inputs. Define control input files ("chip.ctl_*") in an input JSON file.'
 		}

--- a/chip.wdl
+++ b/chip.wdl
@@ -1,12 +1,12 @@
 # ENCODE TF/Histone ChIP-Seq pipeline
 # Author: Jin Lee (leepc12@gmail.com)
 
-#CAPER docker quay.io/encode-dcc/chip-seq-pipeline:v1.3.5.1
-#CAPER singularity docker://quay.io/encode-dcc/chip-seq-pipeline:v1.3.5.1
+#CAPER docker quay.io/encode-dcc/chip-seq-pipeline:dev-v1.3.6
+#CAPER singularity docker://quay.io/encode-dcc/chip-seq-pipeline:dev-v1.3.6
 #CROO out_def https://storage.googleapis.com/encode-pipeline-output-definition/chip.croo.v3.json
 
 workflow chip {
-	String pipeline_ver = 'v1.3.5.1'
+	String pipeline_ver = 'dev-v1.3.6'
 	### sample name, description
 	String title = 'Untitled'
 	String description = 'No description'

--- a/chip.wdl
+++ b/chip.wdl
@@ -1543,7 +1543,7 @@ task call_peak {
 	File chrsz			# 2-col chromosome sizes file
 	Int cap_num_peak	# cap number of raw peaks called from MACS2
 	Float pval_thresh 	# p.value threshold for MACS2
-	Float fdr_thresh 	# FDR threshold for SPP
+	Float? fdr_thresh 	# FDR threshold for SPP
 
 	File? blacklist 	# blacklist BED to filter raw peaks
 	String? regex_bfilt_peak_chr_name

--- a/chip.wdl
+++ b/chip.wdl
@@ -87,7 +87,8 @@ workflow chip {
 	Int? cap_num_peak
 	Int cap_num_peak_spp = 300000	# cap number of raw peaks called from SPP
 	Int cap_num_peak_macs2 = 500000	# cap number of raw peaks called from MACS2
-	Float pval_thresh = 0.01		# p.value threshold
+	Float pval_thresh = 0.01		# p.value threshold (for MACS2 peak caller only)
+	Float fdr_thresh = 0.01			# FDR threshold (for SPP peak caller only: Rscript run_spp.R -fdr)
 	Float idr_thresh = 0.05			# IDR threshold
 
 	### resources
@@ -768,6 +769,7 @@ workflow chip {
 				chrsz = chrsz_,
 				cap_num_peak = cap_num_peak_,
 				pval_thresh = pval_thresh,
+				fdr_thresh = fdr_thresh,
 				fraglen = fraglen_tmp[i],
 				blacklist = blacklist_,
 				regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
@@ -809,6 +811,7 @@ workflow chip {
 				chrsz = chrsz_,
 				cap_num_peak = cap_num_peak_,
 				pval_thresh = pval_thresh,
+				fdr_thresh = fdr_thresh,
 				fraglen = fraglen_tmp[i],
 				blacklist = blacklist_,
 				regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
@@ -835,6 +838,7 @@ workflow chip {
 				chrsz = chrsz_,
 				cap_num_peak = cap_num_peak_,
 				pval_thresh = pval_thresh,
+				fdr_thresh = fdr_thresh,
 				fraglen = fraglen_tmp[i],
 				blacklist = blacklist_,
 				regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
@@ -877,6 +881,7 @@ workflow chip {
 			chrsz = chrsz_,
 			cap_num_peak = cap_num_peak_,
 			pval_thresh = pval_thresh,
+			fdr_thresh = fdr_thresh,
 			fraglen = fraglen_mean.rounded_mean,
 			blacklist = blacklist_,
 			regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
@@ -918,6 +923,7 @@ workflow chip {
 			chrsz = chrsz_,
 			cap_num_peak = cap_num_peak_,
 			pval_thresh = pval_thresh,
+			fdr_thresh = fdr_thresh,
 			fraglen = fraglen_mean.rounded_mean,
 			blacklist = blacklist_,
 			regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
@@ -944,6 +950,7 @@ workflow chip {
 			chrsz = chrsz_,
 			cap_num_peak = cap_num_peak_,
 			pval_thresh = pval_thresh,
+			fdr_thresh = fdr_thresh,
 			fraglen = fraglen_mean.rounded_mean,
 			blacklist = blacklist_,
 			regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
@@ -1535,7 +1542,9 @@ task call_peak {
                         # chr. sizes file, or hs for human, ms for mouse)
 	File chrsz			# 2-col chromosome sizes file
 	Int cap_num_peak	# cap number of raw peaks called from MACS2
-	Float pval_thresh 	# p.value threshold
+	Float pval_thresh 	# p.value threshold for MACS2
+	Float fdr_thresh 	# FDR threshold for SPP
+
 	File? blacklist 	# blacklist BED to filter raw peaks
 	String? regex_bfilt_peak_chr_name
 
@@ -1561,6 +1570,7 @@ task call_peak {
 				${sep=' ' tas} \
 				${'--fraglen ' + fraglen} \
 				${'--cap-num-peak ' + cap_num_peak} \
+				${'--fdr-thresh '+ fdr_thresh} \
 				${'--nth ' + cpu}
 
 		else
@@ -1571,6 +1581,7 @@ task call_peak {
 				${'--fraglen ' + fraglen} \
 				${'--cap-num-peak ' + cap_num_peak} \
 				${'--pval-thresh '+ pval_thresh}
+				${'--fdr-thresh '+ fdr_thresh}
 				${'--nth ' + cpu}
 		fi
 

--- a/dev/build_on_dx_dockerhub.sh
+++ b/dev/build_on_dx_dockerhub.sh
@@ -2,7 +2,7 @@
 set -e
 
 VER=$(cat chip.wdl | grep "#CAPER docker" | awk 'BEGIN{FS=":"} {print $2}')
-DOCKER=leepc12/chip-seq-pipeline:$VER
+DOCKER=encodedcc/chip-seq-pipeline:$VER
 
 # general
 java -jar ~/dxWDL-0.79.1.jar compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER-dockerhub/general -defaults example_input_json/dx/template_general.json

--- a/dev/build_on_dx_dockerhub.sh
+++ b/dev/build_on_dx_dockerhub.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -e
+
+VER=$(cat chip.wdl | grep "#CAPER docker" | awk 'BEGIN{FS=":"} {print $2}')
+DOCKER=leepc12/chip-seq-pipeline:$VER
+
+# general
+java -jar ~/dxWDL-0.79.1.jar compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER-dockerhub/general -defaults example_input_json/dx/template_general.json
+
+# hg38
+java -jar ~/dxWDL-0.79.1.jar compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER-dockerhub/hg38 -defaults example_input_json/dx/template_hg38.json
+
+# hg19
+java -jar ~/dxWDL-0.79.1.jar compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER-dockerhub/hg19 -defaults example_input_json/dx/template_hg19.json
+
+# mm10
+java -jar ~/dxWDL-0.79.1.jar compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER-dockerhub/mm10 -defaults example_input_json/dx/template_mm10.json
+
+# mm9
+java -jar ~/dxWDL-0.79.1.jar compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER-dockerhub/mm9 -defaults example_input_json/dx/template_mm9.json
+
+# test sample PE ENCSR936XTK (full)
+java -jar ~/dxWDL-0.79.1.jar compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER-dockerhub/test_ENCSR936XTK -defaults example_input_json/dx/ENCSR936XTK_dx.json
+
+# test sample SE ENCSR000DYI (full)
+java -jar ~/dxWDL-0.79.1.jar compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER-dockerhub/test_ENCSR000DYI -defaults example_input_json/dx/ENCSR000DYI_dx.json
+
+# test sample SE ENCSR000DYI (subsampled, chr19/chrM only)
+java -jar ~/dxWDL-0.79.1.jar compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER-dockerhub/test_ENCSR000DYI_subsampled_chr19_only -defaults example_input_json/dx/ENCSR000DYI_subsampled_chr19_only_dx.json
+
+# test sample SE ENCSR000DYI (subsampled, chr19/chrM only, rep1)
+java -jar ~/dxWDL-0.79.1.jar compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER-dockerhub/test_ENCSR000DYI_subsampled_chr19_only_rep1 -defaults example_input_json/dx/ENCSR000DYI_subsampled_chr19_only_rep1_dx.json
+
+## DX Azure
+
+# general
+java -jar ~/dxWDL-0.79.1.jar compile chip.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER-dockerhub/general -defaults example_input_json/dx_azure/template_general.json
+
+# hg38
+java -jar ~/dxWDL-0.79.1.jar compile chip.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER-dockerhub/hg38 -defaults example_input_json/dx_azure/template_hg38.json
+
+# hg19
+java -jar ~/dxWDL-0.79.1.jar compile chip.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER-dockerhub/hg19 -defaults example_input_json/dx_azure/template_hg19.json
+
+# mm10
+java -jar ~/dxWDL-0.79.1.jar compile chip.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER-dockerhub/mm10 -defaults example_input_json/dx_azure/template_mm10.json
+
+# mm9
+java -jar ~/dxWDL-0.79.1.jar compile chip.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER-dockerhub/mm9 -defaults example_input_json/dx_azure/template_mm9.json
+
+# test sample PE ENCSR936XTK (full)
+java -jar ~/dxWDL-0.79.1.jar compile chip.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER-dockerhub/test_ENCSR936XTK -defaults example_input_json/dx_azure/ENCSR936XTK_dx_azure.json
+
+# test sample SE ENCSR000DYI (full)
+java -jar ~/dxWDL-0.79.1.jar compile chip.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER-dockerhub/test_ENCSR000DYI -defaults example_input_json/dx_azure/ENCSR000DYI_dx_azure.json
+
+# test sample SE ENCSR000DYI (subsampled, chr19/chrM only)
+java -jar ~/dxWDL-0.79.1.jar compile chip.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER-dockerhub/test_ENCSR000DYI_subsampled_chr19_only -defaults example_input_json/dx_azure/ENCSR000DYI_subsampled_chr19_only_dx_azure.json

--- a/dev/docker_image/Dockerfile
+++ b/dev/docker_image/Dockerfile
@@ -105,6 +105,9 @@ RUN git clone https://github.com/ENCODE-DCC/kentUtils_bin_v377
 ENV PATH=${PATH}:/software/kentUtils_bin_v377/bin
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/software/kentUtils_bin_v377/lib
 
+# Instal Trimmomatic JAR
+RUN wget http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.39.zip && unzip Trimmomatic-0.39.zip && mv Trimmomatic-0.39/trimmomatic-0.39.jar trimmomatic.jar && chmod +rx trimmomatic.jar && rm -rf Trimmomatic-0.39.zip Trimmomatic-0.39/
+
 # Prevent conflict with locally installed python outside of singularity container
 ENV PYTHONNOUSERSITE=True
 

--- a/dev/test/test_task/test_bowtie2.json
+++ b/dev/test/test_task/test_bowtie2.json
@@ -11,7 +11,11 @@
     "test_bowtie2.se_fastqs" : [
         "chip-seq-pipeline-test-data/input/se/fastqs/rep1/rep1.subsampled.25.fastq.gz"
     ],
+    "test_bowtie2.pe_crop_length" : 50,
+    "test_bowtie2.se_crop_length" : 30,
 
     "test_bowtie2.ref_pe_flagstat" : "chip-seq-pipeline-test-data/ref_output/test_bowtie2/pe/rep1-R1.subsampled.67.samstats.qc",
-    "test_bowtie2.ref_se_flagstat" : "chip-seq-pipeline-test-data/ref_output/test_bowtie2/se/rep1.subsampled.25.samstats.qc"
+    "test_bowtie2.ref_se_flagstat" : "chip-seq-pipeline-test-data/ref_output/test_bowtie2/se/rep1.subsampled.25.samstats.qc",
+    "test_bowtie2.ref_pe_cropped_flagstat" : "chip-seq-pipeline-test-data/ref_output/test_bowtie2/pe/rep1-R1.subsampled.67.merged.crop_50bp.samstats.qc",
+    "test_bowtie2.ref_se_cropped_flagstat" : "chip-seq-pipeline-test-data/ref_output/test_bowtie2/se/rep1.subsampled.25.merged.crop_30bp.samstats.qc"
 }

--- a/dev/test/test_task/test_bowtie2.wdl
+++ b/dev/test/test_task/test_bowtie2.wdl
@@ -8,10 +8,16 @@ workflow test_bowtie2 {
 	Array[File] pe_fastqs_R2
 	Array[File] se_fastqs
 
+	Int pe_crop_length
+	Int se_crop_length
+
 	# we don't compare BAM because BAM's header includes date
 	# hence md5sums don't match all the time
 	String ref_pe_flagstat
 	String ref_se_flagstat
+
+	String ref_pe_cropped_flagstat
+	String ref_se_cropped_flagstat
 
 	String pe_bowtie2_idx_tar
 	String se_bowtie2_idx_tar
@@ -29,6 +35,7 @@ workflow test_bowtie2 {
 		fastqs_R2 = pe_fastqs_R2,
 		paired_end = true,
 		use_bwa_mem_for_pe = false,
+		crop_length = 0,
 
 		cpu = bowtie2_cpu,
 		mem_mb = bowtie2_mem_mb,
@@ -43,6 +50,38 @@ workflow test_bowtie2 {
 		fastqs_R2 = [],
 		paired_end = false,
 		use_bwa_mem_for_pe = false,
+		crop_length = 0,
+
+		cpu = bowtie2_cpu,
+		mem_mb = bowtie2_mem_mb,
+		time_hr = bowtie2_time_hr,
+		disks = bowtie2_disks,
+	}
+
+	call chip.align as pe_cropped_bowtie2 { input :
+		aligner = 'bowtie2',
+		idx_tar = pe_bowtie2_idx_tar,
+		mito_chr_name = 'chrM',
+		fastqs_R1 = pe_fastqs_R1,
+		fastqs_R2 = pe_fastqs_R2,
+		paired_end = true,
+		use_bwa_mem_for_pe = false,
+		crop_length = pe_crop_length,
+
+		cpu = bowtie2_cpu,
+		mem_mb = bowtie2_mem_mb,
+		time_hr = bowtie2_time_hr,
+		disks = bowtie2_disks,
+	}
+	call chip.align as se_cropped_bowtie2 { input :
+		aligner = 'bowtie2',
+		idx_tar = se_bowtie2_idx_tar,
+		mito_chr_name = 'chrM',
+		fastqs_R1 = se_fastqs,
+		fastqs_R2 = [],
+		paired_end = false,
+		use_bwa_mem_for_pe = false,
+		crop_length = se_crop_length,
 
 		cpu = bowtie2_cpu,
 		mem_mb = bowtie2_mem_mb,
@@ -54,14 +93,20 @@ workflow test_bowtie2 {
 		labels = [
 			'pe_bowtie2',
 			'se_bowtie2',
+			'pe_cropped_bowtie2',
+			'se_cropped_bowtie2',
 		],
 		files = [
 			pe_bowtie2.samstat_qc,
 			se_bowtie2.samstat_qc,
+			pe_cropped_bowtie2.samstat_qc,
+			se_cropped_bowtie2.samstat_qc,
 		],
 		ref_files = [
 			ref_pe_flagstat,
 			ref_se_flagstat,
+			ref_pe_cropped_flagstat,
+			ref_se_cropped_flagstat,
 		],
 	}
 }

--- a/dev/test/test_task/test_bwa.wdl
+++ b/dev/test/test_task/test_bwa.wdl
@@ -29,6 +29,7 @@ workflow test_bwa {
 		fastqs_R2 = pe_fastqs_R2,
 		paired_end = true,
 		use_bwa_mem_for_pe = false,
+		crop_length = 0,
 
 		cpu = bwa_cpu,
 		mem_mb = bwa_mem_mb,
@@ -43,6 +44,7 @@ workflow test_bwa {
 		fastqs_R2 = [],
 		paired_end = false,
 		use_bwa_mem_for_pe = false,
+		crop_length = 0,
 
 		cpu = bwa_cpu,
 		mem_mb = bwa_mem_mb,

--- a/docs/input.md
+++ b/docs/input.md
@@ -130,7 +130,7 @@ You can mix up different data types for individual replicate/control replicate. 
 Parameter|Type|Default|Description
 ---------|---|----|-----------
 `chip.aligner` | String | bowtie2 | Currently supported aligners: bwa and bowtie2. To use your own custom aligner, see the below parameter `chip.custom_align_py`.
-`chip.crop_length` | Int | 0 | Crop FASTQs with Trimmomatic. **WARNING**: Check your FASTQs' read length first. Reads SMALLER than this will be excluded from mapping, hence not included in output BAM files and all downstream analyses. 0: cropping disabled.
+`chip.crop_length` | Int | 0 | Crop FASTQs with Trimmomatic. **WARNING**: Check your FASTQs' read length first. Reads SHORTER than this will be excluded while cropping, hence not included in output BAM files and all downstream analyses. 0: cropping disabled.
 `chip.use_bwa_mem_for_pe` | Boolean | false | Currently supported aligners: bwa and bowtie2. To use your own custom aligner, see the below parameter.
 `chip.custom_align_py` | File | | Python script for your custom aligner. See details about [how to use a custom aligner](#how-to-use-a-custom-aligner)
 

--- a/docs/input.md
+++ b/docs/input.md
@@ -170,10 +170,11 @@ Parameter|Default|Description
 Parameter|Default|Description
 ---------|-------|-----------
 `chip.peak_caller`| `spp` for `tf` type<br>`macs2` for `histone` type| `spp` or `macs2`. `spp` requires control<br>`macs2` can work without controls
-`chip.macs2_cap_num_peak` | 500000 | Cap number of peaks called from a peak-caller (MACS2)
+`chip.cap_num_peak_macs2` | 500000 | Cap number of peaks called from a peak-caller (MACS2)
 `chip.pval_thresh` | 0.01 | P-value threshold for MACS2 (macs2 callpeak -p)
 `chip.idr_thresh` | 0.05 | Threshold for IDR (irreproducible discovery rate)
-`chip.spp_cap_num_peak` | 300000 | Cap number of peaks called from a peak-caller (SPP)
+`chip.fdr_thresh` | 0.01 | Threshold for FDR for run_spp.R -fdr
+`chip.cap_num_peak_spp` | 300000 | Cap number of peaks called from a peak-caller (SPP)
 `chip.custom_call_peak_py` | File | Python script for your custom peak caller. See details about [how to use a custom peak caller](#how-to-use-a-peak-caller)
 
 ## Optional pipeline flags

--- a/docs/input.md
+++ b/docs/input.md
@@ -130,6 +130,7 @@ You can mix up different data types for individual replicate/control replicate. 
 Parameter|Type|Default|Description
 ---------|---|----|-----------
 `chip.aligner` | String | bowtie2 | Currently supported aligners: bwa and bowtie2. To use your own custom aligner, see the below parameter `chip.custom_align_py`.
+`chip.crop_length` | Int | 0 | Crop FASTQs with Trimmomatic. **WARNING**: Check your FASTQs' read length first. Reads SMALLER than this will be excluded from mapping, hence not included in output BAM files and all downstream analyses. 0: cropping disabled.
 `chip.use_bwa_mem_for_pe` | Boolean | false | Currently supported aligners: bwa and bowtie2. To use your own custom aligner, see the below parameter.
 `chip.custom_align_py` | File | | Python script for your custom aligner. See details about [how to use a custom aligner](#how-to-use-a-custom-aligner)
 
@@ -153,7 +154,7 @@ Parameter|Default|Description
 
 Parameter|Default|Description
 ---------|-------|-----------
-`chip.xcor_pe_trim_bp` | 50 | Trim R1 of paired ended fastqs for cross-correlation analysis only. Trimmed fastqs will not be used for any other analyses
+`chip.xcor_trim_bp` | 50 | Trim R1 fastq for cross-correlation analysis only. Trimmed fastqs will not be used for any other analyses
 `chip.use_filt_pe_ta_for_xcor` | false | Use filtered PE BAM/TAG-ALIGN for cross-correlation analysis ignoring the above trimmed R1 fastq
 `chip.xcor_exclusion_range_min` | -500 | Exclusion minimum for cross-corr. analysis. See [description for `-x=<min>:<max>`](https://github.com/kundajelab/phantompeakqualtools) for details. Make sure that it's consistent with default strand shift `-s=-500:5:1500` in `phantompeakqualtools`.
 `chip.xcor_exclusion_range_max` |  | Exclusion minimum for cross-corr. analysis. If not defined default value of `max(read length + 10, 50)` for TF and `max(read_len + 10, 100)` for histone are used.
@@ -264,6 +265,7 @@ There are special parameters to control maximum Java heap memory (e.g. `java -Xm
 Parameter|Default
 ---------|-------
 `chip.filter_picard_java_heap` | = `chip.filter_mem_mb`
+`chip.align_trimmomatic_java_heap` | = `chip.align_mem_mb`
 `chip.gc_bias_picard_java_heap` | `10G`
 
 ## How to use a custom aligner

--- a/docs/input_short.md
+++ b/docs/input_short.md
@@ -33,7 +33,7 @@ Mandatory parameters.
     * See [this](#adapters) for how to define adapters to be trimmed.
 
 6) Important parameters
-    * `chip.crop_length`: Crop FASTQs with Trimmomatic. **WARNING**: Check your FASTQs' read length first. Reads SMALLER than this will be excluded from mapping, hence not included in output BAM files and all downstream analyses. It is 0 (disabled) by default.
+    * `chip.crop_length`: Crop FASTQs with Trimmomatic. **WARNING**: Check your FASTQs' read length first. Reads SHORTER than this will be excluded while cropping, hence not included in output BAM files and all downstream analyses. It is 0 (disabled) by default.
     * `chip.always_use_pooled_ctl`: (For TF ChIP-seq only) Always use a pooled control to compare with each replicate. If a single control is given then use it. It is disabled by default.
     * `chip.ctl_depth_ratio`: (For TF ChIP-seq only) If ratio of depth between controls is higher than this. then always use a pooled control for all replicates. It's 1.2 by default.
 

--- a/docs/input_short.md
+++ b/docs/input_short.md
@@ -33,6 +33,7 @@ Mandatory parameters.
     * See [this](#adapters) for how to define adapters to be trimmed.
 
 6) Important parameters
+    * `chip.crop_length`: Crop FASTQs with Trimmomatic. **WARNING**: Check your FASTQs' read length first. Reads SMALLER than this will be excluded from mapping, hence not included in output BAM files and all downstream analyses. It is 0 (disabled) by default.
     * `chip.always_use_pooled_ctl`: (For TF ChIP-seq only) Always use a pooled control to compare with each replicate. If a single control is given then use it. It is disabled by default.
     * `chip.ctl_depth_ratio`: (For TF ChIP-seq only) If ratio of depth between controls is higher than this. then always use a pooled control for all replicates. It's 1.2 by default.
 
@@ -241,4 +242,5 @@ There are special parameters to control maximum Java heap memory (e.g. `java -Xm
 Parameter|Default
 ---------|-------
 `chip.filter_picard_java_heap` | = `chip.filter_mem_mb`
+`chip.align_trimmomatic_java_heap` | = `chip.align_mem_mb`
 `chip.gc_bias_picard_java_heap` | `10G`

--- a/docs/tutorial_dx_web.md
+++ b/docs/tutorial_dx_web.md
@@ -15,8 +15,10 @@ This document describes instruction for the item 2).
 
 3. Move to one of the following workflow directories according to the platform you have chosen for your project (AWS or Azure). These DX workflows are pre-built with all parameters defined.
 
-* [AWS test workflow](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ChIP-seq2/workflows): Use `[LATEST_VER]/test_ENCSR936XTK_subsampled_chr19_only`.
-* [Azure test workflow](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ChIP-seq2/workflows): Use `[LATEST_VER]/test_ENCSR936XTK_subsampled_chr19_only`.
+* [AWS test workflow](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ChIP-seq2/workflows): Use `[LATEST_VER]-dockerhub/test_ENCSR936XTK_subsampled_chr19_only`.
+* [Azure test workflow](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ChIP-seq2/workflows): Use `[LATEST_VER]-dockerhub/test_ENCSR936XTK_subsampled_chr19_only`.
+
+> **WARNING**: If your pipeline fails at the beginning (`read_genome_tsv` step) then it fails to find pipeline's docker image on `quay.io`. Use workflow versions suffixed with `-dockerhub` until we fix this `quay.io` issue.
 
 4. Copy it to your project by right-clicking on the DX workflow `chip` and choose "Copy". 
 

--- a/example_input_json/template.full.json
+++ b/example_input_json/template.full.json
@@ -39,6 +39,7 @@
     "chip.peak_caller" : null,
     "chip.cap_num_peak_macs2" : 500000,
     "chip.pval_thresh" : 0.01,
+    "chip.fdr_thresh" : 0.01,
     "chip.idr_thresh" : 0.05,
     "chip.cap_num_peak_spp" : 300000,
 

--- a/example_input_json/template.full.json
+++ b/example_input_json/template.full.json
@@ -22,6 +22,8 @@
     "chip.ctl_fastqs_rep2_R1" : [ "ctl2_R1.fastq.gz" ],
     "chip.ctl_fastqs_rep2_R2" : [ "ctl2_R2.fastq.gz" ],
 
+    "chip.crop_length" : 0,
+
     "chip.mapq_thresh" : 30,
     "chip.dup_marker" : "picard",
     "chip.no_dup_removal" : false,
@@ -30,7 +32,7 @@
     "chip.ctl_subsample_reads" : 0,
     "chip.xcor_subsample_reads" : 15000000,
 
-    "chip.xcor_pe_trim_bp" : 50,
+    "chip.xcor_trim_bp" : 50,
     "chip.use_filt_pe_ta_for_xcor" : false,
 
     "chip.always_use_pooled_ctl" : false,

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -11,6 +11,7 @@ sambamba ==0.6.6
 samstats ==0.2.1
 bedtools ==2.29.0
 picard ==2.20.7
+trimmomatic ==0.39
 
 ucsc-fetchchromsizes ==357  # 377 in docker/singularity image
 ucsc-wigtobigwig ==357

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -28,7 +28,7 @@ r-snowfall
 r-bitops
 r-catools
 bioconductor-rsamtools
-r-spp  # 1.15 in docker/singularity image
+r-spp ==1.15.5  # 1.14 in docker/singularity image, 1.16 has lwcc() error
 libiconv
 
 bwa ==0.7.17

--- a/src/encode_lib_genomic.py
+++ b/src/encode_lib_genomic.py
@@ -192,6 +192,35 @@ def locate_picard():
             raise Exception(msg)
 
 
+def locate_trimmomatic():
+    try:
+        cmd = 'which trimmomatic.jar'
+        ret = run_shell_cmd(cmd)
+        return ret
+    except:
+        try:
+            # If trimmomatic.jar cannot be found, try with conda installed binary
+            # This relies on that trimmomatic is correctly installed with a link
+            # to the folder containing trimmomatic.jar
+            cmd = 'which trimmomatic'
+            trimmomatic = run_shell_cmd(cmd)
+            ret = os.path.realpath(trimmomatic) + '.jar'
+            if os.path.isfile(ret) and os.access(ret, os.R_OK):
+                return ret
+            else:
+                msg = 'Potential bioconda installation of trimmomatic'
+                msg += ' located at:\n'
+                msg += trimmomatic + '\n'
+                msg += 'but the associated jar file:\n'
+                msg += ret + '\n'
+                msg += 'cannot be found.'
+                raise Exception(msg)
+        except:
+            msg = 'Cannot find trimmomatic.jar or conda installation '\
+                  'of trimmomatic'
+            raise Exception(msg)
+
+
 def subsample_ta_se(ta, subsample, non_mito, mito_chr_name, out_dir):
     prefix = os.path.join(out_dir,
                           os.path.basename(strip_ext_ta(ta)))

--- a/src/encode_task_merge_fastq.py
+++ b/src/encode_task_merge_fastq.py
@@ -27,10 +27,6 @@ def parse_arguments(debug=False):
                         help='Paired-end FASTQs.')
     parser.add_argument('--nth', type=int, default=1,
                         help='Number of threads to parallelize.')
-    parser.add_argument('--crop-length', type=int, default=0,
-                        help='Crop length for Trimmomatic.')
-    parser.add_argument('--max-memory-mb', type=int,
-                        help='Max memory for Trimmomatic.')
     parser.add_argument('--out-dir', default='', type=str,
                         help='Output directory.')
     parser.add_argument('--log-level', default='INFO',
@@ -76,66 +72,6 @@ def merge_fastqs(fastqs, end, out_dir):
     return merged
 
 
-def trimmomatic_se(fastq, crop_len=0, nth=1, mem_mb=None):
-    """crop SE fastq using trimmoatic SE mode
-    """
-    prefix = os.path.join(
-        os.path.dirname(fastq)
-        os.path.basename(strip_ext_fastq(fastq)))
-    cropped = '{p}.crop_{len}.fastq.gz'.format(
-        p=prefix, len=crop_len)
-    assert(crop_len)
-    java_mem_param = '-Xmx{}m'.format(int(mem_mb*0.9)) if mem_mb else ''
-
-    cmd = ' '.join([
-            'java', java_mem_param,
-            '-jar', locate_trimmomatic(), 'SE',
-            '-threads', nth,
-            fastq,
-            cropped,
-            'MINLEN:{}'.format(crop_length),
-            'CROP:{}'.format(crop_length)])
-    run_shell_cmd(cmd)
-    return cropped
-
-
-def trimmomatic_pe(fastq_R1, fastq_R2, crop_len=0, nth=1, mem_mb=None):
-    """crop PE fastq_R1 and fastq_R2 using trimmoatic PE mode
-    """
-    prefix_R1 = os.path.join(
-        os.path.dirname(fastq_R1)
-        os.path.basename(strip_ext_fastq(fastq_R1)))
-    prefix_R2 = os.path.join(
-        os.path.dirname(fastq_R2)
-        os.path.basename(strip_ext_fastq(fastq_R2)))
-    cropped_R1 = '{p}.crop_{len}.fastq.gz'.format(
-        p=prefix_R1, len=crop_len)
-    cropped_unpaired_R1 = '{p}.crop_{len}.unpaired.fastq.gz'.format(
-        p=prefix_R1, len=crop_len)
-    cropped_R2 = '{p}.crop_{len}.fastq.gz'.format(
-        p=prefix_R2, len=crop_len)
-    cropped_unpaired_R2 = '{p}.crop_{len}.unpaired.fastq.gz'.format(
-        p=prefix_R2, len=crop_len)
-    assert(crop_len)
-    java_mem_param = '-Xmx{}m'.format(int(mem_mb*0.9)) if mem_mb else ''
-
-    cmd = ' '.join([
-            'java', java_mem_param,
-            '-jar', locate_trimmomatic(), 'PE',
-            '-threads', nth,
-            fastq_R1,
-            fastq_R2,
-            cropped_R1,
-            cropped_unpaired_R1,
-            cropped_R2,
-            cropped_unpaired_R2,
-            'MINLEN:{}'.format(crop_length),
-            'CROP:{}'.format(crop_length)])
-    run_shell_cmd(cmd)
-    rm_f([cropped_unpaired_R1, cropped_unpaired_R2])
-    return cropped_R1, cropped_R2
-
-
 def main():
     # read params
     args = parse_arguments()
@@ -157,15 +93,6 @@ def main():
     if args.paired_end:
         log.info('R2 to be merged: {}'.format(fastqs_R2))
         merged_R2 = merge_fastqs(fastqs_R2, 'R2', args.out_dir)
-
-    if args.crop_length:
-        log.info('Cropping fastqs with crop_length {}...'.format(args.crop_length))
-        if args.paired_end:
-            trimmomatic_pe(merged_R1, merged_R2, args.crop_length, args.nth)
-            rm_f([merged_R1, merged_R2])
-        else:
-            trimmomatic_se(merged_R1, args.crop_length, args.nth)
-            rm_f(merged_R1)
 
     log.info('List all files in output directory...')
     ls_l(args.out_dir)

--- a/src/encode_task_merge_fastq.py
+++ b/src/encode_task_merge_fastq.py
@@ -10,9 +10,6 @@ from encode_lib_common import (
     log, ls_l, mkdir_p, read_tsv, run_shell_cmd,
     strip_ext_fastq)
 
-from encode_lib_genomic import (
-    locate_trimmomatic)
-
 
 def parse_arguments(debug=False):
     parser = argparse.ArgumentParser(prog='ENCODE DCC fastq merger.',

--- a/src/encode_task_merge_fastq.py
+++ b/src/encode_task_merge_fastq.py
@@ -7,7 +7,7 @@ import sys
 import os
 import argparse
 from encode_lib_common import (
-    copy_f_to_f, log, ls_l, mkdir_p, read_tsv, run_shell_cmd,
+    log, ls_l, mkdir_p, read_tsv, run_shell_cmd,
     strip_ext_fastq)
 
 
@@ -62,14 +62,11 @@ def merge_fastqs(fastqs, end, out_dir):
                           os.path.basename(strip_ext_fastq(fastqs[0])))
     merged = '{}.merged.fastq.gz'.format(prefix)
 
-    if len(fastqs) > 1:
-        cmd = 'zcat -f {} | gzip -nc > {}'.format(
-            ' '.join(fastqs),
-            merged)
-        run_shell_cmd(cmd)
-        return merged
-    else:
-        return copy_f_to_f(fastqs[0], merged)
+    cmd = 'zcat -f {} | gzip -nc > {}'.format(
+        ' '.join(fastqs),
+        merged)
+    run_shell_cmd(cmd)
+    return merged
 
 
 def main():

--- a/src/encode_task_merge_fastq.py
+++ b/src/encode_task_merge_fastq.py
@@ -63,7 +63,11 @@ def merge_fastqs(fastqs, end, out_dir):
     mkdir_p(out_dir)
     prefix = os.path.join(out_dir,
                           os.path.basename(strip_ext_fastq(fastqs[0])))
-    merged = '{}.merged.fastq.gz'.format(prefix)
+
+    if len(fastqs) > 1:
+        merged = '{}.merged.fastq.gz'.format(prefix)
+    else:
+        merged = '{}.fastq.gz'.format(prefix)
 
     cmd = 'zcat -f {} | gzip -nc > {}'.format(
         ' '.join(fastqs),

--- a/src/encode_task_qc_report.py
+++ b/src/encode_task_qc_report.py
@@ -58,7 +58,7 @@ def parse_arguments():
                         help='IDR threshold.')
     parser.add_argument('--pval-thresh', type=float,
                         help='pValue threshold for MACS2 peak caller.')
-    parser.add_argument('--xcor-pe-trim-bp', type=int,
+    parser.add_argument('--xcor-trim-bp', type=int,
                         help='FASTQs are trimmed to this for cross-correlation '
                              'analysis only.')
     parser.add_argument('--xcor-subsample-reads', type=int,
@@ -628,15 +628,15 @@ def make_cat_align_enrich(args, cat_root):
     if args.pipeline_type in ('tf', 'histone'):
         html_head_xcor = '<h2>Strand cross-correlation measures (trimmed/filtered SE BAM)</h2>'
         html_foot_xcor = """
-            <br><p>Performed on subsampled ({xcor_subsample_reads}) reads mapped from FASTQs that are trimmed to {xcor_pe_trim_bp}.
+            <br><p>Performed on subsampled ({xcor_subsample_reads}) reads mapped from FASTQs that are trimmed to {xcor_trim_bp}.
             Such FASTQ trimming and subsampling reads are for cross-corrleation analysis only. 
             Untrimmed FASTQs are used for all the other analyses.</p>
             <div id='help-xcor'><p>
             NOTE1: For SE datasets, reads from replicates are randomly subsampled to {xcor_subsample_reads}.<br>
-            NOTE2: For PE datasets, the first end (R1) of each read-pair is selected and trimmed to {xcor_pe_trim_bp} the reads are then randomly subsampled to {xcor_subsample_reads}.<br>
+            NOTE2: For PE datasets, the first end (R1) of each read-pair is selected and trimmed to {xcor_trim_bp} the reads are then randomly subsampled to {xcor_subsample_reads}.<br>
         """.format(
             xcor_subsample_reads=args.xcor_subsample_reads,
-            xcor_pe_trim_bp=args.xcor_pe_trim_bp,
+            xcor_trim_bp=args.xcor_trim_bp,
         )
     else:
         html_head_xcor = '<h2>Strand cross-correlation measures (filtered BAM)</h2>'

--- a/src/encode_task_spp.py
+++ b/src/encode_task_spp.py
@@ -95,7 +95,9 @@ def main():
                 args.nth, args.out_dir)
 
     log.info('Checking if output is empty...')
-    assert_file_not_empty(rpeak)
+    assert_file_not_empty(rpeak, help=
+        'No peaks found. FDR threshold (fdr_thresh in your input JSON) '
+        'might be too stringent or poor quality sample?')
 
     log.info('List all files in output directory...')
     ls_l(args.out_dir)

--- a/src/encode_task_spp.py
+++ b/src/encode_task_spp.py
@@ -21,6 +21,8 @@ def parse_arguments():
                         help='2-col chromosome sizes file.')
     parser.add_argument('--fraglen', type=int, required=True,
                         help='Fragment length.')
+    parser.add_argument('--fdr-thresh', default=0.01, type=float,
+                        help='FDR threshold for run_spp.R -fdr parameter.')
     parser.add_argument('--cap-num-peak', default=300000, type=int,
                         help='Capping number of peaks by taking top N peaks.')
     parser.add_argument('--nth', type=int, default=1,
@@ -39,7 +41,7 @@ def parse_arguments():
     return args
 
 
-def spp(ta, ctl_ta, fraglen, cap_num_peak, nth, out_dir):
+def spp(ta, ctl_ta, fraglen, cap_num_peak, fdr_thresh, nth, out_dir):
     basename_ta = os.path.basename(strip_ext_ta(ta))
     basename_ctl_ta = os.path.basename(strip_ext_ta(ctl_ta))
     basename_prefix = '{}_x_{}'.format(basename_ta, basename_ctl_ta)
@@ -54,7 +56,7 @@ def spp(ta, ctl_ta, fraglen, cap_num_peak, nth, out_dir):
     rpeak_tmp_gz = '{}.tmp.gz'.format(rpeak)
 
     cmd0 = 'Rscript --max-ppsize=500000 $(which run_spp.R) -c={} -i={} '
-    cmd0 += '-npeak={} -odir={} -speak={} -savr={} -rf {}'
+    cmd0 += '-npeak={} -odir={} -speak={} -savr={} -fdr={} -rf {}'
     cmd0 = cmd0.format(
         ta,
         ctl_ta,
@@ -62,6 +64,7 @@ def spp(ta, ctl_ta, fraglen, cap_num_peak, nth, out_dir):
         os.path.abspath(out_dir),
         fraglen,
         rpeak_tmp,
+        fdr_thresh,
         nth_param)
     run_shell_cmd(cmd0)
 
@@ -88,7 +91,8 @@ def main():
 
     log.info('Calling peaks with spp...')
     rpeak = spp(args.tas[0], args.tas[1],
-                args.fraglen, args.cap_num_peak, args.nth, args.out_dir)
+                args.fraglen, args.cap_num_peak, args.fdr_thresh,
+                args.nth, args.out_dir)
 
     log.info('Checking if output is empty...')
     assert_file_not_empty(rpeak)

--- a/src/encode_task_trim_adapter.py
+++ b/src/encode_task_trim_adapter.py
@@ -9,8 +9,9 @@ import argparse
 import copy
 from detect_adapter import detect_most_likely_adapter
 from encode_lib_common import (
-    copy_f_to_dir, copy_f_to_f, log, ls_l, mkdir_p, read_tsv, rm_f,
+    copy_f_to_dir, log, ls_l, mkdir_p, read_tsv, rm_f,
     run_shell_cmd, strip_ext_fastq)
+from encode_task_merge_fastq import merge_fastqs
 
 
 def parse_arguments(debug=False):
@@ -131,25 +132,6 @@ def trim_adapter_pe(fastq1, fastq2, adapter1, adapter2, adapter_for_all,
         fq1 = copy_f_to_dir(fastq1, out_dir)
         fq2 = copy_f_to_dir(fastq2, out_dir)
         return [fq1, fq2]
-
-
-def merge_fastqs(fastqs, end, out_dir):
-    """make merged fastqs on $out_dir/R1, $out_dir/R2
-    """
-    out_dir = os.path.join(out_dir, end)
-    mkdir_p(out_dir)
-    prefix = os.path.join(out_dir,
-                          os.path.basename(strip_ext_fastq(fastqs[0])))
-    merged = '{}.merged.fastq.gz'.format(prefix)
-
-    if len(fastqs) > 1:
-        cmd = 'zcat -f {} | gzip -nc > {}'.format(
-            ' '.join(fastqs),
-            merged)
-        run_shell_cmd(cmd)
-        return merged
-    else:
-        return copy_f_to_f(fastqs[0], merged)
 
 
 def main():

--- a/src/encode_task_trimmomatic.py
+++ b/src/encode_task_trimmomatic.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+
+# ENCODE DCC Trimmomatic wrapper
+# Author: Jin Lee (leepc12@gmail.com)
+
+import sys
+import os
+import argparse
+from encode_lib_common import (
+    log, ls_l, mkdir_p, rm_f,
+    run_shell_cmd, strip_ext_fastq)
+from encode_lib_genomic import (
+    locate_trimmomatic)
+
+
+def parse_arguments(debug=False):
+    parser = argparse.ArgumentParser(
+        prog='ENCODE DCC Trimmomatic wrapper.')
+    parser.add_argument('--fastq1',
+                        help='FASTQ R1 to be trimmed.')
+    parser.add_argument('--fastq2',
+                        help='FASTQ R2 to be trimmed.')
+    parser.add_argument('--paired-end', action="store_true",
+                        help='Paired-end FASTQs.')
+    parser.add_argument('--crop-length', type=int,
+                        help='Number of basepair to crop.')
+    parser.add_argument('--out-dir-R1', default='', type=str,
+                        help='Output directory for cropped R1 fastq.')
+    parser.add_argument('--out-dir-R2', default='', type=str,
+                        help='Output directory for cropped R2 fastq.')
+    parser.add_argument('--trimmomatic-java-heap',
+                        help='Trimmomatic\'s Java max. heap: java -jar Trimmomatic.jar '
+                             '-Xmx[MAX_HEAP]')
+    parser.add_argument('--nth', type=int, default=1,
+                        help='Number of threads to parallelize.')    
+    parser.add_argument('--log-level', default='INFO',
+                        choices=['NOTSET', 'DEBUG', 'INFO',
+                                 'WARNING', 'CRITICAL', 'ERROR',
+                                 'CRITICAL'],
+                        help='Log level')
+    args = parser.parse_args()
+    if not args.crop_length:
+        raise ValueError('Crop length must be > 0.')
+
+    log.setLevel(args.log_level)
+    log.info(sys.argv)
+    return args
+
+
+def trimmomatic_se(fastq1, crop_length, out_dir,
+                   nth=1, java_heap=None):
+    prefix = os.path.join(out_dir,
+                          os.path.basename(strip_ext_fastq(fastq1)))
+    cropped = '{}.crop_{}bp.fastq.gz'.format(prefix, crop_length)
+
+    if java_heap is None:
+        java_heap_param = '-Xmx6G'
+    else:
+        java_heap_param = '-Xmx{}'.format(java_heap)
+
+    cmd = 'java -XX:ParallelGCThreads=1 {} -jar {} SE -threads {} '
+    cmd += '{} {} MINLEN:{} CROP:{}'
+    cmd = cmd.format(
+        java_heap_param,
+        locate_trimmomatic(),
+        nth,
+        fastq1,
+        cropped,
+        crop_length,
+        crop_length)
+    run_shell_cmd(cmd)
+
+    return cropped
+
+
+def trimmomatic_pe(fastq1, fastq2, crop_length, out_dir_R1, out_dir_R2,
+                   nth=1, java_heap=None):
+    prefix_R1 = os.path.join(
+        out_dir_R1, os.path.basename(strip_ext_fastq(fastq1)))
+    prefix_R2 = os.path.join(
+        out_dir_R2, os.path.basename(strip_ext_fastq(fastq2)))
+    cropped_R1 = '{}.crop_{}bp.fastq.gz'.format(prefix_R1, crop_length)
+    cropped_R2 = '{}.crop_{}bp.fastq.gz'.format(prefix_R2, crop_length)
+    tmp_cropped_R1 = '{}.tmp'.format(cropped_R1)
+    tmp_cropped_R2 = '{}.tmp'.format(cropped_R2)
+
+    if java_heap is None:
+        java_heap_param = '-Xmx6G'
+    else:
+        java_heap_param = '-Xmx{}'.format(java_heap)
+
+    cmd = 'java -XX:ParallelGCThreads=1 {} -jar {} PE -threads {} '
+    cmd += '{} {} {} {} {} {} MINLEN:{} CROP:{}'
+    cmd = cmd.format(
+        java_heap_param,
+        locate_trimmomatic(),
+        nth,
+        fastq1,
+        fastq2,
+        cropped_R1,
+        tmp_cropped_R1,
+        cropped_R2,
+        tmp_cropped_R2,
+        crop_length,
+        crop_length)
+    run_shell_cmd(cmd)
+    rm_f([tmp_cropped_R1, tmp_cropped_R2])
+
+    return cropped_R1, cropped_R2
+
+
+def main():
+    # read params
+    args = parse_arguments()
+
+    log.info('Initializing and making output directory...')
+    mkdir_p(args.out_dir_R1)
+    if args.paired_end:
+        mkdir_p(args.out_dir_R2)
+
+    log.info('Cropping fastqs ({} bp) with Trimmomatic...'.format(args.crop_length))
+    if args.paired_end:
+        trimmomatic_pe(
+            args.fastq1, args.fastq2,
+            args.crop_length,
+            args.out_dir_R1, args.out_dir_R2,
+            args.nth,
+            args.trimmomatic_java_heap)
+    else:
+        trimmomatic_se(
+            args.fastq1,
+            args.crop_length,
+            args.out_dir_R1,
+            args.nth,
+            args.trimmomatic_java_heap)
+
+    log.info('List all files in output directory...')
+    ls_l(args.out_dir_R1)
+    if args.paired_end:
+        ls_l(args.out_dir_R2)
+
+    log.info('All done.')
+
+
+if __name__ == '__main__':
+    main()

--- a/src/encode_task_trimmomatic.py
+++ b/src/encode_task_trimmomatic.py
@@ -7,7 +7,7 @@ import sys
 import os
 import argparse
 from encode_lib_common import (
-    log, ls_l, mkdir_p, rm_f,
+    assert_file_not_empty, log, ls_l, mkdir_p, rm_f,
     run_shell_cmd, strip_ext_fastq)
 from encode_lib_genomic import (
     locate_trimmomatic)

--- a/src/encode_task_trimmomatic.py
+++ b/src/encode_task_trimmomatic.py
@@ -120,14 +120,14 @@ def main():
 
     log.info('Cropping fastqs ({} bp) with Trimmomatic...'.format(args.crop_length))
     if args.paired_end:
-        trimmomatic_pe(
+        cropped_R1, cropped_R2 = trimmomatic_pe(
             args.fastq1, args.fastq2,
             args.crop_length,
             args.out_dir_R1, args.out_dir_R2,
             args.nth,
             args.trimmomatic_java_heap)
     else:
-        trimmomatic_se(
+        cropped_R1 = trimmomatic_se(
             args.fastq1,
             args.crop_length,
             args.out_dir_R1,
@@ -138,6 +138,12 @@ def main():
     ls_l(args.out_dir_R1)
     if args.paired_end:
         ls_l(args.out_dir_R2)
+
+    log.info('Checking if output is empty...')
+    assert_file_not_empty(cropped_R1, help=
+        'No reads in FASTQ after cropping. crop_length might be too high? '
+        'While cropping, Trimmomatic (with MINLEN) excludes all reads '
+        'SHORTER than crop_length.')
 
     log.info('All done.')
 


### PR DESCRIPTION
Conda users should re-install pipeline's environment.
```
$ bash scripts/uninstall_conda_env.sh
$ bash scripts/install_conda_env.sh
```

* New parameters (in an input JSON)
  - `chip.crop_length`: Crop FASTQs with Trimmomatic. Cropping is disabled by default (set as `0`). Check your FASTQs' read length first. Any reads SHORTER than this length will be excluded while cropping, hence not included in output BAMs and all downstream analyses.
  - `chip.fdr_thresh`: FDR threshold for SPP peak caller. It's `0.01` by default. Use a more relaxed value if you see the following `File is empty` error in SPP task `call-peak`. Possible fix for issue #119. 

```
	Traceback (most recent call last):
	  File "/root/miniconda3/envs/encode-chip-seq-pipeline/bin/encode_task_spp.py", line 103, in <module>
	    main()
	  File "/root/miniconda3/envs/encode-chip-seq-pipeline/bin/encode_task_spp.py", line 94, in main
	    assert_file_not_empty(rpeak)
	  File "/root/miniconda3/envs/encode-chip-seq-pipeline/bin/encode_lib_common.py", line 212, in assert_file_not_empty
	    raise Exception('File is empty ({}). Help: {}'.format(f, help))
	Exception: File is empty (rep2-R1.subsampled.50.merged.nodup.pr2_x_ctl_for_rep2.300K.regionPeak.gz). Help:
```

* Changes in parameters
  - `chip.xcor_pe_trim_bp` -> `chip.xcor_trim_bp`: `_pe_` is misleading since it's also applied to SE FASTQs too.


* Bug fixes
  - Ungzipped single FASTQ input
  - DNAnexus: Failure at `read_genome_tsv` due to errors while retrieving image from `quay.io`. `dockerhub` is used instead.
