### PR TITLE
trimmomatic: minlen = crop_length - 2

### DIFF
--- a/chip.wdl
+++ b/chip.wdl
@@ -64,6 +64,7 @@ workflow chip {
 	Boolean use_bwa_mem_for_pe = false # THIS IS EXPERIMENTAL and BWA ONLY (use bwa mem instead of bwa aln/sam)
 									# available only for PE dataset with READ_LEN>=70bp
 	Int crop_length = 0 			# crop reads in FASTQs with Trimmomatic (0 by default, i.e. disabled)
+	Int crop_length_tol = 2 	# keep shorter reads around crop_length
 	Int xcor_trim_bp = 50 			# for cross-correlation analysis only (R1 of paired-end fastqs)
 	Boolean use_filt_pe_ta_for_xcor = false # PE only. use filtered PE BAM for cross-corr.
 	String dup_marker = 'picard'	# picard, sambamba
@@ -398,7 +399,7 @@ workflow chip {
 				fastqs_R1 = fastqs_R1[i],
 				fastqs_R2 = fastqs_R2[i],
 				crop_length = crop_length,
-				min_length = crop_length - 2,
+				crop_length_tol = crop_length_tol,
 
 				aligner = aligner_,
 				mito_chr_name = mito_chr_name_,
@@ -491,7 +492,7 @@ workflow chip {
 				fastqs_R2 = [],
 				trim_bp = xcor_trim_bp,
 				crop_length = 0,
-				min_length = 0,
+				crop_length_tol = 0,
 
 				aligner = aligner_,
 				mito_chr_name = mito_chr_name_,
@@ -618,7 +619,7 @@ workflow chip {
 				fastqs_R1 = ctl_fastqs_R1[i],
 				fastqs_R2 = ctl_fastqs_R2[i],
 				crop_length = crop_length,
-				min_length = crop_length - 2,
+				crop_length_tol = crop_length_tol,
 
 				aligner = aligner_,
 				mito_chr_name = mito_chr_name_,
@@ -1203,7 +1204,7 @@ task align {
 	Array[File] fastqs_R2
 	Int? trim_bp			# this is for R1 only
 	Int crop_length
-	Int min_length
+	Int crop_length_tol
 	String aligner
 	String mito_chr_name
 	Int? multimapping
@@ -1263,7 +1264,7 @@ task align {
 				${if paired_end then '--fastq2 R2$SUFFIX/*.fastq.gz' else ''} \
 				${if paired_end then '--paired-end' else ''} \
 				--crop-length ${crop_length} \
-				--min-length ${min_length} \
+				--crop-length-tol "${crop_length_tol}" \
 				--out-dir-R1 R1$NEW_SUFFIX \
 				${if paired_end then '--out-dir-R2 R2$NEW_SUFFIX' else ''} \
 				${'--trimmomatic-java-heap ' + if defined(trimmomatic_java_heap) then trimmomatic_java_heap else (mem_mb + 'M')} \

--- a/chip.wdl
+++ b/chip.wdl
@@ -398,6 +398,7 @@ workflow chip {
 				fastqs_R1 = fastqs_R1[i],
 				fastqs_R2 = fastqs_R2[i],
 				crop_length = crop_length,
+				min_length = crop_length - 2,
 
 				aligner = aligner_,
 				mito_chr_name = mito_chr_name_,
@@ -490,6 +491,7 @@ workflow chip {
 				fastqs_R2 = [],
 				trim_bp = xcor_trim_bp,
 				crop_length = 0,
+				min_length = 0,
 
 				aligner = aligner_,
 				mito_chr_name = mito_chr_name_,
@@ -616,6 +618,7 @@ workflow chip {
 				fastqs_R1 = ctl_fastqs_R1[i],
 				fastqs_R2 = ctl_fastqs_R2[i],
 				crop_length = crop_length,
+				min_length = crop_length - 2,
 
 				aligner = aligner_,
 				mito_chr_name = mito_chr_name_,
@@ -1200,6 +1203,7 @@ task align {
 	Array[File] fastqs_R2
 	Int? trim_bp			# this is for R1 only
 	Int crop_length
+	Int min_length
 	String aligner
 	String mito_chr_name
 	Int? multimapping
@@ -1259,6 +1263,7 @@ task align {
 				${if paired_end then '--fastq2 R2$SUFFIX/*.fastq.gz' else ''} \
 				${if paired_end then '--paired-end' else ''} \
 				--crop-length ${crop_length} \
+				--min-length ${min_length} \
 				--out-dir-R1 R1$NEW_SUFFIX \
 				${if paired_end then '--out-dir-R2 R2$NEW_SUFFIX' else ''} \
 				${'--trimmomatic-java-heap ' + if defined(trimmomatic_java_heap) then trimmomatic_java_heap else (mem_mb + 'M')} \

--- a/chip.wdl
+++ b/chip.wdl
@@ -1,12 +1,12 @@
 # ENCODE TF/Histone ChIP-Seq pipeline
 # Author: Jin Lee (leepc12@gmail.com)
 
-#CAPER docker quay.io/encode-dcc/chip-seq-pipeline:dev-v1.3.7
-#CAPER singularity docker://quay.io/encode-dcc/chip-seq-pipeline:dev-v1.3.7
+#CAPER docker quay.io/encode-dcc/chip-seq-pipeline:v1.3.7
+#CAPER singularity docker://quay.io/encode-dcc/chip-seq-pipeline:v1.3.7
 #CROO out_def https://storage.googleapis.com/encode-pipeline-output-definition/chip.croo.v4.json
 
 workflow chip {
-	String pipeline_ver = 'dev-v1.3.7'
+	String pipeline_ver = 'v1.3.7'
 	### sample name, description
 	String title = 'Untitled'
 	String description = 'No description'

--- a/dev/test/test_task/test_bowtie2.wdl
+++ b/dev/test/test_task/test_bowtie2.wdl
@@ -36,6 +36,7 @@ workflow test_bowtie2 {
 		paired_end = true,
 		use_bwa_mem_for_pe = false,
 		crop_length = 0,
+		min_length = 0,
 
 		cpu = bowtie2_cpu,
 		mem_mb = bowtie2_mem_mb,
@@ -51,6 +52,7 @@ workflow test_bowtie2 {
 		paired_end = false,
 		use_bwa_mem_for_pe = false,
 		crop_length = 0,
+		min_length = 0,
 
 		cpu = bowtie2_cpu,
 		mem_mb = bowtie2_mem_mb,
@@ -67,6 +69,7 @@ workflow test_bowtie2 {
 		paired_end = true,
 		use_bwa_mem_for_pe = false,
 		crop_length = pe_crop_length,
+		min_length = pe_crop_length - 2,
 
 		cpu = bowtie2_cpu,
 		mem_mb = bowtie2_mem_mb,
@@ -82,6 +85,7 @@ workflow test_bowtie2 {
 		paired_end = false,
 		use_bwa_mem_for_pe = false,
 		crop_length = se_crop_length,
+		min_length = se_crop_length - 2,
 
 		cpu = bowtie2_cpu,
 		mem_mb = bowtie2_mem_mb,

--- a/dev/test/test_task/test_bowtie2.wdl
+++ b/dev/test/test_task/test_bowtie2.wdl
@@ -10,6 +10,8 @@ workflow test_bowtie2 {
 
 	Int pe_crop_length
 	Int se_crop_length
+	Int pe_crop_length_tol = 2
+	Int se_crop_length_tol = 2
 
 	# we don't compare BAM because BAM's header includes date
 	# hence md5sums don't match all the time
@@ -36,7 +38,7 @@ workflow test_bowtie2 {
 		paired_end = true,
 		use_bwa_mem_for_pe = false,
 		crop_length = 0,
-		min_length = 0,
+		crop_length_tol = 0,
 
 		cpu = bowtie2_cpu,
 		mem_mb = bowtie2_mem_mb,
@@ -52,7 +54,7 @@ workflow test_bowtie2 {
 		paired_end = false,
 		use_bwa_mem_for_pe = false,
 		crop_length = 0,
-		min_length = 0,
+		crop_length_tol = 0,
 
 		cpu = bowtie2_cpu,
 		mem_mb = bowtie2_mem_mb,
@@ -69,7 +71,7 @@ workflow test_bowtie2 {
 		paired_end = true,
 		use_bwa_mem_for_pe = false,
 		crop_length = pe_crop_length,
-		min_length = pe_crop_length - 2,
+		crop_length_tol = pe_crop_length_tol,
 
 		cpu = bowtie2_cpu,
 		mem_mb = bowtie2_mem_mb,
@@ -85,7 +87,7 @@ workflow test_bowtie2 {
 		paired_end = false,
 		use_bwa_mem_for_pe = false,
 		crop_length = se_crop_length,
-		min_length = se_crop_length - 2,
+		crop_length_tol = se_crop_length_tol,
 
 		cpu = bowtie2_cpu,
 		mem_mb = bowtie2_mem_mb,

--- a/dev/test/test_task/test_bwa.wdl
+++ b/dev/test/test_task/test_bwa.wdl
@@ -30,7 +30,7 @@ workflow test_bwa {
 		paired_end = true,
 		use_bwa_mem_for_pe = false,
 		crop_length = 0,
-		crop_length = 0,
+		min_length = 0,
 
 		cpu = bwa_cpu,
 		mem_mb = bwa_mem_mb,
@@ -46,7 +46,7 @@ workflow test_bwa {
 		paired_end = false,
 		use_bwa_mem_for_pe = false,
 		crop_length = 0,
-		crop_length = 0,
+		min_length = 0,
 
 		cpu = bwa_cpu,
 		mem_mb = bwa_mem_mb,

--- a/dev/test/test_task/test_bwa.wdl
+++ b/dev/test/test_task/test_bwa.wdl
@@ -30,6 +30,7 @@ workflow test_bwa {
 		paired_end = true,
 		use_bwa_mem_for_pe = false,
 		crop_length = 0,
+		crop_length = 0,
 
 		cpu = bwa_cpu,
 		mem_mb = bwa_mem_mb,
@@ -44,6 +45,7 @@ workflow test_bwa {
 		fastqs_R2 = [],
 		paired_end = false,
 		use_bwa_mem_for_pe = false,
+		crop_length = 0,
 		crop_length = 0,
 
 		cpu = bwa_cpu,

--- a/dev/test/test_task/test_bwa.wdl
+++ b/dev/test/test_task/test_bwa.wdl
@@ -30,7 +30,7 @@ workflow test_bwa {
 		paired_end = true,
 		use_bwa_mem_for_pe = false,
 		crop_length = 0,
-		min_length = 0,
+		crop_length_tol = 0,
 
 		cpu = bwa_cpu,
 		mem_mb = bwa_mem_mb,
@@ -46,7 +46,7 @@ workflow test_bwa {
 		paired_end = false,
 		use_bwa_mem_for_pe = false,
 		crop_length = 0,
-		min_length = 0,
+		crop_length_tol = 0,
 
 		cpu = bwa_cpu,
 		mem_mb = bwa_mem_mb,

--- a/docs/input.md
+++ b/docs/input.md
@@ -131,9 +131,11 @@ You can mix up different data types for individual replicate/control replicate. 
 Parameter|Type|Default|Description
 ---------|---|----|-----------
 `chip.aligner` | String | bowtie2 | Currently supported aligners: bwa and bowtie2. To use your own custom aligner, see the below parameter `chip.custom_align_py`.
-`chip.crop_length` | Int | 0 | Crop FASTQs with Trimmomatic (using parameters `MINLEN` and `CROP`). `MINLEN` will be set as `chip.crop_length` - 2. **WARNING**: Check your FASTQs' read length first. Reads SHORTER than (`chip.crop_length` - 2) will be excluded while cropping, hence not included in output BAM files and all downstream analyses. 0: cropping disabled.
+`chip.crop_length` | Int | 0 | Crop FASTQs with Trimmomatic (using parameters `CROP`). 0: cropping disabled.`chip.crop_length_tol` | Int | 2 | Trimmomatic's `MINLEN` will be set as `chip.crop_length` - `abs(chip.crop_length_tol)` where reads shorter than `MINLEN` will be removed, hence not included in output BAM files and all downstream analyses.
+
 `chip.use_bwa_mem_for_pe` | Boolean | false | Currently supported aligners: bwa and bowtie2. To use your own custom aligner, see the below parameter.
 `chip.custom_align_py` | File | | Python script for your custom aligner. See details about [how to use a custom aligner](#how-to-use-a-custom-aligner)
+
 
 ## Optional filtering parameters
 

--- a/docs/input.md
+++ b/docs/input.md
@@ -131,7 +131,7 @@ You can mix up different data types for individual replicate/control replicate. 
 Parameter|Type|Default|Description
 ---------|---|----|-----------
 `chip.aligner` | String | bowtie2 | Currently supported aligners: bwa and bowtie2. To use your own custom aligner, see the below parameter `chip.custom_align_py`.
-`chip.crop_length` | Int | 0 | Crop FASTQs with Trimmomatic. **WARNING**: Check your FASTQs' read length first. Reads SHORTER than this will be excluded while cropping, hence not included in output BAM files and all downstream analyses. 0: cropping disabled.
+`chip.crop_length` | Int | 0 | Crop FASTQs with Trimmomatic (using parameters `MINLEN` and `CROP`). `MINLEN` will be set as `chip.crop_length` - 2. **WARNING**: Check your FASTQs' read length first. Reads SHORTER than (`chip.crop_length` - 2) will be excluded while cropping, hence not included in output BAM files and all downstream analyses. 0: cropping disabled.
 `chip.use_bwa_mem_for_pe` | Boolean | false | Currently supported aligners: bwa and bowtie2. To use your own custom aligner, see the below parameter.
 `chip.custom_align_py` | File | | Python script for your custom aligner. See details about [how to use a custom aligner](#how-to-use-a-custom-aligner)
 

--- a/docs/input.md
+++ b/docs/input.md
@@ -131,8 +131,8 @@ You can mix up different data types for individual replicate/control replicate. 
 Parameter|Type|Default|Description
 ---------|---|----|-----------
 `chip.aligner` | String | bowtie2 | Currently supported aligners: bwa and bowtie2. To use your own custom aligner, see the below parameter `chip.custom_align_py`.
-`chip.crop_length` | Int | 0 | Crop FASTQs with Trimmomatic (using parameters `CROP`). 0: cropping disabled.`chip.crop_length_tol` | Int | 2 | Trimmomatic's `MINLEN` will be set as `chip.crop_length` - `abs(chip.crop_length_tol)` where reads shorter than `MINLEN` will be removed, hence not included in output BAM files and all downstream analyses.
-
+`chip.crop_length` | Int | 0 | Crop FASTQs with Trimmomatic (using parameters `CROP`). 0: cropping disabled.
+`chip.crop_length_tol` | Int | 2 | Trimmomatic's `MINLEN` will be set as `chip.crop_length` - `abs(chip.crop_length_tol)` where reads shorter than `MINLEN` will be removed, hence not included in output BAM files and all downstream analyses.
 `chip.use_bwa_mem_for_pe` | Boolean | false | Currently supported aligners: bwa and bowtie2. To use your own custom aligner, see the below parameter.
 `chip.custom_align_py` | File | | Python script for your custom aligner. See details about [how to use a custom aligner](#how-to-use-a-custom-aligner)
 

--- a/docs/input_short.md
+++ b/docs/input_short.md
@@ -40,7 +40,7 @@ Mandatory parameters.
     * ChIP-seq pipeline does not have an adapter detector/trimmer.
 
 6) Important parameters
-    * `chip.crop_length`: Crop FASTQs with Trimmomatic. **WARNING**: Check your FASTQs' read length first. Reads SHORTER than this will be excluded while cropping, hence not included in output BAM files and all downstream analyses. It is 0 (disabled) by default.
+    * `chip.crop_length`: Crop FASTQs with Trimmomatic (using parameters `MINLEN` and `CROP`). `MINLEN` will be set as `chip.crop_length` - 2. **WARNING**: Check your FASTQs' read length first. Reads SHORTER than (`chip.crop_length` - 2) will be excluded while cropping, hence not included in output BAM files and all downstream analyses. It is 0 (disabled) by default.
     * `chip.always_use_pooled_ctl`: (For experiments with controls only) Always use a pooled control to compare with each replicate. If a single control is given then use it. It is disabled by default.
     * `chip.ctl_depth_ratio`: (For experiments with controls only) If ratio of depth between controls is higher than this. then always use a pooled control for all replicates. It's 1.2 by default.
     * `chip.pval_thresh`: P-value threshold for peak-caller MACS2 (macs2 callpeak -p).

--- a/docs/input_short.md
+++ b/docs/input_short.md
@@ -40,7 +40,8 @@ Mandatory parameters.
     * ChIP-seq pipeline does not have an adapter detector/trimmer.
 
 6) Important parameters
-    * `chip.crop_length`: Crop FASTQs with Trimmomatic (using parameters `MINLEN` and `CROP`). `MINLEN` will be set as `chip.crop_length` - 2. **WARNING**: Check your FASTQs' read length first. Reads SHORTER than (`chip.crop_length` - 2) will be excluded while cropping, hence not included in output BAM files and all downstream analyses. It is 0 (disabled) by default.
+    * `chip.crop_length`: Crop FASTQs with Trimmomatic (using parameters `CROP`). It is 0 (disabled) by default.
+    * `chip.crop_length_tol`: Read length tolerance while cropping FASTQs with `chip.crop_length`. Trimmomatic's `MINLEN` will be set as `chip.crop_length` - `abs(chip.crop_length_tol)`. **WARNING**: Check your FASTQs' read length first. Reads SHORTER than `MINLEN` will be excluded while cropping, hence not included in output BAM files and all downstream analyses. Tolerance is 2 by default.
     * `chip.always_use_pooled_ctl`: (For experiments with controls only) Always use a pooled control to compare with each replicate. If a single control is given then use it. It is disabled by default.
     * `chip.ctl_depth_ratio`: (For experiments with controls only) If ratio of depth between controls is higher than this. then always use a pooled control for all replicates. It's 1.2 by default.
     * `chip.pval_thresh`: P-value threshold for peak-caller MACS2 (macs2 callpeak -p).

--- a/src/encode_task_trimmomatic.py
+++ b/src/encode_task_trimmomatic.py
@@ -22,8 +22,12 @@ def parse_arguments(debug=False):
                         help='FASTQ R2 to be trimmed.')
     parser.add_argument('--paired-end', action="store_true",
                         help='Paired-end FASTQs.')
-    parser.add_argument('--crop-length', type=int,
-                        help='Number of basepair to crop.')
+    parser.add_argument('--crop-length', type=int, required=True,
+                        help='Number of basepair to crop.'
+                             'Trimmomatic\'s parameter CROP.')
+    parser.add_argument('--min-length', type=int, required=True,
+                        help='All reads shorted than this will be removed '
+                             'Trimmomatic\'s parameter MINLEN.')
     parser.add_argument('--out-dir-R1', default='', type=str,
                         help='Output directory for cropped R1 fastq.')
     parser.add_argument('--out-dir-R2', default='', type=str,
@@ -47,33 +51,34 @@ def parse_arguments(debug=False):
     return args
 
 
-def trimmomatic_se(fastq1, crop_length, out_dir,
+def trimmomatic_se(fastq1, crop_length, min_length, out_dir,
                    nth=1, java_heap=None):
     prefix = os.path.join(out_dir,
                           os.path.basename(strip_ext_fastq(fastq1)))
-    cropped = '{}.crop_{}bp.fastq.gz'.format(prefix, crop_length)
+    cropped = '{p}.crop_{cl}_minlen_{ml}.fastq.gz'.format(
+        p=prefix, cl=crop_length, ml=min_length)
 
     if java_heap is None:
         java_heap_param = '-Xmx6G'
     else:
         java_heap_param = '-Xmx{}'.format(java_heap)
 
-    cmd = 'java -XX:ParallelGCThreads=1 {} -jar {} SE -threads {} '
-    cmd += '{} {} MINLEN:{} CROP:{}'
+    cmd = 'java -XX:ParallelGCThreads=1 {param} -jar {jar} SE -threads {nth} '
+    cmd += '{fq1} {cropped} MINLEN:{ml} CROP:{cl}'
     cmd = cmd.format(
-        java_heap_param,
-        locate_trimmomatic(),
-        nth,
-        fastq1,
-        cropped,
-        crop_length,
-        crop_length)
+        param=java_heap_param,
+        jar=locate_trimmomatic(),
+        nth=nth,
+        fq1=fastq1,
+        cropped=cropped,
+        ml=min_length,
+        cl=crop_length)
     run_shell_cmd(cmd)
 
     return cropped
 
 
-def trimmomatic_pe(fastq1, fastq2, crop_length, out_dir_R1, out_dir_R2,
+def trimmomatic_pe(fastq1, fastq2, crop_length, min_length, out_dir_R1, out_dir_R2,
                    nth=1, java_heap=None):
     prefix_R1 = os.path.join(
         out_dir_R1, os.path.basename(strip_ext_fastq(fastq1)))
@@ -89,20 +94,21 @@ def trimmomatic_pe(fastq1, fastq2, crop_length, out_dir_R1, out_dir_R2,
     else:
         java_heap_param = '-Xmx{}'.format(java_heap)
 
-    cmd = 'java -XX:ParallelGCThreads=1 {} -jar {} PE -threads {} '
-    cmd += '{} {} {} {} {} {} MINLEN:{} CROP:{}'
+    cmd = 'java -XX:ParallelGCThreads=1 {param} -jar {jar} PE -threads {nth} '
+    cmd += '{fq1} {fq2} {cropped1} {tmp_cropped1} {cropped2} {tmp_cropped2} '
+    cmd += 'MINLEN:{ml} CROP:{cl}'
     cmd = cmd.format(
-        java_heap_param,
-        locate_trimmomatic(),
-        nth,
-        fastq1,
-        fastq2,
-        cropped_R1,
-        tmp_cropped_R1,
-        cropped_R2,
-        tmp_cropped_R2,
-        crop_length,
-        crop_length)
+        param=java_heap_param,
+        jar=locate_trimmomatic(),
+        nth=nth,
+        fq1=fastq1,
+        fq2=fastq2,
+        cropped1=cropped_R1,
+        tmp_cropped1=tmp_cropped_R1,
+        cropped2=cropped_R2,
+        tmp_cropped2=tmp_cropped_R2,
+        ml=min_length,
+        cl=crop_length)
     run_shell_cmd(cmd)
     rm_f([tmp_cropped_R1, tmp_cropped_R2])
 
@@ -118,18 +124,22 @@ def main():
     if args.paired_end:
         mkdir_p(args.out_dir_R2)
 
-    log.info('Cropping fastqs ({} bp) with Trimmomatic...'.format(args.crop_length))
+    log.info(
+        'Cropping fastqs with Trimmomatic... '
+        'crop_length={cl}, min_length={ml}'.format(
+            cl=args.crop_length,
+            ml=args.min_length,))
     if args.paired_end:
         cropped_R1, cropped_R2 = trimmomatic_pe(
             args.fastq1, args.fastq2,
-            args.crop_length,
+            args.crop_length, args.min_length,
             args.out_dir_R1, args.out_dir_R2,
             args.nth,
             args.trimmomatic_java_heap)
     else:
         cropped_R1 = trimmomatic_se(
             args.fastq1,
-            args.crop_length,
+            args.crop_length, args.min_length,
             args.out_dir_R1,
             args.nth,
             args.trimmomatic_java_heap)

--- a/src/encode_task_trimmomatic.py
+++ b/src/encode_task_trimmomatic.py
@@ -25,9 +25,11 @@ def parse_arguments(debug=False):
     parser.add_argument('--crop-length', type=int, required=True,
                         help='Number of basepair to crop.'
                              'Trimmomatic\'s parameter CROP.')
-    parser.add_argument('--min-length', type=int, required=True,
-                        help='All reads shorted than this will be removed '
-                             'Trimmomatic\'s parameter MINLEN.')
+    parser.add_argument('--crop-length-tol', type=int, default=2,
+                        help='Crop length tolerance to keep shorter reads '
+                             'around the crop length. '
+                             'Trimmomatic\'s parameter MINLEN will be --crop-length '
+                             '- abs(--crop-length-tol).')
     parser.add_argument('--out-dir-R1', default='', type=str,
                         help='Output directory for cropped R1 fastq.')
     parser.add_argument('--out-dir-R2', default='', type=str,
@@ -51,12 +53,14 @@ def parse_arguments(debug=False):
     return args
 
 
-def trimmomatic_se(fastq1, crop_length, min_length, out_dir,
+def trimmomatic_se(fastq1, crop_length, crop_length_tol, out_dir,
                    nth=1, java_heap=None):
     prefix = os.path.join(out_dir,
                           os.path.basename(strip_ext_fastq(fastq1)))
-    cropped = '{p}.crop_{cl}_minlen_{ml}.fastq.gz'.format(
-        p=prefix, cl=crop_length, ml=min_length)
+    crop_length_tol = abs(crop_length_tol)
+    min_length = crop_length - crop_length_tol
+    cropped = '{p}.crop_{cl}-{tol}bp.fastq.gz'.format(
+        p=prefix, cl=crop_length, tol=crop_length_tol)
 
     if java_heap is None:
         java_heap_param = '-Xmx6G'
@@ -78,14 +82,20 @@ def trimmomatic_se(fastq1, crop_length, min_length, out_dir,
     return cropped
 
 
-def trimmomatic_pe(fastq1, fastq2, crop_length, min_length, out_dir_R1, out_dir_R2,
+def trimmomatic_pe(fastq1, fastq2, crop_length, crop_length_tol, out_dir_R1, out_dir_R2,
                    nth=1, java_heap=None):
     prefix_R1 = os.path.join(
         out_dir_R1, os.path.basename(strip_ext_fastq(fastq1)))
     prefix_R2 = os.path.join(
         out_dir_R2, os.path.basename(strip_ext_fastq(fastq2)))
-    cropped_R1 = '{}.crop_{}bp.fastq.gz'.format(prefix_R1, crop_length)
-    cropped_R2 = '{}.crop_{}bp.fastq.gz'.format(prefix_R2, crop_length)
+
+    crop_length_tol = abs(crop_length_tol)
+    min_length = crop_length - crop_length_tol
+
+    cropped_R1 = '{p}.crop_{cl}-{tol}bp.fastq.gz'.format(
+        p=prefix_R1, cl=crop_length, tol=crop_length_tol)
+    cropped_R2 = '{p}.crop_{cl}-{tol}bp.fastq.gz'.format(
+        p=prefix_R2, cl=crop_length, tol=crop_length_tol)
     tmp_cropped_R1 = '{}.tmp'.format(cropped_R1)
     tmp_cropped_R2 = '{}.tmp'.format(cropped_R2)
 
@@ -126,20 +136,20 @@ def main():
 
     log.info(
         'Cropping fastqs with Trimmomatic... '
-        'crop_length={cl}, min_length={ml}'.format(
+        'crop_length={cl}, crop_length_tol={clt}'.format(
             cl=args.crop_length,
-            ml=args.min_length,))
+            clt=args.crop_length_tol))
     if args.paired_end:
         cropped_R1, cropped_R2 = trimmomatic_pe(
             args.fastq1, args.fastq2,
-            args.crop_length, args.min_length,
+            args.crop_length, args.crop_length_tol,
             args.out_dir_R1, args.out_dir_R2,
             args.nth,
             args.trimmomatic_java_heap)
     else:
         cropped_R1 = trimmomatic_se(
             args.fastq1,
-            args.crop_length, args.min_length,
+            args.crop_length, args.crop_length_tol,
             args.out_dir_R1,
             args.nth,
             args.trimmomatic_java_heap)
@@ -152,8 +162,8 @@ def main():
     log.info('Checking if output is empty...')
     assert_file_not_empty(cropped_R1, help=
         'No reads in FASTQ after cropping. crop_length might be too high? '
-        'While cropping, Trimmomatic (with MINLEN) excludes all reads '
-        'SHORTER than crop_length.')
+        'While cropping, Trimmomatic (with MINLEN=crop_length-abs(crop_length_tol)) '
+        'excludes all reads SHORTER than crop_length.')
 
     log.info('All done.')
 


### PR DESCRIPTION
Trimmomatic cmd lines: `MINLEN` is set as `crop_length - 2`.
Added documentation about `minlen = crop_length - 2`.

Cropped BAM's filename has a suffix `.crop_100_minlen_98.`.
