### PR TITLE
make a copy of BAM instead of zcatting

### DIFF
--- a/src/encode_lib_blacklist_filter.py
+++ b/src/encode_lib_blacklist_filter.py
@@ -80,7 +80,7 @@ def blacklist_filter_bam(bam, blacklist, out_dir):
     filtered = '{}.bfilt.bam'.format(prefix)
 
     if blacklist == '' or get_num_lines(blacklist) == 0:
-        cmd = 'zcat -f {} | gzip -nc > {}'.format(bam, filtered)
+        cmd = 'cp -f {b} {f}'.format(b=bam, f=filtered)
         run_shell_cmd(cmd)
     else:
         # due to bedtools bug when .gz is given for -a and -b


### PR DESCRIPTION
In `jsd` task BAM should be blacklist-filtered (to make a `.bfilt.bam`). However, if blacklist file is empty, pipeline skipped this filtering by making a copy of BAM.

To make a copy of BAM, pipeline `zcat`ed BAM file but this can result in a corrupted BAM file due to headers. So we make a copy (`cp`) of a BAM file instead of `zcat`ting it.