### PR TITLE
choose_ctl returns index instead of file

### DIFF
--- a/dev/test/test_task/test_choose_ctl.wdl
+++ b/dev/test/test_task/test_choose_ctl.wdl
@@ -23,38 +23,59 @@ workflow test_choose_ctl {
 
 	Float ctl_depth_ratio
 
+	Array[File] ctl_tas = [se_ctl_ta_rep1, se_ctl_ta_rep2]
 	call chip.choose_ctl as se_choose_ctl { input :
 		tas = [se_ta_rep1, se_ta_rep2],
-		ctl_tas = [se_ctl_ta_rep1, se_ctl_ta_rep2],
+		ctl_tas = ctl_tas,
 		ta_pooled = se_ta_pooled,
 		always_use_pooled_ctl = false,
 		ctl_ta_pooled = se_ctl_ta_pooled,
 		ctl_depth_ratio = ctl_depth_ratio,
 	}
+	Int ctl_id_se_choose_ctl_idx1 = se_choose_ctl.chosen_ctl_ta_ids[0]
+	Int ctl_id_se_choose_ctl_idx2 = se_choose_ctl.chosen_ctl_ta_ids[1]
+	File ctl_se_choose_ctl_idx1 = if ctl_id_se_choose_ctl_idx1>=0 then ctl_tas[ctl_id_se_choose_ctl_idx1] else se_ctl_ta_pooled
+	File ctl_se_choose_ctl_idx2 = if ctl_id_se_choose_ctl_idx2>=0 then ctl_tas[ctl_id_se_choose_ctl_idx2] else se_ctl_ta_pooled
+
+	Array[File] ctl_tas_always_use_pooled_ctl = [se_ctl_ta_rep1, se_ctl_ta_rep2]
 	call chip.choose_ctl as se_choose_ctl_always_use_pooled_ctl { input :
 		tas = [se_ta_rep1, se_ta_rep2],
-		ctl_tas = [se_ctl_ta_rep1, se_ctl_ta_rep2],
+		ctl_tas = ctl_tas_always_use_pooled_ctl,
 		ta_pooled = se_ta_pooled,
 		always_use_pooled_ctl = true,
 		ctl_ta_pooled = se_ctl_ta_pooled,
 		ctl_depth_ratio = ctl_depth_ratio,
 	}
+	Int ctl_id_se_choose_ctl_always_use_pooled_ctl_idx1 = se_choose_ctl_always_use_pooled_ctl.chosen_ctl_ta_ids[0]
+	Int ctl_id_se_choose_ctl_always_use_pooled_ctl_idx2 = se_choose_ctl_always_use_pooled_ctl.chosen_ctl_ta_ids[1]
+	File ctl_se_choose_ctl_always_use_pooled_ctl_idx1 = if ctl_id_se_choose_ctl_always_use_pooled_ctl_idx1>=0 then ctl_tas_always_use_pooled_ctl[ctl_id_se_choose_ctl_always_use_pooled_ctl_idx1] else se_ctl_ta_pooled
+	File ctl_se_choose_ctl_always_use_pooled_ctl_idx2 = if ctl_id_se_choose_ctl_always_use_pooled_ctl_idx2>=0 then ctl_tas_always_use_pooled_ctl[ctl_id_se_choose_ctl_always_use_pooled_ctl_idx2] else se_ctl_ta_pooled
+
+	Array[File] ctl_tas_single_rep = [se_ctl_ta_rep2, se_ctl_ta_rep1]
 	call chip.choose_ctl as se_choose_ctl_single_rep { input :
 		tas = [se_ta_rep1],
-		ctl_tas = [se_ctl_ta_rep2, se_ctl_ta_rep1],
+		ctl_tas = ctl_tas_single_rep,
 		ta_pooled = null,
 		always_use_pooled_ctl = false,
 		ctl_ta_pooled = se_ctl_ta_pooled,
 		ctl_depth_ratio = ctl_depth_ratio,
 	}
+	Int ctl_id_se_choose_ctl_single_rep_idx1 = se_choose_ctl_single_rep.chosen_ctl_ta_ids[0]
+	File ctl_se_choose_ctl_single_rep_idx1 = if ctl_id_se_choose_ctl_single_rep_idx1>=0 then ctl_tas_single_rep[ctl_id_se_choose_ctl_single_rep_idx1] else se_ctl_ta_pooled
+
+	Array[File] ctl_tas_single_ctl = [se_ctl_ta_rep1]
 	call chip.choose_ctl as se_choose_ctl_single_ctl { input :
 		tas = [se_ta_rep1, se_ta_rep2],
-		ctl_tas = [se_ctl_ta_rep1],
+		ctl_tas = ctl_tas_single_ctl,
 		ta_pooled = se_ta_pooled,
 		always_use_pooled_ctl = false,
 		ctl_ta_pooled = null,
 		ctl_depth_ratio = ctl_depth_ratio,
 	}
+	Int ctl_id_se_choose_ctl_single_ctl_idx1 = se_choose_ctl_single_ctl.chosen_ctl_ta_ids[0]
+	Int ctl_id_se_choose_ctl_single_ctl_idx2 = se_choose_ctl_single_ctl.chosen_ctl_ta_ids[1]
+	File ctl_se_choose_ctl_single_ctl_idx1 = if ctl_id_se_choose_ctl_single_ctl_idx1>=0 then ctl_tas_single_ctl[ctl_id_se_choose_ctl_single_ctl_idx1] else se_ctl_ta_pooled
+	File ctl_se_choose_ctl_single_ctl_idx2 = if ctl_id_se_choose_ctl_single_ctl_idx2>=0 then ctl_tas_single_ctl[ctl_id_se_choose_ctl_single_ctl_idx2] else se_ctl_ta_pooled
 
 	call compare_md5sum.compare_md5sum { input :
 		labels = [
@@ -67,13 +88,13 @@ workflow test_choose_ctl {
 			'se_choose_ctl_single_ctl_idx2',
 		],
 		files = [
-			se_choose_ctl.chosen_ctl_tas[0],
-			se_choose_ctl.chosen_ctl_tas[1],
-			se_choose_ctl_always_use_pooled_ctl.chosen_ctl_tas[0],
-			se_choose_ctl_always_use_pooled_ctl.chosen_ctl_tas[1],
-			se_choose_ctl_single_rep.chosen_ctl_tas[0],
-			se_choose_ctl_single_ctl.chosen_ctl_tas[0],
-			se_choose_ctl_single_ctl.chosen_ctl_tas[1],
+			ctl_se_choose_ctl_idx1,
+			ctl_se_choose_ctl_idx2,
+			ctl_se_choose_ctl_always_use_pooled_ctl_idx1,
+			ctl_se_choose_ctl_always_use_pooled_ctl_idx2,
+			ctl_se_choose_ctl_single_rep_idx1,
+			ctl_se_choose_ctl_single_ctl_idx1,
+			ctl_se_choose_ctl_single_ctl_idx2,
 		],
 		ref_files = [
 			ref_se_choose_ctl_idx1,

--- a/src/encode_task_choose_ctl.py
+++ b/src/encode_task_choose_ctl.py
@@ -7,7 +7,7 @@ import sys
 import os
 import argparse
 from encode_lib_common import (
-    copy_f_to_f, get_num_lines, log, ls_l, mkdir_p)
+    copy_f_to_f, get_num_lines, log, ls_l, mkdir_p, write_txt)
 
 
 def parse_arguments():
@@ -15,7 +15,9 @@ def parse_arguments():
         prog='ENCODE DCC Choose control.',
         description='Choose appropriate control for each IP replicate.'
                     'ctl_for_repN.tagAlign.gz will be generated for each '
-                    'IP replicate on --out-dir.')
+                    'IP replicate on --out-dir. '
+                    'This outputs a file with integers '
+                    '(chosen control index for each replicate per line).')
     parser.add_argument('--tas', type=str, nargs='+', required=True,
                         help='List of experiment TAG-ALIGN per IP replicate.')
     parser.add_argument('--ctl-tas', type=str, nargs='+', required=True,
@@ -29,6 +31,11 @@ def parse_arguments():
     parser.add_argument('--always-use-pooled-ctl', action="store_true",
                         help='Always use pooled control for all IP '
                              'replicates.')
+    parser.add_argument('--out-tsv-basename', default='chosen_ctl.tsv', type=str,
+                        help='Output TSV basename '
+                             '(will be written on directory --out-dir). '
+                             'This TSV file has chosen control index per line '
+                             '(for each replicate).')
     parser.add_argument('--out-dir', default='', type=str,
                         help='Output directory.')
     parser.add_argument('--log-level', default='INFO',
@@ -103,19 +110,9 @@ def main():
                 else:
                     ctl_ta_idx[i] = i
 
-    # log.info('Writing idx.txt...')
-    # out_txt = os.path.join(args.out_dir, 'idx.txt')
-    # write_txt(out_txt, ctl_ta_idx)
-    log.info('Writing ctl_for_repN.tagAlign.gz files...')
-    for i, ctl_id in enumerate(ctl_ta_idx):
-        rep_id = i+1
-        dest = os.path.join(
-            args.out_dir, 'ctl_for_rep{}.tagAlign.gz'.format(rep_id))
-        if ctl_id == -1:
-            src = args.ctl_ta_pooled[0]
-        else:
-            src = args.ctl_tas[ctl_id]
-        copy_f_to_f(src, dest)
+    log.info('Writing idx.txt...')
+    out_txt = os.path.join(args.out_dir, args.out_tsv_basename)
+    write_txt(out_txt, ctl_ta_idx)
 
     log.info('List all files in output directory...')
     ls_l(args.out_dir)


### PR DESCRIPTION
To resolve d diamond dependency problem.

`choose_ctl` takes in all TAG-ALIGNs (both exp IPs, controls) and find an appropriate control for each exp IP replicate.

Before this PR, `choose_ctl` returned `File` control TAG-ALIGN instead of `Int` index of it. So this broke search up algorithm of ENCODE accessioning code and Croo.

Now `choose_ctl` returns an ID of control TAG-ALIGN instead of `File`.
