### PR TITLE
Pip 1056 wdl 1.0

### DIFF
--- a/chip.wdl
+++ b/chip.wdl
@@ -117,23 +117,21 @@ workflow chip {
         Array[String] filter_chrs = []
         Int subsample_reads = 0
         Int ctl_subsample_reads = 0
-        Int ctl_depth_limit = 200000000
-        Float exp_ctl_depth_ratio_limit = 5.0
-
         Int xcor_subsample_reads = 15000000
         Int xcor_exclusion_range_min = -500
         Int? xcor_exclusion_range_max
 
         # group: peak_calling
+        Int ctl_depth_limit = 200000000
+        Float exp_ctl_depth_ratio_limit = 5.0
         Array[Int?] fraglen = []
         String? peak_caller
-        Boolean always_use_pooled_ctl = false # always use pooled control for all exp rep.
-        Float ctl_depth_ratio = 1.2     # if ratio between controls is higher than this
-                                        # then always use pooled control for all exp rep.
+        Boolean always_use_pooled_ctl = false
+        Float ctl_depth_ratio = 1.2
         Int? cap_num_peak
-        Float pval_thresh = 0.01        # p.value threshold (for MACS2 peak caller only)
-        Float fdr_thresh = 0.01            # FDR threshold (for SPP peak caller only: Rscript run_spp.R -fdr)
-        Float idr_thresh = 0.05            # IDR threshold
+        Float pval_thresh = 0.01
+        Float fdr_thresh = 0.01
+        Float idr_thresh = 0.05
 
         # group: resource_parameter
         Int align_cpu = 4
@@ -180,11 +178,11 @@ workflow chip {
     parameter_meta {
         title: {
             description: 'Experiment title.',
-            group: 'pipeline_metadata',
+            group: 'pipeline_metadata'
         }
         description: {
             description: 'Experiment description.',
-            group: 'pipeline_metadata',
+            group: 'pipeline_metadata'
         }
         genome_tsv: {
             description: 'Reference genome database TSV.',
@@ -282,7 +280,7 @@ workflow chip {
             group: 'input_genomic_data',
             help: 'Define if you want to start pipeline from FASTQs files. Pipeline can start from any type of inputs (e.g. FASTQs, BAMs, ...). Choose one type and fill paramters for that type and leave other undefined. Especially for FASTQs, we have individual variable for each biological replicate to allow FASTQs of technical replicates can be merged. Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep1_R2). These FASTQs are usually technical replicates to be merged.'
         }
-        fastqs_rep1_R1: {
+        fastqs_rep1_R2: {
             description: 'Read2 FASTQs to be merged for a biological replicate 1.',
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep1_R1). These FASTQs are usually technical replicates to be merged.'
@@ -292,7 +290,7 @@ workflow chip {
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep2_R2). These FASTQs are usually technical replicates to be merged.'
         }
-        fastqs_rep2_R1: {
+        fastqs_rep2_R2: {
             description: 'Read2 FASTQs to be merged for a biological replicate 2.',
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep2_R1). These FASTQs are usually technical replicates to be merged.'
@@ -302,7 +300,7 @@ workflow chip {
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep3_R2). These FASTQs are usually technical replicates to be merged.'
         }
-        fastqs_rep3_R1: {
+        fastqs_rep3_R2: {
             description: 'Read2 FASTQs to be merged for a biological replicate 3.',
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep3_R1). These FASTQs are usually technical replicates to be merged.'
@@ -312,7 +310,7 @@ workflow chip {
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep4_R2). These FASTQs are usually technical replicates to be merged.'
         }
-        fastqs_rep4_R1: {
+        fastqs_rep4_R2: {
             description: 'Read2 FASTQs to be merged for a biological replicate 4.',
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep4_R1). These FASTQs are usually technical replicates to be merged.'
@@ -322,7 +320,7 @@ workflow chip {
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep5_R2). These FASTQs are usually technical replicates to be merged.'
         }
-        fastqs_rep5_R1: {
+        fastqs_rep5_R2: {
             description: 'Read2 FASTQs to be merged for a biological replicate 5.',
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep5_R1). These FASTQs are usually technical replicates to be merged.'
@@ -332,7 +330,7 @@ workflow chip {
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep6_R2). These FASTQs are usually technical replicates to be merged.'
         }
-        fastqs_rep6_R1: {
+        fastqs_rep6_R2: {
             description: 'Read2 FASTQs to be merged for a biological replicate 6.',
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep6_R1). These FASTQs are usually technical replicates to be merged.'
@@ -438,7 +436,7 @@ workflow chip {
             group: 'input_genomic_data_control',
             help: 'Define if you want to start pipeline from FASTQs files. Pipeline can start from any type of controls (e.g. FASTQs, BAMs, ...). Choose one type and fill paramters for that type and leave other undefined.  Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep1_R2).'
         }
-        ctl_fastqs_rep1_R1: {
+        ctl_fastqs_rep1_R2: {
             description: 'Read2 FASTQs to be merged for a control replicate 1.',
             group: 'input_genomic_data_control',
             help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep1_R1). These FASTQs are usually technical replicates to be merged.'
@@ -448,7 +446,7 @@ workflow chip {
             group: 'input_genomic_data_control',
             help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep2_R2). These FASTQs are usually technical replicates to be merged.'
         }
-        ctl_fastqs_rep2_R1: {
+        ctl_fastqs_rep2_R2: {
             description: 'Read2 FASTQs to be merged for a control replicate 2.',
             group: 'input_genomic_data_control',
             help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep2_R1). These FASTQs are usually technical replicates to be merged.'
@@ -458,7 +456,7 @@ workflow chip {
             group: 'input_genomic_data_control',
             help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep3_R2). These FASTQs are usually technical replicates to be merged.'
         }
-        ctl_fastqs_rep3_R1: {
+        ctl_fastqs_rep3_R2: {
             description: 'Read2 FASTQs to be merged for a control replicate 3.',
             group: 'input_genomic_data_control',
             help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep3_R1). These FASTQs are usually technical replicates to be merged.'
@@ -468,7 +466,7 @@ workflow chip {
             group: 'input_genomic_data_control',
             help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep4_R2). These FASTQs are usually technical replicates to be merged.'
         }
-        ctl_fastqs_rep4_R1: {
+        ctl_fastqs_rep4_R2: {
             description: 'Read2 FASTQs to be merged for a control replicate 4.',
             group: 'input_genomic_data_control',
             help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep4_R1). These FASTQs are usually technical replicates to be merged.'
@@ -478,7 +476,7 @@ workflow chip {
             group: 'input_genomic_data_control',
             help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep5_R2). These FASTQs are usually technical replicates to be merged.'
         }
-        ctl_fastqs_rep5_R1: {
+        ctl_fastqs_rep5_R2: {
             description: 'Read2 FASTQs to be merged for a control replicate 5.',
             group: 'input_genomic_data_control',
             help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep5_R1). These FASTQs are usually technical replicates to be merged.'
@@ -488,7 +486,7 @@ workflow chip {
             group: 'input_genomic_data_control',
             help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep6_R2). These FASTQs are usually technical replicates to be merged.'
         }
-        ctl_fastqs_rep6_R1: {
+        ctl_fastqs_rep6_R2: {
             description: 'Read2 FASTQs to be merged for a control replicate 6.',
             group: 'input_genomic_data_control',
             help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep6_R1). These FASTQs are usually technical replicates to be merged.'
@@ -618,9 +616,9 @@ workflow chip {
             help: 'Duplicate reads are filtererd out during filtering BAMs to gerenate NODUP_BAM. This flag will keep all duplicate reads in NODUP_BAM. This flag does not affect naming of NODUP_BAM. NODUP_BAM will still have .nodup. suffix in its filename.'
         }
         mapq_thresh: {
-            description: 'Threshold for low MAPQ reads removal',
+            description: 'Threshold for low MAPQ reads removal.',
             group: 'alignment',
-            help: 'Low MAPQ reads are filtered out while filtering BAM.',
+            help: 'Low MAPQ reads are filtered out while filtering BAM.'
         }
         filter_chrs: {
             description: 'List of chromosomes to be filtered out while filtering BAM.',
@@ -637,6 +635,21 @@ workflow chip {
             group: 'alignment',
             help: 'This affects all downstream analyses after filtering control BAM. (e.g. all TAG-ALIGN files, peak-calling). Reads will be shuffled only if actual number of reads in BAM exceeds this number. 0 means disabled.'
         }
+        xcor_subsample_reads: {
+            description: 'Subsample reads for cross-corrlelation analysis only.',
+            group: 'alignment',
+            help: 'This does not affect downstream analyses after filtering BAM. It is for cross-correlation analysis only.  0 means disabled.'
+        }
+        xcor_exclusion_range_min: {
+            description: 'Exclusion minimum for cross-correlation analysis.',
+            group: 'alignment',
+            help: 'For run_spp.R -s. Make sure that it is consistent with default strand shift -s=-500:5:1500 in run_spp.R.'
+        }
+        xcor_exclusion_range_max: {
+            description: 'Exclusion maximum for cross-coorrelation analysis.',
+            group: 'alignment',
+            help: 'For run_spp.R -s. If not defined default value of `max(read length + 10, 50)` for TF and `max(read_len + 10, 100)` for histone are used'
+        }
 
         ctl_depth_limit: {
             description: 'Hard limit for chosen control\'s depth.',
@@ -647,23 +660,6 @@ workflow chip {
             description: 'Second limit for chosen control\'s depth.',
             group: 'peak_calling',
             help: 'If control chosen by chip.always_use_pooled_ctl and chip.ctl_depth_ratio is deeper than experiment replicate\'s read depth multiplied by this factor then such control is subsampled down to maximum of multiplied value and hard limit chip.ctl_depth_limit.'
-        }
-
-        xcor_subsample_reads: {
-            description: 'Subsample reads for cross-corrlelation analysis only.',
-            group: 'alignment',
-            help: 'This does not affect downstream analyses after filtering BAM. It is for cross-correlation analysis only.  0 means disabled.'
-        }
-
-        xcor_exclusion_range_min: {
-            description: 'Exclusion minimum for cross-correlation analysis.',
-            group: 'peak_calling',
-            help: 'For run_spp.R -s. Make sure that it is consistent with default strand shift -s=-500:5:1500 in run_spp.R.'
-        }
-        xcor_exclusion_range_max: {
-            description: 'Exclusion maximum for cross-coorrelation analysis.',
-            group: 'peak_calling',
-            help: 'For run_spp.R -s. If not defined default value of `max(read length + 10, 50)` for TF and `max(read_len + 10, 100)` for histone are used'
         }
         fraglen: {
             description: 'Fragment length for each biological replicate.',

--- a/chip.wdl
+++ b/chip.wdl
@@ -1,15 +1,15 @@
 version 1.0
 
 workflow chip {
-    String pipeline_ver = 'v1.4.0.1'
+    String pipeline_ver = 'dev-v1.4.1'
 
     meta {
         author: 'Jin wook Lee (leepc12@gmail.com) at ENCODE-DCC'
         description: 'ENCODE TF/Histone ChIP-Seq pipeline'
         specification_document: 'https://docs.google.com/document/d/1lG_Rd7fnYgRpSIqrIfuVlAz2dW1VaSQThzk836Db99c/edit?usp=sharing'
 
-        caper_docker: 'quay.io/encode-dcc/chip-seq-pipeline:v1.4.0.1'
-        caper_singularity: 'docker://quay.io/encode-dcc/chip-seq-pipeline:v1.4.0.1'
+        caper_docker: 'quay.io/encode-dcc/chip-seq-pipeline:dev-v1.4.1'
+        caper_singularity: 'docker://quay.io/encode-dcc/chip-seq-pipeline:dev-v1.4.1'
         croo_out_def: 'https://storage.googleapis.com/encode-pipeline-output-definition/chip.croo.v4.json'
     }
     input {

--- a/chip.wdl
+++ b/chip.wdl
@@ -2006,6 +2006,7 @@ task filter {
     Float picard_java_heap_factor = 0.9
 
     command {
+        set -e
         python3 $(which encode_task_filter.py) \
             ${bam} \
             ${if paired_end then '--paired-end' else ''} \
@@ -2048,6 +2049,7 @@ task bam2ta {
     }
 
     command {
+        set -e
         python3 $(which encode_task_bam2ta.py) \
             ${bam} \
             --disable-tn5-shift \
@@ -2076,6 +2078,7 @@ task spr {
     }
 
     command {
+        set -e
         python3 $(which encode_task_spr.py) \
             ${ta} \
             ${if paired_end then '--paired-end' else ''}
@@ -2100,6 +2103,7 @@ task pool_ta {
     }
 
     command {
+        set -e
         python3 $(which encode_task_pool_ta.py) \
             ${sep=' ' select_all(tas)} \
             ${'--prefix ' + prefix} \
@@ -2135,6 +2139,7 @@ task xcor {
     }
 
     command {
+        set -e
         python3 $(which encode_task_xcor.py) \
             ${ta} \
             ${if paired_end then '--paired-end' else ''} \
@@ -2175,6 +2180,7 @@ task jsd {
     }
 
     command {
+        set -e
         python3 $(which encode_task_jsd.py) \
             ${sep=' ' select_all(nodup_bams)} \
             ${if length(ctl_bams)>0 then '--ctl-bam '+ select_first(ctl_bams) else ''} \
@@ -2208,6 +2214,7 @@ task choose_ctl {
     }
 
     command {
+        set -e
         python3 $(which encode_task_choose_ctl.py) \
             --tas ${sep=' ' select_all(tas)} \
             --ctl-tas ${sep=' ' select_all(ctl_tas)} \
@@ -2241,6 +2248,7 @@ task count_signal_track {
     }
 
     command {
+        set -e
         python3 $(which encode_task_count_signal_track.py) \
             ${ta} \
             ${'--chrsz ' + chrsz}
@@ -2353,6 +2361,7 @@ task macs2_signal_track {
     }
 
     command {
+        set -e
         python3 $(which encode_task_macs2_signal_track_chip.py) \
             ${sep=' ' select_all(tas)} \
             ${'--gensz '+ gensz} \
@@ -2393,6 +2402,7 @@ task idr {
     }
 
     command {
+        set -e
         ${if defined(ta) then '' else 'touch null.frip.qc'}
         touch null 
         python3 $(which encode_task_idr.py) \
@@ -2442,6 +2452,7 @@ task overlap {
     }
 
     command {
+        set -e
         ${if defined(ta) then '' else 'touch null.frip.qc'}
         touch null 
         python3 $(which encode_task_overlap.py) \
@@ -2485,6 +2496,7 @@ task reproducibility {
     }
 
     command {
+        set -e
         python3 $(which encode_task_reproducibility.py) \
             ${sep=' ' peaks} \
             --peaks-pr ${sep=' ' peaks_pr} \
@@ -2527,6 +2539,7 @@ task gc_bias {
     Float picard_java_heap_factor = 0.9
 
     command {
+        set -e
         python3 $(which encode_task_gc_bias.py) \
             ${'--nodup-bam ' + nodup_bam} \
             ${'--ref-fa ' + ref_fa} \
@@ -2612,6 +2625,7 @@ task qc_report {
     }
 
     command {
+        set -e
         python3 $(which encode_task_qc_report.py) \
             ${'--pipeline-ver ' + pipeline_ver} \
             ${"--title '" + sub(title,"'","_") + "'"} \

--- a/chip.wdl
+++ b/chip.wdl
@@ -1,2790 +1,2790 @@
 version 1.0
 
 workflow chip {
-	String pipeline_ver = 'v1.4.0.1'
-
-	meta {
-		author: 'Jin wook Lee (leepc12@gmail.com) at ENCODE-DCC'
-		description: 'ENCODE TF/Histone ChIP-Seq pipeline'
-		specification_document: 'https://docs.google.com/document/d/1lG_Rd7fnYgRpSIqrIfuVlAz2dW1VaSQThzk836Db99c/edit?usp=sharing'
-
-		caper_docker: 'quay.io/encode-dcc/chip-seq-pipeline:v1.4.0.1'
-		caper_singularity: 'docker://quay.io/encode-dcc/chip-seq-pipeline:v1.4.0.1'
-		croo_out_def: 'https://storage.googleapis.com/encode-pipeline-output-definition/chip.croo.v4.json'
-	}
-	input {
-		# group: pipeline_metadata
-		String title = 'Untitled'
-		String description = 'No description'
-
-		# group: reference_genome
-		File? genome_tsv
-		String? genome_name
-		File? ref_fa
-		File? bwa_idx_tar
-		File? bowtie2_idx_tar
-		File? chrsz
-		File? blacklist
-		File? blacklist2
-		String? mito_chr_name
-		String? regex_bfilt_peak_chr_name
-		String? gensz
-		File? tss
-		File? dnase
-		File? prom
-		File? enh
-		File? reg2map
-		File? reg2map_bed
-		File? roadmap_meta
-
-		# group: input_genomic_data
-		Boolean? paired_end
-		Array[Boolean] paired_ends = []
-		Array[File] fastqs_rep1_R1 = []
-		Array[File] fastqs_rep1_R2 = []
-		Array[File] fastqs_rep2_R1 = []
-		Array[File] fastqs_rep2_R2 = []
-		Array[File] fastqs_rep3_R1 = []
-		Array[File] fastqs_rep3_R2 = []
-		Array[File] fastqs_rep4_R1 = []
-		Array[File] fastqs_rep4_R2 = []
-		Array[File] fastqs_rep5_R1 = []
-		Array[File] fastqs_rep5_R2 = []
-		Array[File] fastqs_rep6_R1 = []
-		Array[File] fastqs_rep6_R2 = []
-		Array[File] fastqs_rep7_R1 = []
-		Array[File] fastqs_rep7_R2 = []
-		Array[File] fastqs_rep8_R1 = []
-		Array[File] fastqs_rep8_R2 = []
-		Array[File] fastqs_rep9_R1 = []
-		Array[File] fastqs_rep9_R2 = []
-		Array[File] fastqs_rep10_R1 = []
-		Array[File] fastqs_rep10_R2 = []
-		Array[File?] bams = []
-		Array[File?] nodup_bams = []
-		Array[File?] tas = []
-		Array[File?] peaks = []
-		Array[File?] peaks_pr1 = []
-		Array[File?] peaks_pr2 = []
-		File? peak_ppr1
-		File? peak_ppr2
-		File? peak_pooled
-
-		Boolean? ctl_paired_end
-		Array[Boolean] ctl_paired_ends = []
-		Array[File] ctl_fastqs_rep1_R1 = []
-		Array[File] ctl_fastqs_rep1_R2 = []
-		Array[File] ctl_fastqs_rep2_R1 = []
-		Array[File] ctl_fastqs_rep2_R2 = []
-		Array[File] ctl_fastqs_rep3_R1 = []
-		Array[File] ctl_fastqs_rep3_R2 = []
-		Array[File] ctl_fastqs_rep4_R1 = []
-		Array[File] ctl_fastqs_rep4_R2 = []
-		Array[File] ctl_fastqs_rep5_R1 = []
-		Array[File] ctl_fastqs_rep5_R2 = []
-		Array[File] ctl_fastqs_rep6_R1 = []
-		Array[File] ctl_fastqs_rep6_R2 = []
-		Array[File] ctl_fastqs_rep7_R1 = []
-		Array[File] ctl_fastqs_rep7_R2 = []
-		Array[File] ctl_fastqs_rep8_R1 = []
-		Array[File] ctl_fastqs_rep8_R2 = []
-		Array[File] ctl_fastqs_rep9_R1 = []
-		Array[File] ctl_fastqs_rep9_R2 = []
-		Array[File] ctl_fastqs_rep10_R1 = []
-		Array[File] ctl_fastqs_rep10_R2 = []
-		Array[File?] ctl_bams = []
-		Array[File?] ctl_nodup_bams = []
-		Array[File?] ctl_tas = []
-
-		# group: pipeline_parameter
-		String pipeline_type
-		Boolean align_only = false
-		Boolean true_rep_only = false
-		Boolean enable_count_signal_track = false
-		Boolean enable_jsd = true
-		Boolean enable_gc_bias = true
-
-		# group: alignment
-		String aligner = 'bowtie2'
-		Boolean use_bwa_mem_for_pe = false
-		Int crop_length = 0
-		Int crop_length_tol = 2
-		Int xcor_trim_bp = 50
-		Boolean use_filt_pe_ta_for_xcor = false
-		String dup_marker = 'picard'
-		Boolean no_dup_removal = false
-		Int mapq_thresh = 30
-		Array[String] filter_chrs = []
-		Int subsample_reads = 0
-		Int ctl_subsample_reads = 0
-		Int ctl_depth_limit = 200000000
-		Float exp_ctl_depth_ratio_limit = 5.0
-
-		Int xcor_subsample_reads = 15000000
-		Int xcor_exclusion_range_min = -500
-		Int? xcor_exclusion_range_max
-
-		# group: peak_calling
-		Array[Int?] fraglen = []
-		String? peak_caller
-		Boolean always_use_pooled_ctl = false # always use pooled control for all exp rep.
-		Float ctl_depth_ratio = 1.2	 # if ratio between controls is higher than this
-										# then always use pooled control for all exp rep.
-		Int? cap_num_peak
-		Float pval_thresh = 0.01		# p.value threshold (for MACS2 peak caller only)
-		Float fdr_thresh = 0.01			# FDR threshold (for SPP peak caller only: Rscript run_spp.R -fdr)
-		Float idr_thresh = 0.05			# IDR threshold
-
-		# group: resource_parameter
-		Int align_cpu = 4
-		Int align_mem_mb = 20000
-		Int align_time_hr = 48
-		String align_disks = 'local-disk 400 HDD'
-
-		Int filter_cpu = 2
-		Int filter_mem_mb = 20000
-		Int filter_time_hr = 24
-		String filter_disks = 'local-disk 400 HDD'
-
-		Int bam2ta_cpu = 2
-		Int bam2ta_mem_mb = 10000
-		Int bam2ta_time_hr = 6
-		String bam2ta_disks = 'local-disk 100 HDD'
-
-		Int spr_mem_mb = 16000
-
-		Int jsd_cpu = 2
-		Int jsd_mem_mb = 12000
-		Int jsd_time_hr = 6
-		String jsd_disks = 'local-disk 200 HDD'
-
-		Int xcor_cpu = 2
-		Int xcor_mem_mb = 16000	
-		Int xcor_time_hr = 24
-		String xcor_disks = 'local-disk 100 HDD'
-
-		Int macs2_signal_track_mem_mb = 16000
-		Int macs2_signal_track_time_hr = 24
-		String macs2_signal_track_disks = 'local-disk 400 HDD'
-
-		Int call_peak_cpu = 2
-		Int call_peak_mem_mb = 16000
-		Int call_peak_time_hr = 72
-		String call_peak_disks = 'local-disk 200 HDD'
-
-		String? align_trimmomatic_java_heap
-		String? filter_picard_java_heap
-		String? gc_bias_picard_java_heap
-	}
-
-	parameter_meta {
-		title: {
-			description: 'Experiment title.',
-			group: 'pipeline_metadata',
-		}
-		description: {
-			description: 'Experiment description.',
-			group: 'pipeline_metadata',
-		}
-		genome_tsv: {
-			description: 'Reference genome database TSV.',
-			group: 'reference_genome',
-			help: 'This TSV files includes all genome specific parameters (e.g. reference FASTA, bowtie2 index). You can still invidiaully define any parameters in it. Parameters defined in input JSON will override those defined in genome TSV.'
-		}
-		genome_name: {
-			description: 'Genome name.',
-			group: 'reference_genome'
-		}
-		ref_fa: {
-			description: 'Reference FASTA file.',
-			group: 'reference_genome'
-		}
-		ref_mito_fa: {
-			description: 'Reference FASTA file (mitochondrial reads only).',
-			group: 'reference_genome'
-		}
-		bowtie2_idx_tar: {
-			description: 'BWA index TAR file.',
-			group: 'reference_genome'
-		}
-		bowtie2_mito_idx_tar: {
-			description: 'BWA index TAR file (mitochondrial reads only).',
-			group: 'reference_genome'
-		}
-		chrsz: {
-			description: '2-col chromosome sizes file.',
-			group: 'reference_genome'
-		}
-		blacklist: {
-			description: 'Blacklist file in BED format.',
-			group: 'reference_genome',
-			help: 'Peaks will be filtered with this file.'
-		}
-		blacklist2: {
-			description: 'Secondary blacklist file in BED format.',
-			group: 'reference_genome',
-			help: 'If it is defined, it will be merged with chip.blacklist. Peaks will be filtered with merged blacklist.'
-		}
-		mito_chr_name: {
-			description: 'Mitochondrial chromosome name.',
-			group: 'reference_genome',
-			help: 'e.g. chrM, MT. Mitochondrial reads defined here will be filtered out during filtering BAMs in "filter" task.'
-		}
-		regex_bfilt_peak_chr_name: {
-			description: 'Reg-ex for chromosomes to keep while filtering peaks.',
-			group: 'reference_genome',
-			help: 'Chromosomes defined here will be kept. All other chromosomes will be filtered out in .bfilt. peak file. This is done along with blacklist filtering peak file.'
-		}
-		gensz: {
-			description: 'Genome sizes. "hs" for human, "mm" for mouse or sum of 2nd columnin chromosome sizes file.',
-			group: 'reference_genome'
-		}
-		tss: {
-			description: 'TSS file in BED format.',
-			group: 'reference_genome'
-		}
-		dnase: {
-			description: 'Open chromatin regions file in BED format.',
-			group: 'reference_genome'
-		}
-		prom: {
-			description: 'Promoter regions file in BED format.',
-			group: 'reference_genome'
-		}
-		enh: {
-			description: 'Enhancer regions file in BED format.',
-			group: 'reference_genome'
-		}
-		reg2map: {
-			description: 'Cell type signals file.',
-			group: 'reference_genome'
-		}
-		reg2map_bed: {
-			description: 'File of regions used to generate reg2map signals.',
-			group: 'reference_genome'
-		}
-		roadmap_meta: {
-			description: 'Roadmap metadata.',
-			group: 'reference_genome'
-		}
-		paired_end: {
-			description: 'Sequencing endedness.',
-			group: 'input_genomic_data',
-			help: 'Setting this on means that all replicates are paired ended. For mixed samples, use chip.paired_ends array instead.'
-		}
-		paired_ends: {
-			description: 'Sequencing endedness array (for mixed SE/PE datasets).',
-			group: 'input_genomic_data',
-			help: 'Whether each biological replicate is paired ended or not.'
-		}
-		fastqs_rep1_R1: {
-			description: 'Read1 FASTQs to be merged for a biological replicate 1.',
-			group: 'input_genomic_data',
-			help: 'Define if you want to start pipeline from FASTQs files. Pipeline can start from any type of inputs (e.g. FASTQs, BAMs, ...). Choose one type and fill paramters for that type and leave other undefined. Especially for FASTQs, we have individual variable for each biological replicate to allow FASTQs of technical replicates can be merged. Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep1_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep1_R1: {
-			description: 'Read2 FASTQs to be merged for a biological replicate 1.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep1_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep2_R1: {
-			description: 'Read1 FASTQs to be merged for a biological replicate 2.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep2_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep2_R1: {
-			description: 'Read2 FASTQs to be merged for a biological replicate 2.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep2_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep3_R1: {
-			description: 'Read1 FASTQs to be merged for a biological replicate 3.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep3_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep3_R1: {
-			description: 'Read2 FASTQs to be merged for a biological replicate 3.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep3_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep4_R1: {
-			description: 'Read1 FASTQs to be merged for a biological replicate 4.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep4_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep4_R1: {
-			description: 'Read2 FASTQs to be merged for a biological replicate 4.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep4_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep5_R1: {
-			description: 'Read1 FASTQs to be merged for a biological replicate 5.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep5_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep5_R1: {
-			description: 'Read2 FASTQs to be merged for a biological replicate 5.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep5_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep6_R1: {
-			description: 'Read1 FASTQs to be merged for a biological replicate 6.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep6_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep6_R1: {
-			description: 'Read2 FASTQs to be merged for a biological replicate 6.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep6_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep7_R1: {
-			description: 'Read1 FASTQs to be merged for a biological replicate 7.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep7_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep7_R2: {
-			description: 'Read2 FASTQs to be merged for a biological replicate 7.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep7_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep8_R1: {
-			description: 'Read1 FASTQs to be merged for a biological replicate 8.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep8_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep8_R2: {
-			description: 'Read2 FASTQs to be merged for a biological replicate 8.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep8_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep9_R1: {
-			description: 'Read1 FASTQs to be merged for a biological replicate 9.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep9_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep9_R2: {
-			description: 'Read2 FASTQs to be merged for a biological replicate 9.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep9_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep10_R1: {
-			description: 'Read1 FASTQs to be merged for a biological replicate 10.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep10_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep10_R2: {
-			description: 'Read2 FASTQs to be merged for a biological replicate 10.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep10_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		bams: {
-			description: 'List of unfiltered/raw BAM files for each biological replicate.',
-			group: 'input_genomic_data',
-			help: 'Define if you want to start pipeline from BAM files. Unfiltered/raw BAM file generated from aligner (e.g. bowtie2). Each entry for each biological replicate. e.g. [rep1.bam, rep2.bam, rep3.bam, ...].'
-		}
-		nodup_bams: {
-			description: 'List of filtered/deduped BAM files for each biological replicate',
-			group: 'input_genomic_data',
-			help: 'Define if you want to start pipeline from filtered BAM files. Filtered/deduped BAM file. Each entry for each biological replicate. e.g. [rep1.nodup.bam, rep2.nodup.bam, rep3.nodup.bam, ...].'
-		}
-		tas: {
-			description: 'List of TAG-ALIGN files for each biological replicate.',
-			group: 'input_genomic_data',
-			help: 'Define if you want to start pipeline from TAG-ALIGN files. TAG-ALIGN is in a 6-col BED format. It is a simplified version of BAM. Each entry for each biological replicate. e.g. [rep1.tagAlign.gz, rep2.tagAlign.gz, ...].'
-		}
-		peaks: {
-			description: 'List of NARROWPEAK files (not blacklist filtered) for each biological replicate.',
-			group: 'input_genomic_data',
-			help: 'Define if you want to start pipeline from PEAK files. Each entry for each biological replicate. e.g. [rep1.narrowPeak.gz, rep2.narrowPeak.gz, ...]. Define other PEAK parameters (e.g. chip.peaks_pr1, chip.peak_pooled) according to your flag settings (e.g. chip.true_rep_only) and number of replicates. If you have more than one replicate then define chip.peak_pooled, chip.peak_ppr1 and chip.peak_ppr2. If chip.true_rep_only flag is on then do not define any parameters (chip.peaks_pr1, chip.peaks_pr2, chip.peak_ppr1 and chip.peak_ppr2) related to pseudo replicates.'
-		}
-		peaks_pr1: {
-			description: 'List of NARROWPEAK files (not blacklist filtered) for pseudo-replicate 1 of each biological replicate.',
-			group: 'input_genomic_data',
-			help: 'Define if you want to start pipeline from PEAK files. Define if chip.true_rep_only flag is off.'
-		}
-		peaks_pr2: {
-			description: 'List of NARROWPEAK files (not blacklist filtered) for pseudo-replicate 2 of each biological replicate.',
-			group: 'input_genomic_data',
-			help: 'Define if you want to start pipeline from PEAK files. Define if chip.true_rep_only flag is off.'
-		}
-		peak_pooled: {
-			description: 'NARROWPEAK file for pooled true replicate.',
-			group: 'input_genomic_data',
-			help: 'Define if you want to start pipeline from PEAK files. Define if you have multiple biological replicates. Pooled true replicate means analysis on pooled biological replicates.'
-		}
-		peak_ppr1: {
-			description: 'NARROWPEAK file for pooled pseudo replicate 1.',
-			group: 'input_genomic_data',
-			help: 'Define if you want to start pipeline from PEAK files. Define if you have multiple biological replicates and chip.true_rep_only flag is off. PPR1 means analysis on pooled 1st pseudo replicates. Each biological replicate is shuf/split into two pseudos. This is a pooling of each replicate\'s 1st pseudos.'
-		}
-		peak_ppr2: {
-			description: 'NARROWPEAK file for pooled pseudo replicate 2.',
-			group: 'input_genomic_data',
-			help: 'Define if you want to start pipeline from PEAK files. Define if you have multiple biological replicates and chip.true_rep_only flag is off. PPR1 means analysis on pooled 2nd pseudo replicates. Each biological replicate is shuf/split into two pseudos. This is a pooling of each replicate\'s 2nd pseudos.'
-		}
-
-		ctl_paired_end: {
-			description: 'Sequencing endedness for all controls.',
-			group: 'input_genomic_data_control',
-			help: 'Setting this on means that all control replicates are paired ended. For mixed controls, use chip.ctl_paired_ends array instead.'
-		}
-		ctl_paired_ends: {
-			description: 'Sequencing endedness array for mixed SE/PE controls.',
-			group: 'input_genomic_data_control',
-			help: 'Whether each control replicate is paired ended or not.'
-		}
-		ctl_fastqs_rep1_R1: {
-			description: 'Read1 FASTQs to be merged for a control replicate 1.',
-			group: 'input_genomic_data_control',
-			help: 'Define if you want to start pipeline from FASTQs files. Pipeline can start from any type of controls (e.g. FASTQs, BAMs, ...). Choose one type and fill paramters for that type and leave other undefined.  Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep1_R2).'
-		}
-		ctl_fastqs_rep1_R1: {
-			description: 'Read2 FASTQs to be merged for a control replicate 1.',
-			group: 'input_genomic_data_control',
-			help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep1_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		ctl_fastqs_rep2_R1: {
-			description: 'Read1 FASTQs to be merged for a control replicate 2.',
-			group: 'input_genomic_data_control',
-			help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep2_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		ctl_fastqs_rep2_R1: {
-			description: 'Read2 FASTQs to be merged for a control replicate 2.',
-			group: 'input_genomic_data_control',
-			help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep2_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		ctl_fastqs_rep3_R1: {
-			description: 'Read1 FASTQs to be merged for a control replicate 3.',
-			group: 'input_genomic_data_control',
-			help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep3_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		ctl_fastqs_rep3_R1: {
-			description: 'Read2 FASTQs to be merged for a control replicate 3.',
-			group: 'input_genomic_data_control',
-			help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep3_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		ctl_fastqs_rep4_R1: {
-			description: 'Read1 FASTQs to be merged for a control replicate 4.',
-			group: 'input_genomic_data_control',
-			help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep4_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		ctl_fastqs_rep4_R1: {
-			description: 'Read2 FASTQs to be merged for a control replicate 4.',
-			group: 'input_genomic_data_control',
-			help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep4_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		ctl_fastqs_rep5_R1: {
-			description: 'Read1 FASTQs to be merged for a control replicate 5.',
-			group: 'input_genomic_data_control',
-			help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep5_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		ctl_fastqs_rep5_R1: {
-			description: 'Read2 FASTQs to be merged for a control replicate 5.',
-			group: 'input_genomic_data_control',
-			help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep5_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		ctl_fastqs_rep6_R1: {
-			description: 'Read1 FASTQs to be merged for a control replicate 6.',
-			group: 'input_genomic_data_control',
-			help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep6_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		ctl_fastqs_rep6_R1: {
-			description: 'Read2 FASTQs to be merged for a control replicate 6.',
-			group: 'input_genomic_data_control',
-			help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep6_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		ctl_fastqs_rep7_R1: {
-			description: 'Read1 FASTQs to be merged for a control replicate 7.',
-			group: 'input_genomic_data_control',
-			help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep7_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		ctl_fastqs_rep7_R2: {
-			description: 'Read2 FASTQs to be merged for a control replicate 7.',
-			group: 'input_genomic_data_control',
-			help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep7_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		ctl_fastqs_rep8_R1: {
-			description: 'Read1 FASTQs to be merged for a control replicate 8.',
-			group: 'input_genomic_data_control',
-			help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep8_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		ctl_fastqs_rep8_R2: {
-			description: 'Read2 FASTQs to be merged for a control replicate 8.',
-			group: 'input_genomic_data_control',
-			help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep8_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		ctl_fastqs_rep9_R1: {
-			description: 'Read1 FASTQs to be merged for a control replicate 9.',
-			group: 'input_genomic_data_control',
-			help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep9_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		ctl_fastqs_rep9_R2: {
-			description: 'Read2 FASTQs to be merged for a control replicate 9.',
-			group: 'input_genomic_data_control',
-			help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep9_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		ctl_fastqs_rep10_R1: {
-			description: 'Read1 FASTQs to be merged for a control replicate 10.',
-			group: 'input_genomic_data_control',
-			help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep10_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		ctl_fastqs_rep10_R2: {
-			description: 'Read2 FASTQs to be merged for a control replicate 10.',
-			group: 'input_genomic_data_control',
-			help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep10_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		ctl_bams: {
-			description: 'List of unfiltered/raw BAM files for each control replicate.',
-			group: 'input_genomic_data_control',
-			help: 'Define if you want to start pipeline from BAM files. Unfiltered/raw BAM file generated from aligner (e.g. bowtie2). Each entry for each control replicate. e.g. [ctl1.bam, ctl2.bam, ctl3.bam, ...].'
-		}
-		ctl_nodup_bams: {
-			description: 'List of filtered/deduped BAM files for each control replicate',
-			group: 'input_genomic_data_control',
-			help: 'Define if you want to start pipeline from filtered BAM files. Filtered/deduped BAM file. Each entry for each control replicate. e.g. [ctl1.nodup.bam, ctl2.nodup.bam, ctl3.nodup.bam, ...].'
-		}
-		ctl_tas: {
-			description: 'List of TAG-ALIGN files for each biological replicate.',
-			group: 'input_genomic_data_control',
-			help: 'Define if you want to start pipeline from TAG-ALIGN files. TAG-ALIGN is in a 6-col BED format. It is a simplified version of BAM. Each entry for each control replicate. e.g. [ctl1.tagAlign.gz, ctl2.tagAlign.gz, ...].'
-		}
-
-		pipeline_type: {
-			description: 'Pipeline type. tf for TF ChIP-Seq or histone for Histone ChIP-Seq.',
-			group: 'pipeline_parameter',
-			help: 'Default peak caller is different for each type. spp For TF ChIP-Seq and macs2 for histone ChIP-Seq. Regardless of pipeline type, spp always requires controls but macs2 doesn\'t.'
-		}
-		align_only: {
-			description: 'Align only mode.',
-			group: 'pipeline_parameter',
-			help: 'Reads will be aligned but there will be no peak-calling on them.'
-		}
-		true_rep_only: {
-			description: 'Disables all analyses related to pseudo-replicates.',
-			group: 'pipeline_parameter',
-			help: 'Pipeline generates 2 pseudo-replicate from one biological replicate. This flag turns off all analyses related to pseudos (with prefix/suffix pr, ppr).'
-		}
-		enable_count_signal_track: {
-			description: 'Enables generation of count signal tracks.',
-			group: 'pipeline_parameter'
-		}
-		enable_jsd: {
-			description: 'Enables Jensen-Shannon Distance (JSD) plot generation.',
-			group: 'pipeline_parameter'
-		}
-		enable_gc_bias: {
-			description: 'Enables GC bias calculation.',
-			group: 'pipeline_parameter'
-		}
-
-		aligner: {
-			description: 'Aligner. bowtie2 or bwa',
-			group: 'alignment',
-			help: 'It is bowtie2 by default.'
-		}
-		use_bwa_mem_for_pe: {
-			description: 'For paired end dataset with read length >= 70bp, use bwa mem instead of bwa aln.',
-			group: 'alignment',
-			help: 'Use it only for paired end reads >= 70bp.'
-		}
-		crop_length: {
-			description: 'Crop FASTQs\' reads longer than this length.',
-			group: 'alignment',
-			help: 'Also drop all reads shorter than chip.crop_length - chip.crop_length_tol.'
-		}
-		crop_length_tol: {
-			description: 'Tolerance for cropping reads in FASTQs.',
-			group: 'alignment',
-			help: 'Drop all reads shorter than chip.crop_length - chip.crop_length_tol. Activated only when chip.crop_length is defined.'
-		}
-		xcor_trim_bp: {
-			description: 'Trim experiment read1 FASTQ (for both SE and PE) for cross-correlation analysis.',
-			group: 'alignment',
-			help: 'This does not affect alignment of experimental/control replicates. Pipeline additionaly aligns R1 FASTQ only for cross-correlation analysis only. This parameter is used for it.'
-		}
-		use_filt_pe_ta_for_xcor: {
-			description: 'Use filtered PE BAM for cross-correlation analysis.',
-			group: 'alignment',
-			help: 'If not defined, pipeline uses SE BAM generated from trimmed read1 FASTQ for cross-correlation analysis.'
-		}
-		dup_marker: {
-			description: 'Marker for duplicate reads. picard or sambamba.',
-			group: 'alignment',
-			help: 'picard for Picard MarkDuplicates or sambamba for sambamba markdup.'
-		}
-		no_dup_removal: {
-			description: 'Disable removal of duplicate reads during filtering BAM.',
-			group: 'alignment',
-			help: 'Duplicate reads are filtererd out during filtering BAMs to gerenate NODUP_BAM. This flag will keep all duplicate reads in NODUP_BAM. This flag does not affect naming of NODUP_BAM. NODUP_BAM will still have .nodup. suffix in its filename.'
-		}
-		mapq_thresh: {
-			description: 'Threshold for low MAPQ reads removal',
-			group: 'alignment',
-			help: 'Low MAPQ reads are filtered out while filtering BAM.',
-		}
-		filter_chrs: {
-			description: 'List of chromosomes to be filtered out while filtering BAM.',
-			group: 'alignment',
-			help: 'It is empty by default, hence no filtering out of specfic chromosomes. It is case-sensitive. Use exact word for chromosome names.'
-		}
-		subsample_reads: {
-			description: 'Subsample reads. Shuffle and subsample reads.',
-			group: 'alignment',
-			help: 'This affects all downstream analyses after filtering experiment BAM. (e.g. all TAG-ALIGN files, peak-calling). Reads will be shuffled only if actual number of reads in BAM exceeds this number. 0 means disabled.'
-		}
-		ctl_subsample_reads: {
-			description: 'Subsample control reads. Shuffle and subsample control reads.',
-			group: 'alignment',
-			help: 'This affects all downstream analyses after filtering control BAM. (e.g. all TAG-ALIGN files, peak-calling). Reads will be shuffled only if actual number of reads in BAM exceeds this number. 0 means disabled.'
-		}
-
-		ctl_depth_limit: {
-			description: 'Hard limit for chosen control\'s depth.',
-			group: 'peak_calling',
-			help: 'If control chosen by chip.always_use_pooled_ctl and chip.ctl_depth_ratio is deeper than this hard limit, then such control is subsampled.'
-		}
-		exp_ctl_depth_ratio_limit: {
-			description: 'Second limit for chosen control\'s' depth.',
-			group: 'peak_calling',
-			help: 'If control chosen by chip.always_use_pooled_ctl and chip.ctl_depth_ratio is deeper than experiment replicate\'s read depth multiplied by this factor then such control is subsampled down to maximum of multiplied value and hard limit chip.ctl_depth_limit.'
-		}
-
-		xcor_subsample_reads: {
-			description: 'Subsample reads for cross-corrlelation analysis only.',
-			group: 'alignment',
-			help: 'This does not affect downstream analyses after filtering BAM. It is for cross-correlation analysis only.  0 means disabled.'
-		}
-
-		xcor_exclusion_range_min: {
-			description: 'Exclusion minimum for cross-correlation analysis.',
-			group: 'peak_calling',
-			help: 'For run_spp.R -s. Make sure that it is consistent with default strand shift -s=-500:5:1500 in run_spp.R.'
-		}
-		xcor_exclusion_range_max: {
-			description: 'Exclusion maximum for cross-coorrelation analysis.',
-			group: 'peak_calling',
-			help: 'For run_spp.R -s. If not defined default value of `max(read length + 10, 50)` for TF and `max(read_len + 10, 100)` for histone are used'
-		}
-		fraglen: {
-			description: 'Fragment length for each biological replicate.',
-			group: 'peak_calling',
-			help: 'Fragment length is estimated by cross-correlation analysis, which is valid only when pipeline started from FASTQs. If defined, fragment length estimated by cross-correlation analysis is ignored.'
-		}
-		peak_caller: {
-			description: 'Peak caller.',
-			group: 'peak_calling',
-			help: 'It is spp and macs2 by default for TF ChIP-seq and histone ChIP-seq, respectively. e.g. you can use macs2 for TF ChIP-Seq even though spp is by default for TF ChIP-Seq (chip.pipeline_type == tf).'
-		}
-		always_use_pooled_ctl: {
-			description: 'Always choose a pooled control for each experiment replicate.',
-			group: 'peak_calling',
-			help: 'If turned on, ignores chip.ctl_depth_ratio.'
-		}
-		ctl_depth_ratio: {
-			description: 'Maximum depth ratio between control replicates.',
-			group: 'peak_calling',
-			help: 'If ratio of depth between any two controls is higher than this, then always use a pooled control for all experiment replicates.'
-		}
-
-		cap_num_peak: {
-			description: 'Upper limit on the number of peaks.',
-			group: 'peak_calling',
-			help: 'It is 30000000 and 50000000 by default for spp and macs2, respectively.'
-		}
-		pval_thresh: {
-			description: 'p-value Threshold for MACS2 peak caller.',
-			group: 'peak_calling',
-			help: 'macs2 callpeak -p'
-		}
-		fdr_thresh: {
-			description: 'FDR threshold for spp peak caller (phantompeakqualtools).',
-			group: 'peak_calling',
-			help: 'run_spp.R -fdr='
-		}
-		idr_thresh: {
-			description: 'IDR threshold.',
-			group: 'peak_calling'
-		}
-
-		align_cpu: {
-			description: 'Number of cores for task align.',
-			group: 'resource_parameter',
-			help: 'Task align merges/crops/maps FASTQs.'
-		}
-		align_mem_mb: {
-			description: 'Memory (MB) required for task align.',
-			group: 'resource_parameter',
-			help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
-		}
-		align_time_hr: {
-			description: 'Walltime (h) required for task align.',
-			group: 'resource_parameter',
-			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
-		}
-		align_disks: {
-			description: 'Persistent disk size to store intermediate files and outputs of task align.',
-			group: 'resource_parameter',
-			help: 'This is for GCP/AWS only.'
-		}
-		filter_cpu: {
-			description: 'Number of cores for task filter.',
-			group: 'resource_parameter',
-			help: 'Task filter filters raw/unfilterd BAM to get filtered/deduped BAM.'
-		}
-		filter_mem_mb: {
-			description: 'Memory (MB) required for task filter.',
-			group: 'resource_parameter',
-			help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
-		}
-		filter_time_hr: {
-			description: 'Walltime (h) required for task filter.',
-			group: 'resource_parameter',
-			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
-		}
-		filter_disks: {
-			description: 'Persistent disk size to store intermediate files and outputs of task filter.',
-			group: 'resource_parameter',
-			help: 'This is for GCP/AWS only.'
-		}
-		bam2ta_cpu: {
-			description: 'Number of cores for task bam2ta.',
-			group: 'resource_parameter',
-			help: 'Task bam2ta converts filtered/deduped BAM in to TAG-ALIGN (6-col BED) format.'
-		}
-		bam2ta_mem_mb: {
-			description: 'Memory (MB) required for task bam2ta.',
-			group: 'resource_parameter',
-			help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
-		}
-		bam2ta_time_hr: {
-			description: 'Walltime (h) required for task bam2ta.',
-			group: 'resource_parameter',
-			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
-		}
-		bam2ta_disks: {
-			description: 'Persistent disk size to store intermediate files and outputs of task bam2ta.',
-			group: 'resource_parameter',
-			help: 'This is for GCP/AWS only.'
-		}
-		spr_mem_mb: {
-			description: 'Memory (MB) required for task spr.',
-			group: 'resource_parameter',
-			help: 'Task spr generates two pseudo-replicates from each biological replicate. This task uses Unix shuf/sort, which can take significant amount of memory.'
-		}
-		jsd_cpu: {
-			description: 'Number of cores for task jsd.',
-			group: 'resource_parameter',
-			help: 'Task jsd plots Jensen-Shannon distance and metrics related to it.'
-		}
-		jsd_mem_mb: {
-			description: 'Memory (MB) required for task jsd.',
-			group: 'resource_parameter',
-			help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
-		}
-		jsd_time_hr: {
-			description: 'Walltime (h) required for task jsd.',
-			group: 'resource_parameter',
-			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
-		}
-		jsd_disks: {
-			description: 'Persistent disk size to store intermediate files and outputs of task jsd.',
-			group: 'resource_parameter',
-			help: 'This is for GCP/AWS only.'
-		}
-		xcor_cpu: {
-			description: 'Number of cores for task xcor.',
-			group: 'resource_parameter',
-			help: 'Task xcor does cross-correlation analysis (including a plot) on subsampled TAG-ALIGNs.'
-		}
-		xcor_mem_mb: {
-			description: 'Memory (MB) required for task xcor.',
-			group: 'resource_parameter',
-			help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
-		}
-		xcor_time_hr: {
-			description: 'Walltime (h) required for task xcor.',
-			group: 'resource_parameter',
-			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
-		}
-		xcor_disks: {
-			description: 'Persistent disk size to store intermediate files and outputs of task xcor.',
-			group: 'resource_parameter',
-			help: 'This is for GCP/AWS only.'
-		}
-		call_peak_cpu: {
-			description: 'Number of cores for task call_peak.',
-			group: 'resource_parameter',
-			help: 'Task call_peak call peaks on TAG-ALIGNs by using MACS2 peak caller.'
-		}
-		call_peak_mem_mb: {
-			description: 'Memory (MB) required for task call_peak.',
-			group: 'resource_parameter',
-			help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
-		}
-		call_peak_time_hr: {
-			description: 'Walltime (h) required for task call_peak.',
-			group: 'resource_parameter',
-			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
-		}
-		call_peak_disks: {
-			description: 'Persistent disk size to store intermediate files and outputs of task call_peak.',
-			group: 'resource_parameter',
-			help: 'This is for GCP/AWS only.'
-		}
-		macs2_signal_track_mem_mb: {
-			description: 'Memory (MB) required for task macs2_signal_track.',
-			group: 'resource_parameter',
-			help: 'Task macs2_signal_track_mem_mb uses MACS2 to get signal tracks for p-val (suffixed with .pval.) and fold enrichment (suffixed with .fc.). This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
-		}
-		macs2_signal_track_time_hr: {
-			description: 'Walltime (h) required for task macs2_signal_track.',
-			group: 'resource_parameter',
-			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
-		}
-		macs2_signal_track_disks: {
-			description: 'Persistent disk size to store intermediate files and outputs of task macs2_signal_track.',
-			group: 'resource_parameter',
-			help: 'This is for GCP/AWS only.'
-		}
-		align_trimmomatic_java_heap: {
-			description: 'Maximum Java heap (java -Xmx) in task align.',
-			group: 'resource_parameter',
-			help: 'Maximum memory for Trimmomatic. If not defined, 90% of align_mem_mb will be used.'
-		}
-		filter_picard_java_heap: {
-			description: 'Maximum Java heap (java -Xmx) in task filter.',
-			group: 'resource_parameter',
-			help: 'Maximum memory for Picard tools MarkDuplicates. If not defined, 90% of filter_mem_mb will be used.'
-		}
-		gc_bias_picard_java_heap: {
-			description: 'Maximum Java heap (java -Xmx) in task gc_bias.',
-			group: 'resource_parameter',
-			help: 'Maximum memory for Picard tools CollectGcBiasMetrics. If not defined, 90% of 10000 MB will be used.'
-		}
-	}
-
-	# read genome data and paths
-	if ( defined(genome_tsv) ) {
-		call read_genome_tsv { input: genome_tsv = genome_tsv }
-	}
-	File ref_fa_ = select_first([ref_fa, read_genome_tsv.ref_fa])
-	File? bwa_idx_tar_ = if defined(bwa_idx_tar) then bwa_idx_tar
-		else read_genome_tsv.bwa_idx_tar
-	File bowtie2_idx_tar_ = select_first([bowtie2_idx_tar, read_genome_tsv.bowtie2_idx_tar])
-	File chrsz_ = select_first([chrsz, read_genome_tsv.chrsz])
-	String gensz_ = select_first([gensz, read_genome_tsv.gensz])
-	File? blacklist1_ = if defined(blacklist) then blacklist
-		else read_genome_tsv.blacklist
-	File? blacklist2_ = if defined(blacklist2) then blacklist2
-		else read_genome_tsv.blacklist2
-	# merge multiple blacklists
-	# two blacklists can have different number of columns (3 vs 6)
-	# so we limit merged blacklist's columns to 3
-	Array[File] blacklists = select_all([blacklist1_, blacklist2_])
-	if ( length(blacklists) > 1 ) {
-		call pool_ta as pool_blacklist { input:
-			tas = blacklists,
-			col = 3,
-		}
-	}
-	File? blacklist_ = if length(blacklists) > 1 then pool_blacklist.ta_pooled
-		else if length(blacklists) > 0 then blacklists[0]
-		else blacklist2_
-	String mito_chr_name_ = select_first([mito_chr_name, read_genome_tsv.mito_chr_name])
-	String regex_bfilt_peak_chr_name_ = select_first([regex_bfilt_peak_chr_name, read_genome_tsv.regex_bfilt_peak_chr_name])
-	String genome_name_ = select_first([genome_name, read_genome_tsv.genome_name, basename(chrsz_)])
-
-	# read additional annotation data
-	File? tss_ = if defined(tss) then tss
-		else read_genome_tsv.tss
-	File? dnase_ = if defined(dnase) then dnase
-		else read_genome_tsv.dnase
-	File? prom_ = if defined(prom) then prom
-		else read_genome_tsv.prom
-	File? enh_ = if defined(enh) then enh
-		else read_genome_tsv.enh
-	File? reg2map_ = if defined(reg2map) then reg2map
-		else read_genome_tsv.reg2map
-	File? reg2map_bed_ = if defined(reg2map_bed) then reg2map_bed
-		else read_genome_tsv.reg2map_bed
-	File? roadmap_meta_ = if defined(roadmap_meta) then roadmap_meta
-		else read_genome_tsv.roadmap_meta
-
-	### temp vars (do not define these)
-	String aligner_ = aligner
-	String peak_caller_ = if pipeline_type=='tf' then select_first([peak_caller, 'spp'])
-						else select_first([peak_caller, 'macs2'])
-	String peak_type_ = if peak_caller_=='spp' then 'regionPeak'
-						else 'narrowPeak'
-	Boolean enable_idr = pipeline_type=='tf' # enable_idr for TF chipseq only
-	String idr_rank_ = if peak_caller_=='spp' then 'signal.value'
-						else if peak_caller_=='macs2' then 'p.value'
-						else 'p.value'
-	Int cap_num_peak_spp = 300000
-	Int cap_num_peak_macs2 = 500000						
-	Int cap_num_peak_ = if peak_caller_ == 'spp' then select_first([cap_num_peak, cap_num_peak_spp])
-		else select_first([cap_num_peak, cap_num_peak_macs2])
-	Int mapq_thresh_ = mapq_thresh
-
-	# temporary 2-dim fastqs array [rep_id][merge_id]
-	Array[Array[File]] fastqs_R1 = 
-		if length(fastqs_rep10_R1)>0 then
-			[fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1, fastqs_rep5_R1,
-			fastqs_rep6_R1, fastqs_rep7_R1, fastqs_rep8_R1, fastqs_rep9_R1, fastqs_rep10_R1]
-		else if length(fastqs_rep9_R1)>0 then
-			[fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1, fastqs_rep5_R1,
-			fastqs_rep6_R1, fastqs_rep7_R1, fastqs_rep8_R1, fastqs_rep9_R1]
-		else if length(fastqs_rep8_R1)>0 then
-			[fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1, fastqs_rep5_R1,
-			fastqs_rep6_R1, fastqs_rep7_R1, fastqs_rep8_R1]
-		else if length(fastqs_rep7_R1)>0 then
-			[fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1, fastqs_rep5_R1,
-			fastqs_rep6_R1, fastqs_rep7_R1]
-		else if length(fastqs_rep6_R1)>0 then
-			[fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1, fastqs_rep5_R1,
-			fastqs_rep6_R1]
-		else if length(fastqs_rep5_R1)>0 then
-			[fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1, fastqs_rep5_R1]
-		else if length(fastqs_rep4_R1)>0 then
-			[fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1]
-		else if length(fastqs_rep3_R1)>0 then
-			[fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1]
-		else if length(fastqs_rep2_R1)>0 then
-			[fastqs_rep1_R1, fastqs_rep2_R1]
-		else if length(fastqs_rep1_R1)>0 then
-			[fastqs_rep1_R1]
-		else []
-	# no need to do that for R2 (R1 array will be used to determine presense of fastq for each rep)
-	Array[Array[File]] fastqs_R2 = 
-		[fastqs_rep1_R2, fastqs_rep2_R2, fastqs_rep3_R2, fastqs_rep4_R2, fastqs_rep5_R2,
-		fastqs_rep6_R2, fastqs_rep7_R2, fastqs_rep8_R2, fastqs_rep9_R2, fastqs_rep10_R2]
-
-	# temporary 2-dim ctl fastqs array [rep_id][merge_id]
-	Array[Array[File]] ctl_fastqs_R1 = 
-		if length(ctl_fastqs_rep10_R1)>0 then
-			[ctl_fastqs_rep1_R1, ctl_fastqs_rep2_R1, ctl_fastqs_rep3_R1, ctl_fastqs_rep4_R1, ctl_fastqs_rep5_R1,
-			ctl_fastqs_rep6_R1, ctl_fastqs_rep7_R1, ctl_fastqs_rep8_R1, ctl_fastqs_rep9_R1, ctl_fastqs_rep10_R1]
-		else if length(ctl_fastqs_rep9_R1)>0 then
-			[ctl_fastqs_rep1_R1, ctl_fastqs_rep2_R1, ctl_fastqs_rep3_R1, ctl_fastqs_rep4_R1, ctl_fastqs_rep5_R1,
-			ctl_fastqs_rep6_R1, ctl_fastqs_rep7_R1, ctl_fastqs_rep8_R1, ctl_fastqs_rep9_R1]
-		else if length(ctl_fastqs_rep8_R1)>0 then
-			[ctl_fastqs_rep1_R1, ctl_fastqs_rep2_R1, ctl_fastqs_rep3_R1, ctl_fastqs_rep4_R1, ctl_fastqs_rep5_R1,
-			ctl_fastqs_rep6_R1, ctl_fastqs_rep7_R1, ctl_fastqs_rep8_R1]
-		else if length(ctl_fastqs_rep7_R1)>0 then
-			[ctl_fastqs_rep1_R1, ctl_fastqs_rep2_R1, ctl_fastqs_rep3_R1, ctl_fastqs_rep4_R1, ctl_fastqs_rep5_R1,
-			ctl_fastqs_rep6_R1, ctl_fastqs_rep7_R1]
-		else if length(ctl_fastqs_rep6_R1)>0 then
-			[ctl_fastqs_rep1_R1, ctl_fastqs_rep2_R1, ctl_fastqs_rep3_R1, ctl_fastqs_rep4_R1, ctl_fastqs_rep5_R1,
-			ctl_fastqs_rep6_R1]
-		else if length(ctl_fastqs_rep5_R1)>0 then
-			[ctl_fastqs_rep1_R1, ctl_fastqs_rep2_R1, ctl_fastqs_rep3_R1, ctl_fastqs_rep4_R1, ctl_fastqs_rep5_R1]
-		else if length(ctl_fastqs_rep4_R1)>0 then
-			[ctl_fastqs_rep1_R1, ctl_fastqs_rep2_R1, ctl_fastqs_rep3_R1, ctl_fastqs_rep4_R1]
-		else if length(ctl_fastqs_rep3_R1)>0 then
-			[ctl_fastqs_rep1_R1, ctl_fastqs_rep2_R1, ctl_fastqs_rep3_R1]
-		else if length(ctl_fastqs_rep2_R1)>0 then
-			[ctl_fastqs_rep1_R1, ctl_fastqs_rep2_R1]
-		else if length(ctl_fastqs_rep1_R1)>0 then
-			[ctl_fastqs_rep1_R1]
-		else []
-	# no need to do that for R2 (R1 array will be used to determine presense of fastq for each rep)
-	Array[Array[File]] ctl_fastqs_R2 = 
-		[ctl_fastqs_rep1_R2, ctl_fastqs_rep2_R2, ctl_fastqs_rep3_R2, ctl_fastqs_rep4_R2, ctl_fastqs_rep5_R2,
-		ctl_fastqs_rep6_R2, ctl_fastqs_rep7_R2, ctl_fastqs_rep8_R2, ctl_fastqs_rep9_R2, ctl_fastqs_rep10_R2]
-
-	# temporary variables to get number of replicates
-	#	 WDLic implementation of max(A,B,C,...)
-	Int num_rep_fastq = length(fastqs_R1)
-	Int num_rep_bam = if length(bams)<num_rep_fastq then num_rep_fastq
-		else length(bams)
-	Int num_rep_nodup_bam = if length(nodup_bams)<num_rep_bam then num_rep_bam
-		else length(nodup_bams)
-	Int num_rep_ta = if length(tas)<num_rep_nodup_bam then num_rep_nodup_bam
-		else length(tas)
-	Int num_rep_peak = if length(peaks)<num_rep_ta then num_rep_ta
-		else length(peaks)
-	Int num_rep = num_rep_peak
-
-	# temporary variables to get number of controls
-	Int num_ctl_fastq = length(ctl_fastqs_R1)
-	Int num_ctl_bam = if length(ctl_bams)<num_ctl_fastq then num_ctl_fastq
-		else length(ctl_bams)
-	Int num_ctl_nodup_bam = if length(ctl_nodup_bams)<num_ctl_bam then num_ctl_bam
-		else length(ctl_nodup_bams)
-	Int num_ctl_ta = if length(ctl_tas)<num_ctl_nodup_bam then num_ctl_nodup_bam
-		else length(ctl_tas)
-	Int num_ctl = num_ctl_ta
-
-	# sanity check for inputs
-	if ( num_rep == 0 && num_ctl == 0 ) {
-		call raise_exception as error_input_data { input:
-			msg = 'No FASTQ/BAM/TAG-ALIGN/PEAK defined in your input JSON. Check if your FASTQs are defined as "chip.fastqs_repX_RY". DO NOT MISS suffix _R1 even for single ended FASTQ.'
-		}
-	}
-	if ( !align_only && peak_caller_ == 'spp' && num_ctl == 0 ) {
-		call raise_exception as error_control_required { input:
-			msg = 'SPP requires control inputs. Define control input files ("chip.ctl_*") in an input JSON file.'
-		}
-	}
-	if ( (num_rep_fastq > 0 || num_ctl_fastq > 0) && aligner_ != 'bwa' && aligner_ != 'bowtie2' ) {
-		call raise_exception as error_wrong_aligner { input:
-			msg = 'Choose chip.aligner between bwa and bowtie2.'
-		}
-	}
-	if ( aligner_ != 'bwa' && use_bwa_mem_for_pe ) {
-		call raise_exception as error_use_bwa_mem_for_non_bwa { input:
-			msg = 'To use chip.use_bwa_mem_for_pe, choose bwa for chip.aligner.'
-		}
-	}	
-	if ( ( ctl_depth_limit > 0 || exp_ctl_depth_ratio_limit > 0 ) && num_ctl > 1 && length(ctl_paired_ends) > 1  ) {
-		call raise_exception as error_subsample_pooled_control_with_mixed_endedness { input:
-			msg = 'Cannot use automatic control subsampling ("chip.ctl_depth_limit">0 and "chip.exp_ctl_depth_limit">0) for ' +
-				  'multiple controls with mixed endedness (e.g. SE ctl-rep1 and PE ctl-rep2). ' +
-				  'Automatic control subsampling is enabled by default. ' +
-				  'Disable automatic control subsampling by explicitly defining the above two parameters as 0 in your input JSON file. ' +
-				  'You can still use manual control subsamping ("chip.ctl_subsample_reads">0) since it is done ' +
-				  'for individual control\'s TAG-ALIGN output according to each control\'s endedness. '
-		}
-	}
-
-	# align each replicate
-	scatter(i in range(num_rep)) {
-		# to override endedness definition for individual replicate
-		#	 paired_end will override paired_ends[i]
-		Boolean paired_end_ = if !defined(paired_end) && i<length(paired_ends) then paired_ends[i]
-			else select_first([paired_end])
-
-		Boolean has_input_of_align = i<length(fastqs_R1) && length(fastqs_R1[i])>0
-		Boolean has_output_of_align = i<length(bams) && defined(bams[i])
-		if ( has_input_of_align && !has_output_of_align ) {
-			call align { input :
-				fastqs_R1 = fastqs_R1[i],
-				fastqs_R2 = fastqs_R2[i],
-				crop_length = crop_length,
-				crop_length_tol = crop_length_tol,
-
-				aligner = aligner_,
-				mito_chr_name = mito_chr_name_,
-				idx_tar = if aligner=='bwa' then bwa_idx_tar_
-					else bowtie2_idx_tar_,
-				paired_end = paired_end_,
-				use_bwa_mem_for_pe = use_bwa_mem_for_pe,
-
-				trimmomatic_java_heap = align_trimmomatic_java_heap,
-				cpu = align_cpu,
-				mem_mb = align_mem_mb,
-				time_hr = align_time_hr,
-				disks = align_disks,
-			}
-		}
-		File? bam_ = if has_output_of_align then bams[i] else align.bam
-
-		Boolean has_input_of_filter = has_output_of_align || defined(align.bam)
-		Boolean has_output_of_filter = i<length(nodup_bams) && defined(nodup_bams[i])
-		# skip if we already have output of this step
-		if ( has_input_of_filter && !has_output_of_filter ) {
-			call filter { input :
-				bam = bam_,
-				paired_end = paired_end_,
-				dup_marker = dup_marker,
-				mapq_thresh = mapq_thresh_,
-				filter_chrs = filter_chrs,
-				chrsz = chrsz_,
-				no_dup_removal = no_dup_removal,
-				mito_chr_name = mito_chr_name_,
-
-				cpu = filter_cpu,
-				mem_mb = filter_mem_mb,
-				picard_java_heap = filter_picard_java_heap,
-				time_hr = filter_time_hr,
-				disks = filter_disks,
-			}
-		}
-		File? nodup_bam_ = if has_output_of_filter then nodup_bams[i] else filter.nodup_bam
-
-		Boolean has_input_of_bam2ta = has_output_of_filter || defined(filter.nodup_bam)
-		Boolean has_output_of_bam2ta = i<length(tas) && defined(tas[i])
-		if ( has_input_of_bam2ta && !has_output_of_bam2ta ) {
-			call bam2ta { input :
-				bam = nodup_bam_,
-				subsample = subsample_reads,
-				paired_end = paired_end_,
-				mito_chr_name = mito_chr_name_,
-
-				cpu = bam2ta_cpu,
-				mem_mb = bam2ta_mem_mb,
-				time_hr = bam2ta_time_hr,
-				disks = bam2ta_disks,
-			}
-		}
-		File? ta_ = if has_output_of_bam2ta then tas[i] else bam2ta.ta
-
-		Boolean has_input_of_spr = has_output_of_bam2ta || defined(bam2ta.ta)
-		if ( has_input_of_spr && !align_only && !true_rep_only ) {
-			call spr { input :
-				ta = ta_,
-				paired_end = paired_end_,
-				mem_mb = spr_mem_mb,
-			}
-		}
-
-		Boolean has_input_of_count_signal_track = has_output_of_bam2ta || defined(bam2ta.ta)
-		if ( has_input_of_count_signal_track && enable_count_signal_track ) {
-			# generate count signal track
-			call count_signal_track { input :
-				ta = ta_,
-				chrsz = chrsz_,
-			}
-		}
-
-		if ( enable_gc_bias && defined(nodup_bam_) && defined(ref_fa_) ) {
-			call gc_bias { input :
-				nodup_bam = nodup_bam_,
-				ref_fa = ref_fa_,
-				picard_java_heap = gc_bias_picard_java_heap,
-			}
-		}
-
-		# special trimming/mapping for xcor (when starting from FASTQs)
-		if ( has_input_of_align ) {
-			call align as align_R1 { input :
-				fastqs_R1 = fastqs_R1[i],
-				fastqs_R2 = [],
-				trim_bp = xcor_trim_bp,
-				crop_length = 0,
-				crop_length_tol = 0,
-
-				aligner = aligner_,
-				mito_chr_name = mito_chr_name_,
-				idx_tar = if aligner=='bwa' then bwa_idx_tar_
-					else bowtie2_idx_tar_,
-				paired_end = false,
-				use_bwa_mem_for_pe = use_bwa_mem_for_pe,
-
-				cpu = align_cpu,
-				mem_mb = align_mem_mb,
-				time_hr = align_time_hr,
-				disks = align_disks,
-			}
-			# no bam deduping for xcor
-			call filter as filter_R1 { input :
-				bam = align_R1.bam,
-				paired_end = false,
-				dup_marker = dup_marker,
-				mapq_thresh = mapq_thresh_,
-				filter_chrs = filter_chrs,
-				chrsz = chrsz_,
-				no_dup_removal = true,
-				mito_chr_name = mito_chr_name_,
-
-				cpu = filter_cpu,
-				mem_mb = filter_mem_mb,
-				picard_java_heap = filter_picard_java_heap,
-				time_hr = filter_time_hr,
-				disks = filter_disks,
-			}
-			call bam2ta as bam2ta_no_dedup_R1 { input :
-				bam = filter_R1.nodup_bam,  # it's named as nodup bam but it's not deduped but just filtered
-				paired_end = false,
-				subsample = 0,
-				mito_chr_name = mito_chr_name_,
-
-				cpu = bam2ta_cpu,
-				mem_mb = bam2ta_mem_mb,
-				time_hr = bam2ta_time_hr,
-				disks = bam2ta_disks,
-			}
-		}
-
-		# special trimming/mapping for xcor (when starting from BAMs)
-		Boolean has_input_of_bam2ta_no_dedup = (has_output_of_align || defined(align.bam))
-			&& !defined(bam2ta_no_dedup_R1.ta)
-		if ( has_input_of_bam2ta_no_dedup ) {
-			call filter as filter_no_dedup { input :
-				bam = bam_,
-				paired_end = paired_end_,
-				dup_marker = dup_marker,
-				mapq_thresh = mapq_thresh_,
-				filter_chrs = filter_chrs,
-				chrsz = chrsz_,
-				no_dup_removal = true,
-				mito_chr_name = mito_chr_name_,
-
-				cpu = filter_cpu,
-				mem_mb = filter_mem_mb,
-				picard_java_heap = filter_picard_java_heap,
-				time_hr = filter_time_hr,
-				disks = filter_disks,
-			}
-			call bam2ta as bam2ta_no_dedup { input :
-				bam = filter_no_dedup.nodup_bam,  # output name is nodup but it's not deduped
-				paired_end = paired_end_,
-				subsample = 0,
-				mito_chr_name = mito_chr_name_,
-
-				cpu = bam2ta_cpu,
-				mem_mb = bam2ta_mem_mb,
-				time_hr = bam2ta_time_hr,
-				disks = bam2ta_disks,
-			}
-		}
-
-		# use trimmed/unfilitered R1 tagAlign for paired end dataset
-		# if not starting from fastqs, keep using old method
-		#  (mapping with both ends for tag-aligns to be used for xcor)
-		# subsample tagalign (non-mito) and cross-correlation analysis
-		File? ta_xcor = if defined(bam2ta_no_dedup_R1.ta) then bam2ta_no_dedup_R1.ta
-			else if defined(bam2ta_no_dedup.ta) then bam2ta_no_dedup.ta
-			else ta_
-		Boolean paired_end_xcor = if defined(bam2ta_no_dedup_R1.ta) then false
-			else paired_end_
-
-		Boolean has_input_of_xcor = defined(ta_xcor)
-		if ( has_input_of_xcor ) {
-			call xcor { input :
-				ta = ta_xcor,
-				paired_end = paired_end_xcor,
-				subsample = xcor_subsample_reads,
-				mito_chr_name = mito_chr_name_,
-				chip_seq_type = pipeline_type,
-				exclusion_range_min = xcor_exclusion_range_min,
-				exclusion_range_max = xcor_exclusion_range_max,
-				cpu = xcor_cpu,
-				mem_mb = xcor_mem_mb,
-				time_hr = xcor_time_hr,
-				disks = xcor_disks,
-			}
-		}
-
-		# before peak calling, get fragment length from xcor analysis or given input
-		# if fraglen [] is defined in the input JSON, fraglen from xcor will be ignored
-		Int? fraglen_ = if i<length(fraglen) && defined(fraglen[i]) then fraglen[i]
-			else xcor.fraglen
-	}
-
-	# align each control
-	scatter(i in range(num_ctl)) {
-		# to override endedness definition for individual control
-		#	 ctl_paired_end will override ctl_paired_ends[i]
-		Boolean ctl_paired_end_ = if !defined(ctl_paired_end) && i<length(ctl_paired_ends) then ctl_paired_ends[i]
-			else select_first([ctl_paired_end, paired_end])
-
-		Boolean has_input_of_align_ctl = i<length(ctl_fastqs_R1) && length(ctl_fastqs_R1[i])>0
-		Boolean has_output_of_align_ctl = i<length(ctl_bams) && defined(ctl_bams[i])
-		if ( has_input_of_align_ctl && !has_output_of_align_ctl ) {
-			call align as align_ctl { input :
-				fastqs_R1 = ctl_fastqs_R1[i],
-				fastqs_R2 = ctl_fastqs_R2[i],
-				crop_length = crop_length,
-				crop_length_tol = crop_length_tol,
-
-				aligner = aligner_,
-				mito_chr_name = mito_chr_name_,
-				idx_tar = if aligner=='bwa' then bwa_idx_tar_
-					else bowtie2_idx_tar_,
-				paired_end = ctl_paired_end_,
-				use_bwa_mem_for_pe = use_bwa_mem_for_pe,
-
-				trimmomatic_java_heap = align_trimmomatic_java_heap,
-				cpu = align_cpu,
-				mem_mb = align_mem_mb,
-				time_hr = align_time_hr,
-				disks = align_disks,
-			}
-		}
-		File? ctl_bam_ = if has_output_of_align_ctl then ctl_bams[i] else align_ctl.bam
-
-		Boolean has_input_of_filter_ctl = has_output_of_align_ctl || defined(align_ctl.bam)
-		Boolean has_output_of_filter_ctl = i<length(ctl_nodup_bams) && defined(ctl_nodup_bams[i])
-		# skip if we already have output of this step
-		if ( has_input_of_filter_ctl && !has_output_of_filter_ctl ) {
-			call filter as filter_ctl { input :
-				bam = ctl_bam_,
-				paired_end = ctl_paired_end_,
-				dup_marker = dup_marker,
-				mapq_thresh = mapq_thresh_,
-				filter_chrs = filter_chrs,
-				chrsz = chrsz_,
-				no_dup_removal = no_dup_removal,
-				mito_chr_name = mito_chr_name_,
-
-				cpu = filter_cpu,
-				mem_mb = filter_mem_mb,
-				picard_java_heap = filter_picard_java_heap,
-				time_hr = filter_time_hr,
-				disks = filter_disks,
-			}
-		}
-		File? ctl_nodup_bam_ = if has_output_of_filter_ctl then ctl_nodup_bams[i] else filter_ctl.nodup_bam
-
-		Boolean has_input_of_bam2ta_ctl = has_output_of_filter_ctl || defined(filter_ctl.nodup_bam)
-		Boolean has_output_of_bam2ta_ctl = i<length(ctl_tas) && defined(ctl_tas[i])
-		if ( has_input_of_bam2ta_ctl && !has_output_of_bam2ta_ctl ) {
-			call bam2ta as bam2ta_ctl { input :
-				bam = ctl_nodup_bam_,
-				subsample = subsample_reads,
-				paired_end = ctl_paired_end_,
-				mito_chr_name = mito_chr_name_,
-
-				cpu = bam2ta_cpu,
-				mem_mb = bam2ta_mem_mb,
-				time_hr = bam2ta_time_hr,
-				disks = bam2ta_disks,
-			}
-		}
-		File? ctl_ta_ = if has_output_of_bam2ta_ctl then ctl_tas[i] else bam2ta_ctl.ta
-	}
-
-	# if there are TAs for ALL replicates then pool them
-	Boolean has_all_inputs_of_pool_ta = length(select_all(ta_))==num_rep
-	if ( has_all_inputs_of_pool_ta && num_rep>1 ) {
-		# pool tagaligns from true replicates
-		call pool_ta { input :
-			tas = ta_,
-			prefix = 'rep',
-		}
-	}
-
-	# if there are pr1 TAs for ALL replicates then pool them
-	Boolean has_all_inputs_of_pool_ta_pr1 = length(select_all(spr.ta_pr1))==num_rep
-	if ( has_all_inputs_of_pool_ta_pr1 && num_rep>1 && !align_only && !true_rep_only ) {
-		# pool tagaligns from pseudo replicate 1
-		call pool_ta as pool_ta_pr1 { input :
-			tas = spr.ta_pr1,
-			prefix = 'rep-pr1',
-		}
-	}
-
-	# if there are pr2 TAs for ALL replicates then pool them
-	Boolean has_all_inputs_of_pool_ta_pr2 = length(select_all(spr.ta_pr2))==num_rep
-	if ( has_all_inputs_of_pool_ta_pr1 && num_rep>1 && !align_only && !true_rep_only ) {
-		# pool tagaligns from pseudo replicate 2
-		call pool_ta as pool_ta_pr2 { input :
-			tas = spr.ta_pr2,
-			prefix = 'rep-pr2',
-		}
-	}
-
-	# if there are CTL TAs for ALL replicates then pool them
-	Boolean has_all_inputs_of_pool_ta_ctl = length(select_all(ctl_ta_))==num_ctl
-	if ( has_all_inputs_of_pool_ta_ctl && num_ctl>1 ) {
-		# pool tagaligns from true replicates
-		call pool_ta as pool_ta_ctl { input :
-			tas = ctl_ta_,
-			prefix = 'ctl',
-		}
-	}
-
-	Boolean has_input_of_count_signal_track_pooled = defined(pool_ta.ta_pooled)
-	if ( has_input_of_count_signal_track_pooled && enable_count_signal_track && num_rep>1 ) {
-		call count_signal_track as count_signal_track_pooled { input :
-			ta = pool_ta.ta_pooled,
-			chrsz = chrsz_,
-		}
-	}
-
-	Boolean has_input_of_jsd = defined(blacklist_) && length(select_all(nodup_bam_))==num_rep
-	if ( has_input_of_jsd && num_rep > 0 && enable_jsd ) {
-		# fingerprint and JS-distance plot
-		call jsd { input :
-			nodup_bams = nodup_bam_,
-			ctl_bams = ctl_nodup_bam_, # use first control only
-			blacklist = blacklist_,
-			mapq_thresh = mapq_thresh_,
-
-			cpu = jsd_cpu,
-			mem_mb = jsd_mem_mb,
-			time_hr = jsd_time_hr,
-			disks = jsd_disks,
-		}
-	}
-
-	Boolean has_all_input_of_choose_ctl = length(select_all(ta_))==num_rep
-		&& length(select_all(ctl_ta_))==num_ctl && num_ctl > 0
-	if ( has_all_input_of_choose_ctl && !align_only ) {
-		# choose appropriate control for each exp IP replicate
-		# outputs:
-		#	 choose_ctl.idx : control replicate index for each exp replicate 
-		#					-1 means pooled ctl replicate
-		call choose_ctl { input:
-			tas = ta_,
-			ctl_tas = ctl_ta_,
-			ta_pooled = pool_ta.ta_pooled,
-			ctl_ta_pooled = pool_ta_ctl.ta_pooled,
-			always_use_pooled_ctl = always_use_pooled_ctl,
-			ctl_depth_ratio = ctl_depth_ratio,
-			ctl_depth_limit = ctl_depth_limit,
-			exp_ctl_depth_ratio_limit = exp_ctl_depth_ratio_limit,
-		}
-	}
-
-	scatter(i in range(num_rep)) {
-		# make control ta array [[1,2,3,4]] -> [[1],[2],[3],[4]]
-		# chosen_ctl_ta_id
-		#	 >=0: control TA index (this means that control TA with this index exists)
-		#	 -1: use pooled control
-		#	-2: there is no control
-		Int chosen_ctl_ta_id = if has_all_input_of_choose_ctl && !align_only then
-			select_first([choose_ctl.chosen_ctl_ta_ids])[i] else -2
-		Array[File] chosen_ctl_tas = if chosen_ctl_ta_id == -2 then []
-			else if chosen_ctl_ta_id == -1 then [ select_first([pool_ta_ctl.ta_pooled]) ]
-			else [ select_first([ctl_ta_[ chosen_ctl_ta_id ]]) ]
-
-		Int chosen_ctl_ta_subsample = if has_all_input_of_choose_ctl && !align_only then
-			select_first([choose_ctl.chosen_ctl_ta_subsample])[i] else 0
-		Boolean chosen_ctl_paired_end = if chosen_ctl_ta_id == -2 then false
-			else if chosen_ctl_ta_id == -1 then ctl_paired_end_[0]
-			else ctl_paired_end_[chosen_ctl_ta_id]
-	}
-	Int chosen_ctl_ta_pooled_subsample = if has_all_input_of_choose_ctl && !align_only then
-		select_first([choose_ctl.chosen_ctl_ta_subsample_pooled]) else 0
-
-	# workaround for dx error (Unsupported combination: womType: Int womValue: ([225], Array[Int]))
-	Array[Int] fraglen_tmp = select_all(fraglen_)
-
-	# we have all tas and ctl_tas (optional for histone chipseq) ready, let's call peaks
-	scatter(i in range(num_rep)) {
-		Boolean has_input_of_call_peak = defined(ta_[i])
-		Boolean has_output_of_call_peak = i<length(peaks) && defined(peaks[i])
-		if ( has_input_of_call_peak && !has_output_of_call_peak && !align_only ) {
-			call call_peak { input :
-				peak_caller = peak_caller_,
-				peak_type = peak_type_,
-				tas = flatten([[ta_[i]], chosen_ctl_tas[i]]),
-				gensz = gensz_,
-				chrsz = chrsz_,
-				cap_num_peak = cap_num_peak_,
-				ctl_subsample = chosen_ctl_ta_subsample[i],
-				ctl_paired_end = chosen_ctl_paired_end[i],
-				pval_thresh = pval_thresh,
-				fdr_thresh = fdr_thresh,
-				fraglen = fraglen_tmp[i],
-				blacklist = blacklist_,
-				regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
-
-				cpu = call_peak_cpu,
-				mem_mb = call_peak_mem_mb,
-				disks = call_peak_disks,
-				time_hr = call_peak_time_hr,
-			}
-		}
-		File? peak_ = if has_output_of_call_peak then peaks[i]
-			else call_peak.peak
-
-		# signal track
-		if ( has_input_of_call_peak && !align_only ) {
-			call macs2_signal_track { input :
-				tas = flatten([[ta_[i]], chosen_ctl_tas[i]]),
-				gensz = gensz_,
-				chrsz = chrsz_,
-				pval_thresh = pval_thresh,
-				ctl_subsample = chosen_ctl_ta_subsample[i],
-				ctl_paired_end = chosen_ctl_paired_end[i],
-				fraglen = fraglen_tmp[i],
-
-				mem_mb = macs2_signal_track_mem_mb,
-				disks = macs2_signal_track_disks,
-				time_hr = macs2_signal_track_time_hr,
-			}
-		}
-
-		# call peaks on 1st pseudo replicated tagalign
-		Boolean has_input_of_call_peak_pr1 = defined(spr.ta_pr1[i])
-		Boolean has_output_of_call_peak_pr1 = i<length(peaks_pr1) && defined(peaks_pr1[i])
-		if ( has_input_of_call_peak_pr1 && !has_output_of_call_peak_pr1 && !true_rep_only ) {
-			call call_peak as call_peak_pr1 { input :
-				peak_caller = peak_caller_,
-				peak_type = peak_type_,
-				tas = flatten([[spr.ta_pr1[i]], chosen_ctl_tas[i]]),
-				gensz = gensz_,
-				chrsz = chrsz_,
-				cap_num_peak = cap_num_peak_,
-				ctl_subsample = chosen_ctl_ta_subsample[i],
-				ctl_paired_end = chosen_ctl_paired_end[i],
-				pval_thresh = pval_thresh,
-				fdr_thresh = fdr_thresh,
-				fraglen = fraglen_tmp[i],
-				blacklist = blacklist_,
-				regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
-	
-				cpu = call_peak_cpu,
-				mem_mb = call_peak_mem_mb,
-				disks = call_peak_disks,
-				time_hr = call_peak_time_hr,
-			}
-		}
-		File? peak_pr1_ = if has_output_of_call_peak_pr1 then peaks_pr1[i]
-			else call_peak_pr1.peak
-
-		# call peaks on 2nd pseudo replicated tagalign
-		Boolean has_input_of_call_peak_pr2 = defined(spr.ta_pr2[i])
-		Boolean has_output_of_call_peak_pr2 = i<length(peaks_pr2) && defined(peaks_pr2[i])
-		if ( has_input_of_call_peak_pr2 && !has_output_of_call_peak_pr2 && !true_rep_only ) {
-			call call_peak as call_peak_pr2 { input :
-				peak_caller = peak_caller_,
-				peak_type = peak_type_,
-				tas = flatten([[spr.ta_pr2[i]], chosen_ctl_tas[i]]),
-				gensz = gensz_,
-				chrsz = chrsz_,
-				cap_num_peak = cap_num_peak_,
-				ctl_subsample = chosen_ctl_ta_subsample[i],
-				ctl_paired_end = chosen_ctl_paired_end[i],
-				pval_thresh = pval_thresh,
-				fdr_thresh = fdr_thresh,
-				fraglen = fraglen_tmp[i],
-				blacklist = blacklist_,
-				regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
-
-				cpu = call_peak_cpu,
-				mem_mb = call_peak_mem_mb,
-				disks = call_peak_disks,
-				time_hr = call_peak_time_hr,
-			}
-		}
-		File? peak_pr2_ = if has_output_of_call_peak_pr2 then peaks_pr2[i]
-			else call_peak_pr2.peak
-	}
-
-	# if ( !align_only && num_rep > 1 ) {
-	# rounded mean of fragment length, which will be used for 
-	#  1) calling peaks for pooled true/pseudo replicates
-	#  2) calculating FRiP
-	call rounded_mean as fraglen_mean { input :
-		ints = fraglen_tmp,
-	}
-	# }
-
-	# actually not an array
-	Array[File?] chosen_ctl_ta_pooled = if !has_all_input_of_choose_ctl || align_only then []
-		else if num_ctl < 2 then [ctl_ta_[0]] # choose first (only) control
-		else select_all([pool_ta_ctl.ta_pooled]) # choose pooled control
-	Boolean chosen_ctl_ta_pooled_paired_end = if !has_all_input_of_choose_ctl || align_only then false
-		else ctl_paired_end_[0]
-
-	Boolean has_input_of_call_peak_pooled = defined(pool_ta.ta_pooled)
-	Boolean has_output_of_call_peak_pooled = defined(peak_pooled)
-	if ( has_input_of_call_peak_pooled && !has_output_of_call_peak_pooled && !align_only && num_rep>1 ) {
-		# call peaks on pooled replicate
-		# always call peaks for pooled replicate to get signal tracks
-		call call_peak as call_peak_pooled { input :
-			peak_caller = peak_caller_,
-			peak_type = peak_type_,
-			tas = flatten([select_all([pool_ta.ta_pooled]), chosen_ctl_ta_pooled]),
-			gensz = gensz_,
-			chrsz = chrsz_,
-			cap_num_peak = cap_num_peak_,
-			ctl_subsample = chosen_ctl_ta_pooled_subsample,
-			ctl_paired_end = chosen_ctl_ta_pooled_paired_end,
-			pval_thresh = pval_thresh,
-			fdr_thresh = fdr_thresh,
-			fraglen = fraglen_mean.rounded_mean,
-			blacklist = blacklist_,
-			regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
-
-			cpu = call_peak_cpu,
-			mem_mb = call_peak_mem_mb,
-			disks = call_peak_disks,
-			time_hr = call_peak_time_hr,
-		}
-	}
-	File? peak_pooled_ = if has_output_of_call_peak_pooled then peak_pooled
-		else call_peak_pooled.peak	
-
-	# macs2 signal track for pooled rep
-	if ( has_input_of_call_peak_pooled && !align_only && num_rep>1 ) {
-		call macs2_signal_track as macs2_signal_track_pooled { input :
-			tas = flatten([select_all([pool_ta.ta_pooled]), chosen_ctl_ta_pooled]),
-			gensz = gensz_,
-			chrsz = chrsz_,
-			pval_thresh = pval_thresh,
-			ctl_subsample = chosen_ctl_ta_pooled_subsample,
-			ctl_paired_end = chosen_ctl_ta_pooled_paired_end,
-			fraglen = fraglen_mean.rounded_mean,
-
-			mem_mb = macs2_signal_track_mem_mb,
-			disks = macs2_signal_track_disks,
-			time_hr = macs2_signal_track_time_hr,
-		}
-	}
-
-	Boolean has_input_of_call_peak_ppr1 = defined(pool_ta_pr1.ta_pooled)
-	Boolean has_output_of_call_peak_ppr1 = defined(peak_ppr1)
-	if ( has_input_of_call_peak_ppr1 && !has_output_of_call_peak_ppr1 && !align_only && !true_rep_only && num_rep>1 ) {
-		# call peaks on 1st pooled pseudo replicates
-		call call_peak as call_peak_ppr1 { input :
-			peak_caller = peak_caller_,
-			peak_type = peak_type_,
-			tas = flatten([select_all([pool_ta_pr1.ta_pooled]), chosen_ctl_ta_pooled]),
-			gensz = gensz_,
-			chrsz = chrsz_,
-			cap_num_peak = cap_num_peak_,
-			pval_thresh = pval_thresh,
-			ctl_subsample = chosen_ctl_ta_pooled_subsample,
-			ctl_paired_end = chosen_ctl_ta_pooled_paired_end,
-			fdr_thresh = fdr_thresh,
-			fraglen = fraglen_mean.rounded_mean,
-			blacklist = blacklist_,
-			regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
-
-			cpu = call_peak_cpu,
-			mem_mb = call_peak_mem_mb,
-			disks = call_peak_disks,
-			time_hr = call_peak_time_hr,
-		}
-	}
-	File? peak_ppr1_ = if has_output_of_call_peak_ppr1 then peak_ppr1
-		else call_peak_ppr1.peak
-
-	Boolean has_input_of_call_peak_ppr2 = defined(pool_ta_pr2.ta_pooled)
-	Boolean has_output_of_call_peak_ppr2 = defined(peak_ppr2)
-	if ( has_input_of_call_peak_ppr2 && !has_output_of_call_peak_ppr2 && !align_only && !true_rep_only && num_rep>1 ) {
-		# call peaks on 2nd pooled pseudo replicates
-		call call_peak as call_peak_ppr2 { input :
-			peak_caller = peak_caller_,
-			peak_type = peak_type_,
-			tas = flatten([select_all([pool_ta_pr2.ta_pooled]), chosen_ctl_ta_pooled]),
-			gensz = gensz_,
-			chrsz = chrsz_,
-			cap_num_peak = cap_num_peak_,
-			pval_thresh = pval_thresh,
-			ctl_subsample = chosen_ctl_ta_pooled_subsample,
-			ctl_paired_end = chosen_ctl_ta_pooled_paired_end,
-			fdr_thresh = fdr_thresh,
-			fraglen = fraglen_mean.rounded_mean,
-			blacklist = blacklist_,
-			regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
-
-			cpu = call_peak_cpu,
-			mem_mb = call_peak_mem_mb,
-			disks = call_peak_disks,
-			time_hr = call_peak_time_hr,
-		}
-	}
-	File? peak_ppr2_ = if has_output_of_call_peak_ppr2 then peak_ppr2
-		else call_peak_ppr2.peak
-
-	# do IDR/overlap on all pairs of two replicates (i,j)
-	#	 where i and j are zero-based indices and 0 <= i < j < num_rep
-	scatter( pair in cross(range(num_rep),range(num_rep)) ) {
-		# pair.left = 0-based index of 1st replicate
-		# pair.right = 0-based index of 2nd replicate
-		File? peak1_ = peak_[pair.left]
-		File? peak2_ = peak_[pair.right]
-		if ( !align_only && pair.left<pair.right ) {
-			# Naive overlap on every pair of true replicates
-			call overlap { input :
-				prefix = 'rep'+(pair.left+1)+'_vs_rep'+(pair.right+1),
-				peak1 = peak1_,
-				peak2 = peak2_,
-				peak_pooled = peak_pooled_,
-				fraglen = fraglen_mean.rounded_mean,
-				peak_type = peak_type_,
-				blacklist = blacklist_,
-				chrsz = chrsz_,
-				regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
-				ta = pool_ta.ta_pooled,
-			}
-		}
-		if ( enable_idr && !align_only && pair.left<pair.right ) {
-			# IDR on every pair of true replicates
-			call idr { input :
-				prefix = 'rep'+(pair.left+1)+'_vs_rep'+(pair.right+1),
-				peak1 = peak1_,
-				peak2 = peak2_,
-				peak_pooled = peak_pooled_,
-				fraglen = fraglen_mean.rounded_mean,
-				idr_thresh = idr_thresh,
-				peak_type = peak_type_,
-				rank = idr_rank_,
-				blacklist = blacklist_,
-				chrsz = chrsz_,
-				regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
-				ta = pool_ta.ta_pooled,
-			}
-		}
-	}
-
-	# overlap on pseudo-replicates (pr1, pr2) for each true replicate
-	if ( !align_only && !true_rep_only ) {
-		scatter( i in range(num_rep) ) {
-			call overlap as overlap_pr { input :
-				prefix = 'rep'+(i+1)+'-pr1_vs_rep'+(i+1)+'-pr2',
-				peak1 = peak_pr1_[i],
-				peak2 = peak_pr2_[i],
-				peak_pooled = peak_[i],
-				fraglen = fraglen_[i],
-				peak_type = peak_type_,
-				blacklist = blacklist_,
-				chrsz = chrsz_,
-				regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
-				ta = ta_[i],
-			}
-		}
-	}
-
-	if ( !align_only && !true_rep_only && enable_idr ) {
-		scatter( i in range(num_rep) ) {
-			# IDR on pseduo replicates
-			call idr as idr_pr { input :
-				prefix = 'rep'+(i+1)+'-pr1_vs_rep'+(i+1)+'-pr2',
-				peak1 = peak_pr1_[i],
-				peak2 = peak_pr2_[i],
-				peak_pooled = peak_[i],
-				fraglen = fraglen_[i],
-				idr_thresh = idr_thresh,
-				peak_type = peak_type_,
-				rank = idr_rank_,
-				blacklist = blacklist_,
-				chrsz = chrsz_,
-				regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
-				ta = ta_[i],
-			}
-		}
-	}
-
-	if ( !align_only && !true_rep_only && num_rep > 1 ) {
-		# Naive overlap on pooled pseudo replicates
-		call overlap as overlap_ppr { input :
-			prefix = 'pooled-pr1_vs_pooled-pr2',
-			peak1 = peak_ppr1_,
-			peak2 = peak_ppr2_,
-			peak_pooled = peak_pooled_,
-			peak_type = peak_type_,
-			fraglen = fraglen_mean.rounded_mean,
-			blacklist = blacklist_,
-			chrsz = chrsz_,
-			regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
-			ta = pool_ta.ta_pooled,
-		}
-	}
-
-	if ( !align_only && !true_rep_only && num_rep > 1 ) {
-		# IDR on pooled pseduo replicates
-		call idr as idr_ppr { input :
-			prefix = 'pooled-pr1_vs_pooled-pr2',
-			peak1 = peak_ppr1_,
-			peak2 = peak_ppr2_,
-			peak_pooled = peak_pooled_,
-			idr_thresh = idr_thresh,
-			peak_type = peak_type_,
-			fraglen = fraglen_mean.rounded_mean,
-			rank = idr_rank_,
-			blacklist = blacklist_,
-			chrsz = chrsz_,
-			regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
-			ta = pool_ta.ta_pooled,
-		}
-	}
-
-	# reproducibility QC for overlap/IDR peaks
-	if ( !align_only && !true_rep_only && num_rep > 0 ) {
-		# reproducibility QC for overlapping peaks
-		call reproducibility as reproducibility_overlap { input :
-			prefix = 'overlap',
-			peaks = select_all(overlap.bfilt_overlap_peak),
-			peaks_pr = overlap_pr.bfilt_overlap_peak,
-			peak_ppr = overlap_ppr.bfilt_overlap_peak,
-			peak_type = peak_type_,
-			chrsz = chrsz_,
-		}
-	}
-
-	if ( !align_only && !true_rep_only && num_rep > 0 && enable_idr ) {
-		# reproducibility QC for IDR peaks
-		call reproducibility as reproducibility_idr { input :
-			prefix = 'idr',
-			peaks = select_all(idr.bfilt_idr_peak),
-			peaks_pr = idr_pr.bfilt_idr_peak,
-			peak_ppr = idr_ppr.bfilt_idr_peak,
-			peak_type = peak_type_,
-			chrsz = chrsz_,
-		}
-	}
-
-	# Generate final QC report and JSON
-	call qc_report { input :
-		pipeline_ver = pipeline_ver,
-		title = title,
-		description = description,
-		genome = genome_name_,
-		paired_ends = paired_end_,
-		ctl_paired_ends = ctl_paired_end_,
-		pipeline_type = pipeline_type,
-		aligner = aligner_,
-		peak_caller = peak_caller_,
-		cap_num_peak = cap_num_peak_,
-		idr_thresh = idr_thresh,
-		pval_thresh = pval_thresh,
-		xcor_trim_bp = xcor_trim_bp,
-		xcor_subsample_reads = xcor_subsample_reads,
-
-		samstat_qcs = select_all(align.samstat_qc),
-		nodup_samstat_qcs = select_all(filter.samstat_qc),
-		dup_qcs = select_all(filter.dup_qc),
-		lib_complexity_qcs = select_all(filter.lib_complexity_qc),
-		xcor_plots = select_all(xcor.plot_png),
-		xcor_scores = select_all(xcor.score),
-
-		ctl_samstat_qcs = select_all(align_ctl.samstat_qc),
-		ctl_nodup_samstat_qcs = select_all(filter_ctl.samstat_qc),
-		ctl_dup_qcs = select_all(filter_ctl.dup_qc),
-		ctl_lib_complexity_qcs = select_all(filter_ctl.lib_complexity_qc),
-
-		jsd_plot = jsd.plot,
-		jsd_qcs = jsd.jsd_qcs,
-
-		frip_qcs = select_all(call_peak.frip_qc),
-		frip_qcs_pr1 = select_all(call_peak_pr1.frip_qc),
-		frip_qcs_pr2 = select_all(call_peak_pr2.frip_qc),
-		frip_qc_pooled = call_peak_pooled.frip_qc,
-		frip_qc_ppr1 = call_peak_ppr1.frip_qc,
-		frip_qc_ppr2 = call_peak_ppr2.frip_qc,
-
-		idr_plots = select_all(idr.idr_plot),
-		idr_plots_pr = idr_pr.idr_plot,
-		idr_plot_ppr = idr_ppr.idr_plot,
-		frip_idr_qcs = select_all(idr.frip_qc),
-		frip_idr_qcs_pr = idr_pr.frip_qc,
-		frip_idr_qc_ppr = idr_ppr.frip_qc,
-		frip_overlap_qcs = select_all(overlap.frip_qc),
-		frip_overlap_qcs_pr = overlap_pr.frip_qc,
-		frip_overlap_qc_ppr = overlap_ppr.frip_qc,
-		idr_reproducibility_qc = reproducibility_idr.reproducibility_qc,
-		overlap_reproducibility_qc = reproducibility_overlap.reproducibility_qc,
-
-		gc_plots = select_all(gc_bias.gc_plot),
-
-		peak_region_size_qcs = select_all(call_peak.peak_region_size_qc),
-		peak_region_size_plots = select_all(call_peak.peak_region_size_plot),
-		num_peak_qcs = select_all(call_peak.num_peak_qc),
-
-		idr_opt_peak_region_size_qc = reproducibility_idr.peak_region_size_qc,
-		idr_opt_peak_region_size_plot = reproducibility_overlap.peak_region_size_plot,
-		idr_opt_num_peak_qc = reproducibility_idr.num_peak_qc,
-
-		overlap_opt_peak_region_size_qc = reproducibility_overlap.peak_region_size_qc,
-		overlap_opt_peak_region_size_plot = reproducibility_overlap.peak_region_size_plot,
-		overlap_opt_num_peak_qc = reproducibility_overlap.num_peak_qc,
-	}
-
-	output {
-		File report = qc_report.report
-		File qc_json = qc_report.qc_json
-		Boolean qc_json_ref_match = qc_report.qc_json_ref_match
-	}
+    String pipeline_ver = 'v1.4.0.1'
+
+    meta {
+        author: 'Jin wook Lee (leepc12@gmail.com) at ENCODE-DCC'
+        description: 'ENCODE TF/Histone ChIP-Seq pipeline'
+        specification_document: 'https://docs.google.com/document/d/1lG_Rd7fnYgRpSIqrIfuVlAz2dW1VaSQThzk836Db99c/edit?usp=sharing'
+
+        caper_docker: 'quay.io/encode-dcc/chip-seq-pipeline:v1.4.0.1'
+        caper_singularity: 'docker://quay.io/encode-dcc/chip-seq-pipeline:v1.4.0.1'
+        croo_out_def: 'https://storage.googleapis.com/encode-pipeline-output-definition/chip.croo.v4.json'
+    }
+    input {
+        # group: pipeline_metadata
+        String title = 'Untitled'
+        String description = 'No description'
+
+        # group: reference_genome
+        File? genome_tsv
+        String? genome_name
+        File? ref_fa
+        File? bwa_idx_tar
+        File? bowtie2_idx_tar
+        File? chrsz
+        File? blacklist
+        File? blacklist2
+        String? mito_chr_name
+        String? regex_bfilt_peak_chr_name
+        String? gensz
+        File? tss
+        File? dnase
+        File? prom
+        File? enh
+        File? reg2map
+        File? reg2map_bed
+        File? roadmap_meta
+
+        # group: input_genomic_data
+        Boolean? paired_end
+        Array[Boolean] paired_ends = []
+        Array[File] fastqs_rep1_R1 = []
+        Array[File] fastqs_rep1_R2 = []
+        Array[File] fastqs_rep2_R1 = []
+        Array[File] fastqs_rep2_R2 = []
+        Array[File] fastqs_rep3_R1 = []
+        Array[File] fastqs_rep3_R2 = []
+        Array[File] fastqs_rep4_R1 = []
+        Array[File] fastqs_rep4_R2 = []
+        Array[File] fastqs_rep5_R1 = []
+        Array[File] fastqs_rep5_R2 = []
+        Array[File] fastqs_rep6_R1 = []
+        Array[File] fastqs_rep6_R2 = []
+        Array[File] fastqs_rep7_R1 = []
+        Array[File] fastqs_rep7_R2 = []
+        Array[File] fastqs_rep8_R1 = []
+        Array[File] fastqs_rep8_R2 = []
+        Array[File] fastqs_rep9_R1 = []
+        Array[File] fastqs_rep9_R2 = []
+        Array[File] fastqs_rep10_R1 = []
+        Array[File] fastqs_rep10_R2 = []
+        Array[File?] bams = []
+        Array[File?] nodup_bams = []
+        Array[File?] tas = []
+        Array[File?] peaks = []
+        Array[File?] peaks_pr1 = []
+        Array[File?] peaks_pr2 = []
+        File? peak_ppr1
+        File? peak_ppr2
+        File? peak_pooled
+
+        Boolean? ctl_paired_end
+        Array[Boolean] ctl_paired_ends = []
+        Array[File] ctl_fastqs_rep1_R1 = []
+        Array[File] ctl_fastqs_rep1_R2 = []
+        Array[File] ctl_fastqs_rep2_R1 = []
+        Array[File] ctl_fastqs_rep2_R2 = []
+        Array[File] ctl_fastqs_rep3_R1 = []
+        Array[File] ctl_fastqs_rep3_R2 = []
+        Array[File] ctl_fastqs_rep4_R1 = []
+        Array[File] ctl_fastqs_rep4_R2 = []
+        Array[File] ctl_fastqs_rep5_R1 = []
+        Array[File] ctl_fastqs_rep5_R2 = []
+        Array[File] ctl_fastqs_rep6_R1 = []
+        Array[File] ctl_fastqs_rep6_R2 = []
+        Array[File] ctl_fastqs_rep7_R1 = []
+        Array[File] ctl_fastqs_rep7_R2 = []
+        Array[File] ctl_fastqs_rep8_R1 = []
+        Array[File] ctl_fastqs_rep8_R2 = []
+        Array[File] ctl_fastqs_rep9_R1 = []
+        Array[File] ctl_fastqs_rep9_R2 = []
+        Array[File] ctl_fastqs_rep10_R1 = []
+        Array[File] ctl_fastqs_rep10_R2 = []
+        Array[File?] ctl_bams = []
+        Array[File?] ctl_nodup_bams = []
+        Array[File?] ctl_tas = []
+
+        # group: pipeline_parameter
+        String pipeline_type
+        Boolean align_only = false
+        Boolean true_rep_only = false
+        Boolean enable_count_signal_track = false
+        Boolean enable_jsd = true
+        Boolean enable_gc_bias = true
+
+        # group: alignment
+        String aligner = 'bowtie2'
+        Boolean use_bwa_mem_for_pe = false
+        Int crop_length = 0
+        Int crop_length_tol = 2
+        Int xcor_trim_bp = 50
+        Boolean use_filt_pe_ta_for_xcor = false
+        String dup_marker = 'picard'
+        Boolean no_dup_removal = false
+        Int mapq_thresh = 30
+        Array[String] filter_chrs = []
+        Int subsample_reads = 0
+        Int ctl_subsample_reads = 0
+        Int ctl_depth_limit = 200000000
+        Float exp_ctl_depth_ratio_limit = 5.0
+
+        Int xcor_subsample_reads = 15000000
+        Int xcor_exclusion_range_min = -500
+        Int? xcor_exclusion_range_max
+
+        # group: peak_calling
+        Array[Int?] fraglen = []
+        String? peak_caller
+        Boolean always_use_pooled_ctl = false # always use pooled control for all exp rep.
+        Float ctl_depth_ratio = 1.2     # if ratio between controls is higher than this
+                                        # then always use pooled control for all exp rep.
+        Int? cap_num_peak
+        Float pval_thresh = 0.01        # p.value threshold (for MACS2 peak caller only)
+        Float fdr_thresh = 0.01            # FDR threshold (for SPP peak caller only: Rscript run_spp.R -fdr)
+        Float idr_thresh = 0.05            # IDR threshold
+
+        # group: resource_parameter
+        Int align_cpu = 4
+        Int align_mem_mb = 20000
+        Int align_time_hr = 48
+        String align_disks = 'local-disk 400 HDD'
+
+        Int filter_cpu = 2
+        Int filter_mem_mb = 20000
+        Int filter_time_hr = 24
+        String filter_disks = 'local-disk 400 HDD'
+
+        Int bam2ta_cpu = 2
+        Int bam2ta_mem_mb = 10000
+        Int bam2ta_time_hr = 6
+        String bam2ta_disks = 'local-disk 100 HDD'
+
+        Int spr_mem_mb = 16000
+
+        Int jsd_cpu = 2
+        Int jsd_mem_mb = 12000
+        Int jsd_time_hr = 6
+        String jsd_disks = 'local-disk 200 HDD'
+
+        Int xcor_cpu = 2
+        Int xcor_mem_mb = 16000    
+        Int xcor_time_hr = 24
+        String xcor_disks = 'local-disk 100 HDD'
+
+        Int macs2_signal_track_mem_mb = 16000
+        Int macs2_signal_track_time_hr = 24
+        String macs2_signal_track_disks = 'local-disk 400 HDD'
+
+        Int call_peak_cpu = 2
+        Int call_peak_mem_mb = 16000
+        Int call_peak_time_hr = 72
+        String call_peak_disks = 'local-disk 200 HDD'
+
+        String? align_trimmomatic_java_heap
+        String? filter_picard_java_heap
+        String? gc_bias_picard_java_heap
+    }
+
+    parameter_meta {
+        title: {
+            description: 'Experiment title.',
+            group: 'pipeline_metadata',
+        }
+        description: {
+            description: 'Experiment description.',
+            group: 'pipeline_metadata',
+        }
+        genome_tsv: {
+            description: 'Reference genome database TSV.',
+            group: 'reference_genome',
+            help: 'This TSV files includes all genome specific parameters (e.g. reference FASTA, bowtie2 index). You can still invidiaully define any parameters in it. Parameters defined in input JSON will override those defined in genome TSV.'
+        }
+        genome_name: {
+            description: 'Genome name.',
+            group: 'reference_genome'
+        }
+        ref_fa: {
+            description: 'Reference FASTA file.',
+            group: 'reference_genome'
+        }
+        ref_mito_fa: {
+            description: 'Reference FASTA file (mitochondrial reads only).',
+            group: 'reference_genome'
+        }
+        bowtie2_idx_tar: {
+            description: 'BWA index TAR file.',
+            group: 'reference_genome'
+        }
+        bowtie2_mito_idx_tar: {
+            description: 'BWA index TAR file (mitochondrial reads only).',
+            group: 'reference_genome'
+        }
+        chrsz: {
+            description: '2-col chromosome sizes file.',
+            group: 'reference_genome'
+        }
+        blacklist: {
+            description: 'Blacklist file in BED format.',
+            group: 'reference_genome',
+            help: 'Peaks will be filtered with this file.'
+        }
+        blacklist2: {
+            description: 'Secondary blacklist file in BED format.',
+            group: 'reference_genome',
+            help: 'If it is defined, it will be merged with chip.blacklist. Peaks will be filtered with merged blacklist.'
+        }
+        mito_chr_name: {
+            description: 'Mitochondrial chromosome name.',
+            group: 'reference_genome',
+            help: 'e.g. chrM, MT. Mitochondrial reads defined here will be filtered out during filtering BAMs in "filter" task.'
+        }
+        regex_bfilt_peak_chr_name: {
+            description: 'Reg-ex for chromosomes to keep while filtering peaks.',
+            group: 'reference_genome',
+            help: 'Chromosomes defined here will be kept. All other chromosomes will be filtered out in .bfilt. peak file. This is done along with blacklist filtering peak file.'
+        }
+        gensz: {
+            description: 'Genome sizes. "hs" for human, "mm" for mouse or sum of 2nd columnin chromosome sizes file.',
+            group: 'reference_genome'
+        }
+        tss: {
+            description: 'TSS file in BED format.',
+            group: 'reference_genome'
+        }
+        dnase: {
+            description: 'Open chromatin regions file in BED format.',
+            group: 'reference_genome'
+        }
+        prom: {
+            description: 'Promoter regions file in BED format.',
+            group: 'reference_genome'
+        }
+        enh: {
+            description: 'Enhancer regions file in BED format.',
+            group: 'reference_genome'
+        }
+        reg2map: {
+            description: 'Cell type signals file.',
+            group: 'reference_genome'
+        }
+        reg2map_bed: {
+            description: 'File of regions used to generate reg2map signals.',
+            group: 'reference_genome'
+        }
+        roadmap_meta: {
+            description: 'Roadmap metadata.',
+            group: 'reference_genome'
+        }
+        paired_end: {
+            description: 'Sequencing endedness.',
+            group: 'input_genomic_data',
+            help: 'Setting this on means that all replicates are paired ended. For mixed samples, use chip.paired_ends array instead.'
+        }
+        paired_ends: {
+            description: 'Sequencing endedness array (for mixed SE/PE datasets).',
+            group: 'input_genomic_data',
+            help: 'Whether each biological replicate is paired ended or not.'
+        }
+        fastqs_rep1_R1: {
+            description: 'Read1 FASTQs to be merged for a biological replicate 1.',
+            group: 'input_genomic_data',
+            help: 'Define if you want to start pipeline from FASTQs files. Pipeline can start from any type of inputs (e.g. FASTQs, BAMs, ...). Choose one type and fill paramters for that type and leave other undefined. Especially for FASTQs, we have individual variable for each biological replicate to allow FASTQs of technical replicates can be merged. Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep1_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep1_R1: {
+            description: 'Read2 FASTQs to be merged for a biological replicate 1.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep1_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep2_R1: {
+            description: 'Read1 FASTQs to be merged for a biological replicate 2.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep2_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep2_R1: {
+            description: 'Read2 FASTQs to be merged for a biological replicate 2.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep2_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep3_R1: {
+            description: 'Read1 FASTQs to be merged for a biological replicate 3.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep3_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep3_R1: {
+            description: 'Read2 FASTQs to be merged for a biological replicate 3.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep3_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep4_R1: {
+            description: 'Read1 FASTQs to be merged for a biological replicate 4.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep4_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep4_R1: {
+            description: 'Read2 FASTQs to be merged for a biological replicate 4.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep4_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep5_R1: {
+            description: 'Read1 FASTQs to be merged for a biological replicate 5.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep5_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep5_R1: {
+            description: 'Read2 FASTQs to be merged for a biological replicate 5.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep5_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep6_R1: {
+            description: 'Read1 FASTQs to be merged for a biological replicate 6.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep6_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep6_R1: {
+            description: 'Read2 FASTQs to be merged for a biological replicate 6.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep6_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep7_R1: {
+            description: 'Read1 FASTQs to be merged for a biological replicate 7.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep7_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep7_R2: {
+            description: 'Read2 FASTQs to be merged for a biological replicate 7.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep7_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep8_R1: {
+            description: 'Read1 FASTQs to be merged for a biological replicate 8.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep8_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep8_R2: {
+            description: 'Read2 FASTQs to be merged for a biological replicate 8.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep8_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep9_R1: {
+            description: 'Read1 FASTQs to be merged for a biological replicate 9.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep9_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep9_R2: {
+            description: 'Read2 FASTQs to be merged for a biological replicate 9.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep9_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep10_R1: {
+            description: 'Read1 FASTQs to be merged for a biological replicate 10.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep10_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep10_R2: {
+            description: 'Read2 FASTQs to be merged for a biological replicate 10.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep10_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        bams: {
+            description: 'List of unfiltered/raw BAM files for each biological replicate.',
+            group: 'input_genomic_data',
+            help: 'Define if you want to start pipeline from BAM files. Unfiltered/raw BAM file generated from aligner (e.g. bowtie2). Each entry for each biological replicate. e.g. [rep1.bam, rep2.bam, rep3.bam, ...].'
+        }
+        nodup_bams: {
+            description: 'List of filtered/deduped BAM files for each biological replicate',
+            group: 'input_genomic_data',
+            help: 'Define if you want to start pipeline from filtered BAM files. Filtered/deduped BAM file. Each entry for each biological replicate. e.g. [rep1.nodup.bam, rep2.nodup.bam, rep3.nodup.bam, ...].'
+        }
+        tas: {
+            description: 'List of TAG-ALIGN files for each biological replicate.',
+            group: 'input_genomic_data',
+            help: 'Define if you want to start pipeline from TAG-ALIGN files. TAG-ALIGN is in a 6-col BED format. It is a simplified version of BAM. Each entry for each biological replicate. e.g. [rep1.tagAlign.gz, rep2.tagAlign.gz, ...].'
+        }
+        peaks: {
+            description: 'List of NARROWPEAK files (not blacklist filtered) for each biological replicate.',
+            group: 'input_genomic_data',
+            help: 'Define if you want to start pipeline from PEAK files. Each entry for each biological replicate. e.g. [rep1.narrowPeak.gz, rep2.narrowPeak.gz, ...]. Define other PEAK parameters (e.g. chip.peaks_pr1, chip.peak_pooled) according to your flag settings (e.g. chip.true_rep_only) and number of replicates. If you have more than one replicate then define chip.peak_pooled, chip.peak_ppr1 and chip.peak_ppr2. If chip.true_rep_only flag is on then do not define any parameters (chip.peaks_pr1, chip.peaks_pr2, chip.peak_ppr1 and chip.peak_ppr2) related to pseudo replicates.'
+        }
+        peaks_pr1: {
+            description: 'List of NARROWPEAK files (not blacklist filtered) for pseudo-replicate 1 of each biological replicate.',
+            group: 'input_genomic_data',
+            help: 'Define if you want to start pipeline from PEAK files. Define if chip.true_rep_only flag is off.'
+        }
+        peaks_pr2: {
+            description: 'List of NARROWPEAK files (not blacklist filtered) for pseudo-replicate 2 of each biological replicate.',
+            group: 'input_genomic_data',
+            help: 'Define if you want to start pipeline from PEAK files. Define if chip.true_rep_only flag is off.'
+        }
+        peak_pooled: {
+            description: 'NARROWPEAK file for pooled true replicate.',
+            group: 'input_genomic_data',
+            help: 'Define if you want to start pipeline from PEAK files. Define if you have multiple biological replicates. Pooled true replicate means analysis on pooled biological replicates.'
+        }
+        peak_ppr1: {
+            description: 'NARROWPEAK file for pooled pseudo replicate 1.',
+            group: 'input_genomic_data',
+            help: 'Define if you want to start pipeline from PEAK files. Define if you have multiple biological replicates and chip.true_rep_only flag is off. PPR1 means analysis on pooled 1st pseudo replicates. Each biological replicate is shuf/split into two pseudos. This is a pooling of each replicate\'s 1st pseudos.'
+        }
+        peak_ppr2: {
+            description: 'NARROWPEAK file for pooled pseudo replicate 2.',
+            group: 'input_genomic_data',
+            help: 'Define if you want to start pipeline from PEAK files. Define if you have multiple biological replicates and chip.true_rep_only flag is off. PPR1 means analysis on pooled 2nd pseudo replicates. Each biological replicate is shuf/split into two pseudos. This is a pooling of each replicate\'s 2nd pseudos.'
+        }
+
+        ctl_paired_end: {
+            description: 'Sequencing endedness for all controls.',
+            group: 'input_genomic_data_control',
+            help: 'Setting this on means that all control replicates are paired ended. For mixed controls, use chip.ctl_paired_ends array instead.'
+        }
+        ctl_paired_ends: {
+            description: 'Sequencing endedness array for mixed SE/PE controls.',
+            group: 'input_genomic_data_control',
+            help: 'Whether each control replicate is paired ended or not.'
+        }
+        ctl_fastqs_rep1_R1: {
+            description: 'Read1 FASTQs to be merged for a control replicate 1.',
+            group: 'input_genomic_data_control',
+            help: 'Define if you want to start pipeline from FASTQs files. Pipeline can start from any type of controls (e.g. FASTQs, BAMs, ...). Choose one type and fill paramters for that type and leave other undefined.  Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep1_R2).'
+        }
+        ctl_fastqs_rep1_R1: {
+            description: 'Read2 FASTQs to be merged for a control replicate 1.',
+            group: 'input_genomic_data_control',
+            help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep1_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        ctl_fastqs_rep2_R1: {
+            description: 'Read1 FASTQs to be merged for a control replicate 2.',
+            group: 'input_genomic_data_control',
+            help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep2_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        ctl_fastqs_rep2_R1: {
+            description: 'Read2 FASTQs to be merged for a control replicate 2.',
+            group: 'input_genomic_data_control',
+            help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep2_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        ctl_fastqs_rep3_R1: {
+            description: 'Read1 FASTQs to be merged for a control replicate 3.',
+            group: 'input_genomic_data_control',
+            help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep3_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        ctl_fastqs_rep3_R1: {
+            description: 'Read2 FASTQs to be merged for a control replicate 3.',
+            group: 'input_genomic_data_control',
+            help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep3_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        ctl_fastqs_rep4_R1: {
+            description: 'Read1 FASTQs to be merged for a control replicate 4.',
+            group: 'input_genomic_data_control',
+            help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep4_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        ctl_fastqs_rep4_R1: {
+            description: 'Read2 FASTQs to be merged for a control replicate 4.',
+            group: 'input_genomic_data_control',
+            help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep4_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        ctl_fastqs_rep5_R1: {
+            description: 'Read1 FASTQs to be merged for a control replicate 5.',
+            group: 'input_genomic_data_control',
+            help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep5_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        ctl_fastqs_rep5_R1: {
+            description: 'Read2 FASTQs to be merged for a control replicate 5.',
+            group: 'input_genomic_data_control',
+            help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep5_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        ctl_fastqs_rep6_R1: {
+            description: 'Read1 FASTQs to be merged for a control replicate 6.',
+            group: 'input_genomic_data_control',
+            help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep6_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        ctl_fastqs_rep6_R1: {
+            description: 'Read2 FASTQs to be merged for a control replicate 6.',
+            group: 'input_genomic_data_control',
+            help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep6_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        ctl_fastqs_rep7_R1: {
+            description: 'Read1 FASTQs to be merged for a control replicate 7.',
+            group: 'input_genomic_data_control',
+            help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep7_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        ctl_fastqs_rep7_R2: {
+            description: 'Read2 FASTQs to be merged for a control replicate 7.',
+            group: 'input_genomic_data_control',
+            help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep7_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        ctl_fastqs_rep8_R1: {
+            description: 'Read1 FASTQs to be merged for a control replicate 8.',
+            group: 'input_genomic_data_control',
+            help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep8_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        ctl_fastqs_rep8_R2: {
+            description: 'Read2 FASTQs to be merged for a control replicate 8.',
+            group: 'input_genomic_data_control',
+            help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep8_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        ctl_fastqs_rep9_R1: {
+            description: 'Read1 FASTQs to be merged for a control replicate 9.',
+            group: 'input_genomic_data_control',
+            help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep9_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        ctl_fastqs_rep9_R2: {
+            description: 'Read2 FASTQs to be merged for a control replicate 9.',
+            group: 'input_genomic_data_control',
+            help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep9_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        ctl_fastqs_rep10_R1: {
+            description: 'Read1 FASTQs to be merged for a control replicate 10.',
+            group: 'input_genomic_data_control',
+            help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep10_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        ctl_fastqs_rep10_R2: {
+            description: 'Read2 FASTQs to be merged for a control replicate 10.',
+            group: 'input_genomic_data_control',
+            help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep10_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        ctl_bams: {
+            description: 'List of unfiltered/raw BAM files for each control replicate.',
+            group: 'input_genomic_data_control',
+            help: 'Define if you want to start pipeline from BAM files. Unfiltered/raw BAM file generated from aligner (e.g. bowtie2). Each entry for each control replicate. e.g. [ctl1.bam, ctl2.bam, ctl3.bam, ...].'
+        }
+        ctl_nodup_bams: {
+            description: 'List of filtered/deduped BAM files for each control replicate',
+            group: 'input_genomic_data_control',
+            help: 'Define if you want to start pipeline from filtered BAM files. Filtered/deduped BAM file. Each entry for each control replicate. e.g. [ctl1.nodup.bam, ctl2.nodup.bam, ctl3.nodup.bam, ...].'
+        }
+        ctl_tas: {
+            description: 'List of TAG-ALIGN files for each biological replicate.',
+            group: 'input_genomic_data_control',
+            help: 'Define if you want to start pipeline from TAG-ALIGN files. TAG-ALIGN is in a 6-col BED format. It is a simplified version of BAM. Each entry for each control replicate. e.g. [ctl1.tagAlign.gz, ctl2.tagAlign.gz, ...].'
+        }
+
+        pipeline_type: {
+            description: 'Pipeline type. tf for TF ChIP-Seq or histone for Histone ChIP-Seq.',
+            group: 'pipeline_parameter',
+            help: 'Default peak caller is different for each type. spp For TF ChIP-Seq and macs2 for histone ChIP-Seq. Regardless of pipeline type, spp always requires controls but macs2 doesn\'t.'
+        }
+        align_only: {
+            description: 'Align only mode.',
+            group: 'pipeline_parameter',
+            help: 'Reads will be aligned but there will be no peak-calling on them.'
+        }
+        true_rep_only: {
+            description: 'Disables all analyses related to pseudo-replicates.',
+            group: 'pipeline_parameter',
+            help: 'Pipeline generates 2 pseudo-replicate from one biological replicate. This flag turns off all analyses related to pseudos (with prefix/suffix pr, ppr).'
+        }
+        enable_count_signal_track: {
+            description: 'Enables generation of count signal tracks.',
+            group: 'pipeline_parameter'
+        }
+        enable_jsd: {
+            description: 'Enables Jensen-Shannon Distance (JSD) plot generation.',
+            group: 'pipeline_parameter'
+        }
+        enable_gc_bias: {
+            description: 'Enables GC bias calculation.',
+            group: 'pipeline_parameter'
+        }
+
+        aligner: {
+            description: 'Aligner. bowtie2 or bwa',
+            group: 'alignment',
+            help: 'It is bowtie2 by default.'
+        }
+        use_bwa_mem_for_pe: {
+            description: 'For paired end dataset with read length >= 70bp, use bwa mem instead of bwa aln.',
+            group: 'alignment',
+            help: 'Use it only for paired end reads >= 70bp.'
+        }
+        crop_length: {
+            description: 'Crop FASTQs\' reads longer than this length.',
+            group: 'alignment',
+            help: 'Also drop all reads shorter than chip.crop_length - chip.crop_length_tol.'
+        }
+        crop_length_tol: {
+            description: 'Tolerance for cropping reads in FASTQs.',
+            group: 'alignment',
+            help: 'Drop all reads shorter than chip.crop_length - chip.crop_length_tol. Activated only when chip.crop_length is defined.'
+        }
+        xcor_trim_bp: {
+            description: 'Trim experiment read1 FASTQ (for both SE and PE) for cross-correlation analysis.',
+            group: 'alignment',
+            help: 'This does not affect alignment of experimental/control replicates. Pipeline additionaly aligns R1 FASTQ only for cross-correlation analysis only. This parameter is used for it.'
+        }
+        use_filt_pe_ta_for_xcor: {
+            description: 'Use filtered PE BAM for cross-correlation analysis.',
+            group: 'alignment',
+            help: 'If not defined, pipeline uses SE BAM generated from trimmed read1 FASTQ for cross-correlation analysis.'
+        }
+        dup_marker: {
+            description: 'Marker for duplicate reads. picard or sambamba.',
+            group: 'alignment',
+            help: 'picard for Picard MarkDuplicates or sambamba for sambamba markdup.'
+        }
+        no_dup_removal: {
+            description: 'Disable removal of duplicate reads during filtering BAM.',
+            group: 'alignment',
+            help: 'Duplicate reads are filtererd out during filtering BAMs to gerenate NODUP_BAM. This flag will keep all duplicate reads in NODUP_BAM. This flag does not affect naming of NODUP_BAM. NODUP_BAM will still have .nodup. suffix in its filename.'
+        }
+        mapq_thresh: {
+            description: 'Threshold for low MAPQ reads removal',
+            group: 'alignment',
+            help: 'Low MAPQ reads are filtered out while filtering BAM.',
+        }
+        filter_chrs: {
+            description: 'List of chromosomes to be filtered out while filtering BAM.',
+            group: 'alignment',
+            help: 'It is empty by default, hence no filtering out of specfic chromosomes. It is case-sensitive. Use exact word for chromosome names.'
+        }
+        subsample_reads: {
+            description: 'Subsample reads. Shuffle and subsample reads.',
+            group: 'alignment',
+            help: 'This affects all downstream analyses after filtering experiment BAM. (e.g. all TAG-ALIGN files, peak-calling). Reads will be shuffled only if actual number of reads in BAM exceeds this number. 0 means disabled.'
+        }
+        ctl_subsample_reads: {
+            description: 'Subsample control reads. Shuffle and subsample control reads.',
+            group: 'alignment',
+            help: 'This affects all downstream analyses after filtering control BAM. (e.g. all TAG-ALIGN files, peak-calling). Reads will be shuffled only if actual number of reads in BAM exceeds this number. 0 means disabled.'
+        }
+
+        ctl_depth_limit: {
+            description: 'Hard limit for chosen control\'s depth.',
+            group: 'peak_calling',
+            help: 'If control chosen by chip.always_use_pooled_ctl and chip.ctl_depth_ratio is deeper than this hard limit, then such control is subsampled.'
+        }
+        exp_ctl_depth_ratio_limit: {
+            description: 'Second limit for chosen control\'s' depth.',
+            group: 'peak_calling',
+            help: 'If control chosen by chip.always_use_pooled_ctl and chip.ctl_depth_ratio is deeper than experiment replicate\'s read depth multiplied by this factor then such control is subsampled down to maximum of multiplied value and hard limit chip.ctl_depth_limit.'
+        }
+
+        xcor_subsample_reads: {
+            description: 'Subsample reads for cross-corrlelation analysis only.',
+            group: 'alignment',
+            help: 'This does not affect downstream analyses after filtering BAM. It is for cross-correlation analysis only.  0 means disabled.'
+        }
+
+        xcor_exclusion_range_min: {
+            description: 'Exclusion minimum for cross-correlation analysis.',
+            group: 'peak_calling',
+            help: 'For run_spp.R -s. Make sure that it is consistent with default strand shift -s=-500:5:1500 in run_spp.R.'
+        }
+        xcor_exclusion_range_max: {
+            description: 'Exclusion maximum for cross-coorrelation analysis.',
+            group: 'peak_calling',
+            help: 'For run_spp.R -s. If not defined default value of `max(read length + 10, 50)` for TF and `max(read_len + 10, 100)` for histone are used'
+        }
+        fraglen: {
+            description: 'Fragment length for each biological replicate.',
+            group: 'peak_calling',
+            help: 'Fragment length is estimated by cross-correlation analysis, which is valid only when pipeline started from FASTQs. If defined, fragment length estimated by cross-correlation analysis is ignored.'
+        }
+        peak_caller: {
+            description: 'Peak caller.',
+            group: 'peak_calling',
+            help: 'It is spp and macs2 by default for TF ChIP-seq and histone ChIP-seq, respectively. e.g. you can use macs2 for TF ChIP-Seq even though spp is by default for TF ChIP-Seq (chip.pipeline_type == tf).'
+        }
+        always_use_pooled_ctl: {
+            description: 'Always choose a pooled control for each experiment replicate.',
+            group: 'peak_calling',
+            help: 'If turned on, ignores chip.ctl_depth_ratio.'
+        }
+        ctl_depth_ratio: {
+            description: 'Maximum depth ratio between control replicates.',
+            group: 'peak_calling',
+            help: 'If ratio of depth between any two controls is higher than this, then always use a pooled control for all experiment replicates.'
+        }
+
+        cap_num_peak: {
+            description: 'Upper limit on the number of peaks.',
+            group: 'peak_calling',
+            help: 'It is 30000000 and 50000000 by default for spp and macs2, respectively.'
+        }
+        pval_thresh: {
+            description: 'p-value Threshold for MACS2 peak caller.',
+            group: 'peak_calling',
+            help: 'macs2 callpeak -p'
+        }
+        fdr_thresh: {
+            description: 'FDR threshold for spp peak caller (phantompeakqualtools).',
+            group: 'peak_calling',
+            help: 'run_spp.R -fdr='
+        }
+        idr_thresh: {
+            description: 'IDR threshold.',
+            group: 'peak_calling'
+        }
+
+        align_cpu: {
+            description: 'Number of cores for task align.',
+            group: 'resource_parameter',
+            help: 'Task align merges/crops/maps FASTQs.'
+        }
+        align_mem_mb: {
+            description: 'Memory (MB) required for task align.',
+            group: 'resource_parameter',
+            help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+        }
+        align_time_hr: {
+            description: 'Walltime (h) required for task align.',
+            group: 'resource_parameter',
+            help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+        }
+        align_disks: {
+            description: 'Persistent disk size to store intermediate files and outputs of task align.',
+            group: 'resource_parameter',
+            help: 'This is for GCP/AWS only.'
+        }
+        filter_cpu: {
+            description: 'Number of cores for task filter.',
+            group: 'resource_parameter',
+            help: 'Task filter filters raw/unfilterd BAM to get filtered/deduped BAM.'
+        }
+        filter_mem_mb: {
+            description: 'Memory (MB) required for task filter.',
+            group: 'resource_parameter',
+            help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+        }
+        filter_time_hr: {
+            description: 'Walltime (h) required for task filter.',
+            group: 'resource_parameter',
+            help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+        }
+        filter_disks: {
+            description: 'Persistent disk size to store intermediate files and outputs of task filter.',
+            group: 'resource_parameter',
+            help: 'This is for GCP/AWS only.'
+        }
+        bam2ta_cpu: {
+            description: 'Number of cores for task bam2ta.',
+            group: 'resource_parameter',
+            help: 'Task bam2ta converts filtered/deduped BAM in to TAG-ALIGN (6-col BED) format.'
+        }
+        bam2ta_mem_mb: {
+            description: 'Memory (MB) required for task bam2ta.',
+            group: 'resource_parameter',
+            help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+        }
+        bam2ta_time_hr: {
+            description: 'Walltime (h) required for task bam2ta.',
+            group: 'resource_parameter',
+            help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+        }
+        bam2ta_disks: {
+            description: 'Persistent disk size to store intermediate files and outputs of task bam2ta.',
+            group: 'resource_parameter',
+            help: 'This is for GCP/AWS only.'
+        }
+        spr_mem_mb: {
+            description: 'Memory (MB) required for task spr.',
+            group: 'resource_parameter',
+            help: 'Task spr generates two pseudo-replicates from each biological replicate. This task uses Unix shuf/sort, which can take significant amount of memory.'
+        }
+        jsd_cpu: {
+            description: 'Number of cores for task jsd.',
+            group: 'resource_parameter',
+            help: 'Task jsd plots Jensen-Shannon distance and metrics related to it.'
+        }
+        jsd_mem_mb: {
+            description: 'Memory (MB) required for task jsd.',
+            group: 'resource_parameter',
+            help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+        }
+        jsd_time_hr: {
+            description: 'Walltime (h) required for task jsd.',
+            group: 'resource_parameter',
+            help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+        }
+        jsd_disks: {
+            description: 'Persistent disk size to store intermediate files and outputs of task jsd.',
+            group: 'resource_parameter',
+            help: 'This is for GCP/AWS only.'
+        }
+        xcor_cpu: {
+            description: 'Number of cores for task xcor.',
+            group: 'resource_parameter',
+            help: 'Task xcor does cross-correlation analysis (including a plot) on subsampled TAG-ALIGNs.'
+        }
+        xcor_mem_mb: {
+            description: 'Memory (MB) required for task xcor.',
+            group: 'resource_parameter',
+            help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+        }
+        xcor_time_hr: {
+            description: 'Walltime (h) required for task xcor.',
+            group: 'resource_parameter',
+            help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+        }
+        xcor_disks: {
+            description: 'Persistent disk size to store intermediate files and outputs of task xcor.',
+            group: 'resource_parameter',
+            help: 'This is for GCP/AWS only.'
+        }
+        call_peak_cpu: {
+            description: 'Number of cores for task call_peak.',
+            group: 'resource_parameter',
+            help: 'Task call_peak call peaks on TAG-ALIGNs by using MACS2 peak caller.'
+        }
+        call_peak_mem_mb: {
+            description: 'Memory (MB) required for task call_peak.',
+            group: 'resource_parameter',
+            help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+        }
+        call_peak_time_hr: {
+            description: 'Walltime (h) required for task call_peak.',
+            group: 'resource_parameter',
+            help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+        }
+        call_peak_disks: {
+            description: 'Persistent disk size to store intermediate files and outputs of task call_peak.',
+            group: 'resource_parameter',
+            help: 'This is for GCP/AWS only.'
+        }
+        macs2_signal_track_mem_mb: {
+            description: 'Memory (MB) required for task macs2_signal_track.',
+            group: 'resource_parameter',
+            help: 'Task macs2_signal_track_mem_mb uses MACS2 to get signal tracks for p-val (suffixed with .pval.) and fold enrichment (suffixed with .fc.). This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+        }
+        macs2_signal_track_time_hr: {
+            description: 'Walltime (h) required for task macs2_signal_track.',
+            group: 'resource_parameter',
+            help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+        }
+        macs2_signal_track_disks: {
+            description: 'Persistent disk size to store intermediate files and outputs of task macs2_signal_track.',
+            group: 'resource_parameter',
+            help: 'This is for GCP/AWS only.'
+        }
+        align_trimmomatic_java_heap: {
+            description: 'Maximum Java heap (java -Xmx) in task align.',
+            group: 'resource_parameter',
+            help: 'Maximum memory for Trimmomatic. If not defined, 90% of align_mem_mb will be used.'
+        }
+        filter_picard_java_heap: {
+            description: 'Maximum Java heap (java -Xmx) in task filter.',
+            group: 'resource_parameter',
+            help: 'Maximum memory for Picard tools MarkDuplicates. If not defined, 90% of filter_mem_mb will be used.'
+        }
+        gc_bias_picard_java_heap: {
+            description: 'Maximum Java heap (java -Xmx) in task gc_bias.',
+            group: 'resource_parameter',
+            help: 'Maximum memory for Picard tools CollectGcBiasMetrics. If not defined, 90% of 10000 MB will be used.'
+        }
+    }
+
+    # read genome data and paths
+    if ( defined(genome_tsv) ) {
+        call read_genome_tsv { input: genome_tsv = genome_tsv }
+    }
+    File ref_fa_ = select_first([ref_fa, read_genome_tsv.ref_fa])
+    File? bwa_idx_tar_ = if defined(bwa_idx_tar) then bwa_idx_tar
+        else read_genome_tsv.bwa_idx_tar
+    File bowtie2_idx_tar_ = select_first([bowtie2_idx_tar, read_genome_tsv.bowtie2_idx_tar])
+    File chrsz_ = select_first([chrsz, read_genome_tsv.chrsz])
+    String gensz_ = select_first([gensz, read_genome_tsv.gensz])
+    File? blacklist1_ = if defined(blacklist) then blacklist
+        else read_genome_tsv.blacklist
+    File? blacklist2_ = if defined(blacklist2) then blacklist2
+        else read_genome_tsv.blacklist2
+    # merge multiple blacklists
+    # two blacklists can have different number of columns (3 vs 6)
+    # so we limit merged blacklist's columns to 3
+    Array[File] blacklists = select_all([blacklist1_, blacklist2_])
+    if ( length(blacklists) > 1 ) {
+        call pool_ta as pool_blacklist { input:
+            tas = blacklists,
+            col = 3,
+        }
+    }
+    File? blacklist_ = if length(blacklists) > 1 then pool_blacklist.ta_pooled
+        else if length(blacklists) > 0 then blacklists[0]
+        else blacklist2_
+    String mito_chr_name_ = select_first([mito_chr_name, read_genome_tsv.mito_chr_name])
+    String regex_bfilt_peak_chr_name_ = select_first([regex_bfilt_peak_chr_name, read_genome_tsv.regex_bfilt_peak_chr_name])
+    String genome_name_ = select_first([genome_name, read_genome_tsv.genome_name, basename(chrsz_)])
+
+    # read additional annotation data
+    File? tss_ = if defined(tss) then tss
+        else read_genome_tsv.tss
+    File? dnase_ = if defined(dnase) then dnase
+        else read_genome_tsv.dnase
+    File? prom_ = if defined(prom) then prom
+        else read_genome_tsv.prom
+    File? enh_ = if defined(enh) then enh
+        else read_genome_tsv.enh
+    File? reg2map_ = if defined(reg2map) then reg2map
+        else read_genome_tsv.reg2map
+    File? reg2map_bed_ = if defined(reg2map_bed) then reg2map_bed
+        else read_genome_tsv.reg2map_bed
+    File? roadmap_meta_ = if defined(roadmap_meta) then roadmap_meta
+        else read_genome_tsv.roadmap_meta
+
+    ### temp vars (do not define these)
+    String aligner_ = aligner
+    String peak_caller_ = if pipeline_type=='tf' then select_first([peak_caller, 'spp'])
+                        else select_first([peak_caller, 'macs2'])
+    String peak_type_ = if peak_caller_=='spp' then 'regionPeak'
+                        else 'narrowPeak'
+    Boolean enable_idr = pipeline_type=='tf' # enable_idr for TF chipseq only
+    String idr_rank_ = if peak_caller_=='spp' then 'signal.value'
+                        else if peak_caller_=='macs2' then 'p.value'
+                        else 'p.value'
+    Int cap_num_peak_spp = 300000
+    Int cap_num_peak_macs2 = 500000                        
+    Int cap_num_peak_ = if peak_caller_ == 'spp' then select_first([cap_num_peak, cap_num_peak_spp])
+        else select_first([cap_num_peak, cap_num_peak_macs2])
+    Int mapq_thresh_ = mapq_thresh
+
+    # temporary 2-dim fastqs array [rep_id][merge_id]
+    Array[Array[File]] fastqs_R1 = 
+        if length(fastqs_rep10_R1)>0 then
+            [fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1, fastqs_rep5_R1,
+            fastqs_rep6_R1, fastqs_rep7_R1, fastqs_rep8_R1, fastqs_rep9_R1, fastqs_rep10_R1]
+        else if length(fastqs_rep9_R1)>0 then
+            [fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1, fastqs_rep5_R1,
+            fastqs_rep6_R1, fastqs_rep7_R1, fastqs_rep8_R1, fastqs_rep9_R1]
+        else if length(fastqs_rep8_R1)>0 then
+            [fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1, fastqs_rep5_R1,
+            fastqs_rep6_R1, fastqs_rep7_R1, fastqs_rep8_R1]
+        else if length(fastqs_rep7_R1)>0 then
+            [fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1, fastqs_rep5_R1,
+            fastqs_rep6_R1, fastqs_rep7_R1]
+        else if length(fastqs_rep6_R1)>0 then
+            [fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1, fastqs_rep5_R1,
+            fastqs_rep6_R1]
+        else if length(fastqs_rep5_R1)>0 then
+            [fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1, fastqs_rep5_R1]
+        else if length(fastqs_rep4_R1)>0 then
+            [fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1]
+        else if length(fastqs_rep3_R1)>0 then
+            [fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1]
+        else if length(fastqs_rep2_R1)>0 then
+            [fastqs_rep1_R1, fastqs_rep2_R1]
+        else if length(fastqs_rep1_R1)>0 then
+            [fastqs_rep1_R1]
+        else []
+    # no need to do that for R2 (R1 array will be used to determine presense of fastq for each rep)
+    Array[Array[File]] fastqs_R2 = 
+        [fastqs_rep1_R2, fastqs_rep2_R2, fastqs_rep3_R2, fastqs_rep4_R2, fastqs_rep5_R2,
+        fastqs_rep6_R2, fastqs_rep7_R2, fastqs_rep8_R2, fastqs_rep9_R2, fastqs_rep10_R2]
+
+    # temporary 2-dim ctl fastqs array [rep_id][merge_id]
+    Array[Array[File]] ctl_fastqs_R1 = 
+        if length(ctl_fastqs_rep10_R1)>0 then
+            [ctl_fastqs_rep1_R1, ctl_fastqs_rep2_R1, ctl_fastqs_rep3_R1, ctl_fastqs_rep4_R1, ctl_fastqs_rep5_R1,
+            ctl_fastqs_rep6_R1, ctl_fastqs_rep7_R1, ctl_fastqs_rep8_R1, ctl_fastqs_rep9_R1, ctl_fastqs_rep10_R1]
+        else if length(ctl_fastqs_rep9_R1)>0 then
+            [ctl_fastqs_rep1_R1, ctl_fastqs_rep2_R1, ctl_fastqs_rep3_R1, ctl_fastqs_rep4_R1, ctl_fastqs_rep5_R1,
+            ctl_fastqs_rep6_R1, ctl_fastqs_rep7_R1, ctl_fastqs_rep8_R1, ctl_fastqs_rep9_R1]
+        else if length(ctl_fastqs_rep8_R1)>0 then
+            [ctl_fastqs_rep1_R1, ctl_fastqs_rep2_R1, ctl_fastqs_rep3_R1, ctl_fastqs_rep4_R1, ctl_fastqs_rep5_R1,
+            ctl_fastqs_rep6_R1, ctl_fastqs_rep7_R1, ctl_fastqs_rep8_R1]
+        else if length(ctl_fastqs_rep7_R1)>0 then
+            [ctl_fastqs_rep1_R1, ctl_fastqs_rep2_R1, ctl_fastqs_rep3_R1, ctl_fastqs_rep4_R1, ctl_fastqs_rep5_R1,
+            ctl_fastqs_rep6_R1, ctl_fastqs_rep7_R1]
+        else if length(ctl_fastqs_rep6_R1)>0 then
+            [ctl_fastqs_rep1_R1, ctl_fastqs_rep2_R1, ctl_fastqs_rep3_R1, ctl_fastqs_rep4_R1, ctl_fastqs_rep5_R1,
+            ctl_fastqs_rep6_R1]
+        else if length(ctl_fastqs_rep5_R1)>0 then
+            [ctl_fastqs_rep1_R1, ctl_fastqs_rep2_R1, ctl_fastqs_rep3_R1, ctl_fastqs_rep4_R1, ctl_fastqs_rep5_R1]
+        else if length(ctl_fastqs_rep4_R1)>0 then
+            [ctl_fastqs_rep1_R1, ctl_fastqs_rep2_R1, ctl_fastqs_rep3_R1, ctl_fastqs_rep4_R1]
+        else if length(ctl_fastqs_rep3_R1)>0 then
+            [ctl_fastqs_rep1_R1, ctl_fastqs_rep2_R1, ctl_fastqs_rep3_R1]
+        else if length(ctl_fastqs_rep2_R1)>0 then
+            [ctl_fastqs_rep1_R1, ctl_fastqs_rep2_R1]
+        else if length(ctl_fastqs_rep1_R1)>0 then
+            [ctl_fastqs_rep1_R1]
+        else []
+    # no need to do that for R2 (R1 array will be used to determine presense of fastq for each rep)
+    Array[Array[File]] ctl_fastqs_R2 = 
+        [ctl_fastqs_rep1_R2, ctl_fastqs_rep2_R2, ctl_fastqs_rep3_R2, ctl_fastqs_rep4_R2, ctl_fastqs_rep5_R2,
+        ctl_fastqs_rep6_R2, ctl_fastqs_rep7_R2, ctl_fastqs_rep8_R2, ctl_fastqs_rep9_R2, ctl_fastqs_rep10_R2]
+
+    # temporary variables to get number of replicates
+    #     WDLic implementation of max(A,B,C,...)
+    Int num_rep_fastq = length(fastqs_R1)
+    Int num_rep_bam = if length(bams)<num_rep_fastq then num_rep_fastq
+        else length(bams)
+    Int num_rep_nodup_bam = if length(nodup_bams)<num_rep_bam then num_rep_bam
+        else length(nodup_bams)
+    Int num_rep_ta = if length(tas)<num_rep_nodup_bam then num_rep_nodup_bam
+        else length(tas)
+    Int num_rep_peak = if length(peaks)<num_rep_ta then num_rep_ta
+        else length(peaks)
+    Int num_rep = num_rep_peak
+
+    # temporary variables to get number of controls
+    Int num_ctl_fastq = length(ctl_fastqs_R1)
+    Int num_ctl_bam = if length(ctl_bams)<num_ctl_fastq then num_ctl_fastq
+        else length(ctl_bams)
+    Int num_ctl_nodup_bam = if length(ctl_nodup_bams)<num_ctl_bam then num_ctl_bam
+        else length(ctl_nodup_bams)
+    Int num_ctl_ta = if length(ctl_tas)<num_ctl_nodup_bam then num_ctl_nodup_bam
+        else length(ctl_tas)
+    Int num_ctl = num_ctl_ta
+
+    # sanity check for inputs
+    if ( num_rep == 0 && num_ctl == 0 ) {
+        call raise_exception as error_input_data { input:
+            msg = 'No FASTQ/BAM/TAG-ALIGN/PEAK defined in your input JSON. Check if your FASTQs are defined as "chip.fastqs_repX_RY". DO NOT MISS suffix _R1 even for single ended FASTQ.'
+        }
+    }
+    if ( !align_only && peak_caller_ == 'spp' && num_ctl == 0 ) {
+        call raise_exception as error_control_required { input:
+            msg = 'SPP requires control inputs. Define control input files ("chip.ctl_*") in an input JSON file.'
+        }
+    }
+    if ( (num_rep_fastq > 0 || num_ctl_fastq > 0) && aligner_ != 'bwa' && aligner_ != 'bowtie2' ) {
+        call raise_exception as error_wrong_aligner { input:
+            msg = 'Choose chip.aligner between bwa and bowtie2.'
+        }
+    }
+    if ( aligner_ != 'bwa' && use_bwa_mem_for_pe ) {
+        call raise_exception as error_use_bwa_mem_for_non_bwa { input:
+            msg = 'To use chip.use_bwa_mem_for_pe, choose bwa for chip.aligner.'
+        }
+    }    
+    if ( ( ctl_depth_limit > 0 || exp_ctl_depth_ratio_limit > 0 ) && num_ctl > 1 && length(ctl_paired_ends) > 1  ) {
+        call raise_exception as error_subsample_pooled_control_with_mixed_endedness { input:
+            msg = 'Cannot use automatic control subsampling ("chip.ctl_depth_limit">0 and "chip.exp_ctl_depth_limit">0) for ' +
+                  'multiple controls with mixed endedness (e.g. SE ctl-rep1 and PE ctl-rep2). ' +
+                  'Automatic control subsampling is enabled by default. ' +
+                  'Disable automatic control subsampling by explicitly defining the above two parameters as 0 in your input JSON file. ' +
+                  'You can still use manual control subsamping ("chip.ctl_subsample_reads">0) since it is done ' +
+                  'for individual control\'s TAG-ALIGN output according to each control\'s endedness. '
+        }
+    }
+
+    # align each replicate
+    scatter(i in range(num_rep)) {
+        # to override endedness definition for individual replicate
+        #     paired_end will override paired_ends[i]
+        Boolean paired_end_ = if !defined(paired_end) && i<length(paired_ends) then paired_ends[i]
+            else select_first([paired_end])
+
+        Boolean has_input_of_align = i<length(fastqs_R1) && length(fastqs_R1[i])>0
+        Boolean has_output_of_align = i<length(bams) && defined(bams[i])
+        if ( has_input_of_align && !has_output_of_align ) {
+            call align { input :
+                fastqs_R1 = fastqs_R1[i],
+                fastqs_R2 = fastqs_R2[i],
+                crop_length = crop_length,
+                crop_length_tol = crop_length_tol,
+
+                aligner = aligner_,
+                mito_chr_name = mito_chr_name_,
+                idx_tar = if aligner=='bwa' then bwa_idx_tar_
+                    else bowtie2_idx_tar_,
+                paired_end = paired_end_,
+                use_bwa_mem_for_pe = use_bwa_mem_for_pe,
+
+                trimmomatic_java_heap = align_trimmomatic_java_heap,
+                cpu = align_cpu,
+                mem_mb = align_mem_mb,
+                time_hr = align_time_hr,
+                disks = align_disks,
+            }
+        }
+        File? bam_ = if has_output_of_align then bams[i] else align.bam
+
+        Boolean has_input_of_filter = has_output_of_align || defined(align.bam)
+        Boolean has_output_of_filter = i<length(nodup_bams) && defined(nodup_bams[i])
+        # skip if we already have output of this step
+        if ( has_input_of_filter && !has_output_of_filter ) {
+            call filter { input :
+                bam = bam_,
+                paired_end = paired_end_,
+                dup_marker = dup_marker,
+                mapq_thresh = mapq_thresh_,
+                filter_chrs = filter_chrs,
+                chrsz = chrsz_,
+                no_dup_removal = no_dup_removal,
+                mito_chr_name = mito_chr_name_,
+
+                cpu = filter_cpu,
+                mem_mb = filter_mem_mb,
+                picard_java_heap = filter_picard_java_heap,
+                time_hr = filter_time_hr,
+                disks = filter_disks,
+            }
+        }
+        File? nodup_bam_ = if has_output_of_filter then nodup_bams[i] else filter.nodup_bam
+
+        Boolean has_input_of_bam2ta = has_output_of_filter || defined(filter.nodup_bam)
+        Boolean has_output_of_bam2ta = i<length(tas) && defined(tas[i])
+        if ( has_input_of_bam2ta && !has_output_of_bam2ta ) {
+            call bam2ta { input :
+                bam = nodup_bam_,
+                subsample = subsample_reads,
+                paired_end = paired_end_,
+                mito_chr_name = mito_chr_name_,
+
+                cpu = bam2ta_cpu,
+                mem_mb = bam2ta_mem_mb,
+                time_hr = bam2ta_time_hr,
+                disks = bam2ta_disks,
+            }
+        }
+        File? ta_ = if has_output_of_bam2ta then tas[i] else bam2ta.ta
+
+        Boolean has_input_of_spr = has_output_of_bam2ta || defined(bam2ta.ta)
+        if ( has_input_of_spr && !align_only && !true_rep_only ) {
+            call spr { input :
+                ta = ta_,
+                paired_end = paired_end_,
+                mem_mb = spr_mem_mb,
+            }
+        }
+
+        Boolean has_input_of_count_signal_track = has_output_of_bam2ta || defined(bam2ta.ta)
+        if ( has_input_of_count_signal_track && enable_count_signal_track ) {
+            # generate count signal track
+            call count_signal_track { input :
+                ta = ta_,
+                chrsz = chrsz_,
+            }
+        }
+
+        if ( enable_gc_bias && defined(nodup_bam_) && defined(ref_fa_) ) {
+            call gc_bias { input :
+                nodup_bam = nodup_bam_,
+                ref_fa = ref_fa_,
+                picard_java_heap = gc_bias_picard_java_heap,
+            }
+        }
+
+        # special trimming/mapping for xcor (when starting from FASTQs)
+        if ( has_input_of_align ) {
+            call align as align_R1 { input :
+                fastqs_R1 = fastqs_R1[i],
+                fastqs_R2 = [],
+                trim_bp = xcor_trim_bp,
+                crop_length = 0,
+                crop_length_tol = 0,
+
+                aligner = aligner_,
+                mito_chr_name = mito_chr_name_,
+                idx_tar = if aligner=='bwa' then bwa_idx_tar_
+                    else bowtie2_idx_tar_,
+                paired_end = false,
+                use_bwa_mem_for_pe = use_bwa_mem_for_pe,
+
+                cpu = align_cpu,
+                mem_mb = align_mem_mb,
+                time_hr = align_time_hr,
+                disks = align_disks,
+            }
+            # no bam deduping for xcor
+            call filter as filter_R1 { input :
+                bam = align_R1.bam,
+                paired_end = false,
+                dup_marker = dup_marker,
+                mapq_thresh = mapq_thresh_,
+                filter_chrs = filter_chrs,
+                chrsz = chrsz_,
+                no_dup_removal = true,
+                mito_chr_name = mito_chr_name_,
+
+                cpu = filter_cpu,
+                mem_mb = filter_mem_mb,
+                picard_java_heap = filter_picard_java_heap,
+                time_hr = filter_time_hr,
+                disks = filter_disks,
+            }
+            call bam2ta as bam2ta_no_dedup_R1 { input :
+                bam = filter_R1.nodup_bam,  # it's named as nodup bam but it's not deduped but just filtered
+                paired_end = false,
+                subsample = 0,
+                mito_chr_name = mito_chr_name_,
+
+                cpu = bam2ta_cpu,
+                mem_mb = bam2ta_mem_mb,
+                time_hr = bam2ta_time_hr,
+                disks = bam2ta_disks,
+            }
+        }
+
+        # special trimming/mapping for xcor (when starting from BAMs)
+        Boolean has_input_of_bam2ta_no_dedup = (has_output_of_align || defined(align.bam))
+            && !defined(bam2ta_no_dedup_R1.ta)
+        if ( has_input_of_bam2ta_no_dedup ) {
+            call filter as filter_no_dedup { input :
+                bam = bam_,
+                paired_end = paired_end_,
+                dup_marker = dup_marker,
+                mapq_thresh = mapq_thresh_,
+                filter_chrs = filter_chrs,
+                chrsz = chrsz_,
+                no_dup_removal = true,
+                mito_chr_name = mito_chr_name_,
+
+                cpu = filter_cpu,
+                mem_mb = filter_mem_mb,
+                picard_java_heap = filter_picard_java_heap,
+                time_hr = filter_time_hr,
+                disks = filter_disks,
+            }
+            call bam2ta as bam2ta_no_dedup { input :
+                bam = filter_no_dedup.nodup_bam,  # output name is nodup but it's not deduped
+                paired_end = paired_end_,
+                subsample = 0,
+                mito_chr_name = mito_chr_name_,
+
+                cpu = bam2ta_cpu,
+                mem_mb = bam2ta_mem_mb,
+                time_hr = bam2ta_time_hr,
+                disks = bam2ta_disks,
+            }
+        }
+
+        # use trimmed/unfilitered R1 tagAlign for paired end dataset
+        # if not starting from fastqs, keep using old method
+        #  (mapping with both ends for tag-aligns to be used for xcor)
+        # subsample tagalign (non-mito) and cross-correlation analysis
+        File? ta_xcor = if defined(bam2ta_no_dedup_R1.ta) then bam2ta_no_dedup_R1.ta
+            else if defined(bam2ta_no_dedup.ta) then bam2ta_no_dedup.ta
+            else ta_
+        Boolean paired_end_xcor = if defined(bam2ta_no_dedup_R1.ta) then false
+            else paired_end_
+
+        Boolean has_input_of_xcor = defined(ta_xcor)
+        if ( has_input_of_xcor ) {
+            call xcor { input :
+                ta = ta_xcor,
+                paired_end = paired_end_xcor,
+                subsample = xcor_subsample_reads,
+                mito_chr_name = mito_chr_name_,
+                chip_seq_type = pipeline_type,
+                exclusion_range_min = xcor_exclusion_range_min,
+                exclusion_range_max = xcor_exclusion_range_max,
+                cpu = xcor_cpu,
+                mem_mb = xcor_mem_mb,
+                time_hr = xcor_time_hr,
+                disks = xcor_disks,
+            }
+        }
+
+        # before peak calling, get fragment length from xcor analysis or given input
+        # if fraglen [] is defined in the input JSON, fraglen from xcor will be ignored
+        Int? fraglen_ = if i<length(fraglen) && defined(fraglen[i]) then fraglen[i]
+            else xcor.fraglen
+    }
+
+    # align each control
+    scatter(i in range(num_ctl)) {
+        # to override endedness definition for individual control
+        #     ctl_paired_end will override ctl_paired_ends[i]
+        Boolean ctl_paired_end_ = if !defined(ctl_paired_end) && i<length(ctl_paired_ends) then ctl_paired_ends[i]
+            else select_first([ctl_paired_end, paired_end])
+
+        Boolean has_input_of_align_ctl = i<length(ctl_fastqs_R1) && length(ctl_fastqs_R1[i])>0
+        Boolean has_output_of_align_ctl = i<length(ctl_bams) && defined(ctl_bams[i])
+        if ( has_input_of_align_ctl && !has_output_of_align_ctl ) {
+            call align as align_ctl { input :
+                fastqs_R1 = ctl_fastqs_R1[i],
+                fastqs_R2 = ctl_fastqs_R2[i],
+                crop_length = crop_length,
+                crop_length_tol = crop_length_tol,
+
+                aligner = aligner_,
+                mito_chr_name = mito_chr_name_,
+                idx_tar = if aligner=='bwa' then bwa_idx_tar_
+                    else bowtie2_idx_tar_,
+                paired_end = ctl_paired_end_,
+                use_bwa_mem_for_pe = use_bwa_mem_for_pe,
+
+                trimmomatic_java_heap = align_trimmomatic_java_heap,
+                cpu = align_cpu,
+                mem_mb = align_mem_mb,
+                time_hr = align_time_hr,
+                disks = align_disks,
+            }
+        }
+        File? ctl_bam_ = if has_output_of_align_ctl then ctl_bams[i] else align_ctl.bam
+
+        Boolean has_input_of_filter_ctl = has_output_of_align_ctl || defined(align_ctl.bam)
+        Boolean has_output_of_filter_ctl = i<length(ctl_nodup_bams) && defined(ctl_nodup_bams[i])
+        # skip if we already have output of this step
+        if ( has_input_of_filter_ctl && !has_output_of_filter_ctl ) {
+            call filter as filter_ctl { input :
+                bam = ctl_bam_,
+                paired_end = ctl_paired_end_,
+                dup_marker = dup_marker,
+                mapq_thresh = mapq_thresh_,
+                filter_chrs = filter_chrs,
+                chrsz = chrsz_,
+                no_dup_removal = no_dup_removal,
+                mito_chr_name = mito_chr_name_,
+
+                cpu = filter_cpu,
+                mem_mb = filter_mem_mb,
+                picard_java_heap = filter_picard_java_heap,
+                time_hr = filter_time_hr,
+                disks = filter_disks,
+            }
+        }
+        File? ctl_nodup_bam_ = if has_output_of_filter_ctl then ctl_nodup_bams[i] else filter_ctl.nodup_bam
+
+        Boolean has_input_of_bam2ta_ctl = has_output_of_filter_ctl || defined(filter_ctl.nodup_bam)
+        Boolean has_output_of_bam2ta_ctl = i<length(ctl_tas) && defined(ctl_tas[i])
+        if ( has_input_of_bam2ta_ctl && !has_output_of_bam2ta_ctl ) {
+            call bam2ta as bam2ta_ctl { input :
+                bam = ctl_nodup_bam_,
+                subsample = subsample_reads,
+                paired_end = ctl_paired_end_,
+                mito_chr_name = mito_chr_name_,
+
+                cpu = bam2ta_cpu,
+                mem_mb = bam2ta_mem_mb,
+                time_hr = bam2ta_time_hr,
+                disks = bam2ta_disks,
+            }
+        }
+        File? ctl_ta_ = if has_output_of_bam2ta_ctl then ctl_tas[i] else bam2ta_ctl.ta
+    }
+
+    # if there are TAs for ALL replicates then pool them
+    Boolean has_all_inputs_of_pool_ta = length(select_all(ta_))==num_rep
+    if ( has_all_inputs_of_pool_ta && num_rep>1 ) {
+        # pool tagaligns from true replicates
+        call pool_ta { input :
+            tas = ta_,
+            prefix = 'rep',
+        }
+    }
+
+    # if there are pr1 TAs for ALL replicates then pool them
+    Boolean has_all_inputs_of_pool_ta_pr1 = length(select_all(spr.ta_pr1))==num_rep
+    if ( has_all_inputs_of_pool_ta_pr1 && num_rep>1 && !align_only && !true_rep_only ) {
+        # pool tagaligns from pseudo replicate 1
+        call pool_ta as pool_ta_pr1 { input :
+            tas = spr.ta_pr1,
+            prefix = 'rep-pr1',
+        }
+    }
+
+    # if there are pr2 TAs for ALL replicates then pool them
+    Boolean has_all_inputs_of_pool_ta_pr2 = length(select_all(spr.ta_pr2))==num_rep
+    if ( has_all_inputs_of_pool_ta_pr1 && num_rep>1 && !align_only && !true_rep_only ) {
+        # pool tagaligns from pseudo replicate 2
+        call pool_ta as pool_ta_pr2 { input :
+            tas = spr.ta_pr2,
+            prefix = 'rep-pr2',
+        }
+    }
+
+    # if there are CTL TAs for ALL replicates then pool them
+    Boolean has_all_inputs_of_pool_ta_ctl = length(select_all(ctl_ta_))==num_ctl
+    if ( has_all_inputs_of_pool_ta_ctl && num_ctl>1 ) {
+        # pool tagaligns from true replicates
+        call pool_ta as pool_ta_ctl { input :
+            tas = ctl_ta_,
+            prefix = 'ctl',
+        }
+    }
+
+    Boolean has_input_of_count_signal_track_pooled = defined(pool_ta.ta_pooled)
+    if ( has_input_of_count_signal_track_pooled && enable_count_signal_track && num_rep>1 ) {
+        call count_signal_track as count_signal_track_pooled { input :
+            ta = pool_ta.ta_pooled,
+            chrsz = chrsz_,
+        }
+    }
+
+    Boolean has_input_of_jsd = defined(blacklist_) && length(select_all(nodup_bam_))==num_rep
+    if ( has_input_of_jsd && num_rep > 0 && enable_jsd ) {
+        # fingerprint and JS-distance plot
+        call jsd { input :
+            nodup_bams = nodup_bam_,
+            ctl_bams = ctl_nodup_bam_, # use first control only
+            blacklist = blacklist_,
+            mapq_thresh = mapq_thresh_,
+
+            cpu = jsd_cpu,
+            mem_mb = jsd_mem_mb,
+            time_hr = jsd_time_hr,
+            disks = jsd_disks,
+        }
+    }
+
+    Boolean has_all_input_of_choose_ctl = length(select_all(ta_))==num_rep
+        && length(select_all(ctl_ta_))==num_ctl && num_ctl > 0
+    if ( has_all_input_of_choose_ctl && !align_only ) {
+        # choose appropriate control for each exp IP replicate
+        # outputs:
+        #     choose_ctl.idx : control replicate index for each exp replicate 
+        #                    -1 means pooled ctl replicate
+        call choose_ctl { input:
+            tas = ta_,
+            ctl_tas = ctl_ta_,
+            ta_pooled = pool_ta.ta_pooled,
+            ctl_ta_pooled = pool_ta_ctl.ta_pooled,
+            always_use_pooled_ctl = always_use_pooled_ctl,
+            ctl_depth_ratio = ctl_depth_ratio,
+            ctl_depth_limit = ctl_depth_limit,
+            exp_ctl_depth_ratio_limit = exp_ctl_depth_ratio_limit,
+        }
+    }
+
+    scatter(i in range(num_rep)) {
+        # make control ta array [[1,2,3,4]] -> [[1],[2],[3],[4]]
+        # chosen_ctl_ta_id
+        #     >=0: control TA index (this means that control TA with this index exists)
+        #     -1: use pooled control
+        #    -2: there is no control
+        Int chosen_ctl_ta_id = if has_all_input_of_choose_ctl && !align_only then
+            select_first([choose_ctl.chosen_ctl_ta_ids])[i] else -2
+        Array[File] chosen_ctl_tas = if chosen_ctl_ta_id == -2 then []
+            else if chosen_ctl_ta_id == -1 then [ select_first([pool_ta_ctl.ta_pooled]) ]
+            else [ select_first([ctl_ta_[ chosen_ctl_ta_id ]]) ]
+
+        Int chosen_ctl_ta_subsample = if has_all_input_of_choose_ctl && !align_only then
+            select_first([choose_ctl.chosen_ctl_ta_subsample])[i] else 0
+        Boolean chosen_ctl_paired_end = if chosen_ctl_ta_id == -2 then false
+            else if chosen_ctl_ta_id == -1 then ctl_paired_end_[0]
+            else ctl_paired_end_[chosen_ctl_ta_id]
+    }
+    Int chosen_ctl_ta_pooled_subsample = if has_all_input_of_choose_ctl && !align_only then
+        select_first([choose_ctl.chosen_ctl_ta_subsample_pooled]) else 0
+
+    # workaround for dx error (Unsupported combination: womType: Int womValue: ([225], Array[Int]))
+    Array[Int] fraglen_tmp = select_all(fraglen_)
+
+    # we have all tas and ctl_tas (optional for histone chipseq) ready, let's call peaks
+    scatter(i in range(num_rep)) {
+        Boolean has_input_of_call_peak = defined(ta_[i])
+        Boolean has_output_of_call_peak = i<length(peaks) && defined(peaks[i])
+        if ( has_input_of_call_peak && !has_output_of_call_peak && !align_only ) {
+            call call_peak { input :
+                peak_caller = peak_caller_,
+                peak_type = peak_type_,
+                tas = flatten([[ta_[i]], chosen_ctl_tas[i]]),
+                gensz = gensz_,
+                chrsz = chrsz_,
+                cap_num_peak = cap_num_peak_,
+                ctl_subsample = chosen_ctl_ta_subsample[i],
+                ctl_paired_end = chosen_ctl_paired_end[i],
+                pval_thresh = pval_thresh,
+                fdr_thresh = fdr_thresh,
+                fraglen = fraglen_tmp[i],
+                blacklist = blacklist_,
+                regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
+
+                cpu = call_peak_cpu,
+                mem_mb = call_peak_mem_mb,
+                disks = call_peak_disks,
+                time_hr = call_peak_time_hr,
+            }
+        }
+        File? peak_ = if has_output_of_call_peak then peaks[i]
+            else call_peak.peak
+
+        # signal track
+        if ( has_input_of_call_peak && !align_only ) {
+            call macs2_signal_track { input :
+                tas = flatten([[ta_[i]], chosen_ctl_tas[i]]),
+                gensz = gensz_,
+                chrsz = chrsz_,
+                pval_thresh = pval_thresh,
+                ctl_subsample = chosen_ctl_ta_subsample[i],
+                ctl_paired_end = chosen_ctl_paired_end[i],
+                fraglen = fraglen_tmp[i],
+
+                mem_mb = macs2_signal_track_mem_mb,
+                disks = macs2_signal_track_disks,
+                time_hr = macs2_signal_track_time_hr,
+            }
+        }
+
+        # call peaks on 1st pseudo replicated tagalign
+        Boolean has_input_of_call_peak_pr1 = defined(spr.ta_pr1[i])
+        Boolean has_output_of_call_peak_pr1 = i<length(peaks_pr1) && defined(peaks_pr1[i])
+        if ( has_input_of_call_peak_pr1 && !has_output_of_call_peak_pr1 && !true_rep_only ) {
+            call call_peak as call_peak_pr1 { input :
+                peak_caller = peak_caller_,
+                peak_type = peak_type_,
+                tas = flatten([[spr.ta_pr1[i]], chosen_ctl_tas[i]]),
+                gensz = gensz_,
+                chrsz = chrsz_,
+                cap_num_peak = cap_num_peak_,
+                ctl_subsample = chosen_ctl_ta_subsample[i],
+                ctl_paired_end = chosen_ctl_paired_end[i],
+                pval_thresh = pval_thresh,
+                fdr_thresh = fdr_thresh,
+                fraglen = fraglen_tmp[i],
+                blacklist = blacklist_,
+                regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
+    
+                cpu = call_peak_cpu,
+                mem_mb = call_peak_mem_mb,
+                disks = call_peak_disks,
+                time_hr = call_peak_time_hr,
+            }
+        }
+        File? peak_pr1_ = if has_output_of_call_peak_pr1 then peaks_pr1[i]
+            else call_peak_pr1.peak
+
+        # call peaks on 2nd pseudo replicated tagalign
+        Boolean has_input_of_call_peak_pr2 = defined(spr.ta_pr2[i])
+        Boolean has_output_of_call_peak_pr2 = i<length(peaks_pr2) && defined(peaks_pr2[i])
+        if ( has_input_of_call_peak_pr2 && !has_output_of_call_peak_pr2 && !true_rep_only ) {
+            call call_peak as call_peak_pr2 { input :
+                peak_caller = peak_caller_,
+                peak_type = peak_type_,
+                tas = flatten([[spr.ta_pr2[i]], chosen_ctl_tas[i]]),
+                gensz = gensz_,
+                chrsz = chrsz_,
+                cap_num_peak = cap_num_peak_,
+                ctl_subsample = chosen_ctl_ta_subsample[i],
+                ctl_paired_end = chosen_ctl_paired_end[i],
+                pval_thresh = pval_thresh,
+                fdr_thresh = fdr_thresh,
+                fraglen = fraglen_tmp[i],
+                blacklist = blacklist_,
+                regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
+
+                cpu = call_peak_cpu,
+                mem_mb = call_peak_mem_mb,
+                disks = call_peak_disks,
+                time_hr = call_peak_time_hr,
+            }
+        }
+        File? peak_pr2_ = if has_output_of_call_peak_pr2 then peaks_pr2[i]
+            else call_peak_pr2.peak
+    }
+
+    # if ( !align_only && num_rep > 1 ) {
+    # rounded mean of fragment length, which will be used for 
+    #  1) calling peaks for pooled true/pseudo replicates
+    #  2) calculating FRiP
+    call rounded_mean as fraglen_mean { input :
+        ints = fraglen_tmp,
+    }
+    # }
+
+    # actually not an array
+    Array[File?] chosen_ctl_ta_pooled = if !has_all_input_of_choose_ctl || align_only then []
+        else if num_ctl < 2 then [ctl_ta_[0]] # choose first (only) control
+        else select_all([pool_ta_ctl.ta_pooled]) # choose pooled control
+    Boolean chosen_ctl_ta_pooled_paired_end = if !has_all_input_of_choose_ctl || align_only then false
+        else ctl_paired_end_[0]
+
+    Boolean has_input_of_call_peak_pooled = defined(pool_ta.ta_pooled)
+    Boolean has_output_of_call_peak_pooled = defined(peak_pooled)
+    if ( has_input_of_call_peak_pooled && !has_output_of_call_peak_pooled && !align_only && num_rep>1 ) {
+        # call peaks on pooled replicate
+        # always call peaks for pooled replicate to get signal tracks
+        call call_peak as call_peak_pooled { input :
+            peak_caller = peak_caller_,
+            peak_type = peak_type_,
+            tas = flatten([select_all([pool_ta.ta_pooled]), chosen_ctl_ta_pooled]),
+            gensz = gensz_,
+            chrsz = chrsz_,
+            cap_num_peak = cap_num_peak_,
+            ctl_subsample = chosen_ctl_ta_pooled_subsample,
+            ctl_paired_end = chosen_ctl_ta_pooled_paired_end,
+            pval_thresh = pval_thresh,
+            fdr_thresh = fdr_thresh,
+            fraglen = fraglen_mean.rounded_mean,
+            blacklist = blacklist_,
+            regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
+
+            cpu = call_peak_cpu,
+            mem_mb = call_peak_mem_mb,
+            disks = call_peak_disks,
+            time_hr = call_peak_time_hr,
+        }
+    }
+    File? peak_pooled_ = if has_output_of_call_peak_pooled then peak_pooled
+        else call_peak_pooled.peak    
+
+    # macs2 signal track for pooled rep
+    if ( has_input_of_call_peak_pooled && !align_only && num_rep>1 ) {
+        call macs2_signal_track as macs2_signal_track_pooled { input :
+            tas = flatten([select_all([pool_ta.ta_pooled]), chosen_ctl_ta_pooled]),
+            gensz = gensz_,
+            chrsz = chrsz_,
+            pval_thresh = pval_thresh,
+            ctl_subsample = chosen_ctl_ta_pooled_subsample,
+            ctl_paired_end = chosen_ctl_ta_pooled_paired_end,
+            fraglen = fraglen_mean.rounded_mean,
+
+            mem_mb = macs2_signal_track_mem_mb,
+            disks = macs2_signal_track_disks,
+            time_hr = macs2_signal_track_time_hr,
+        }
+    }
+
+    Boolean has_input_of_call_peak_ppr1 = defined(pool_ta_pr1.ta_pooled)
+    Boolean has_output_of_call_peak_ppr1 = defined(peak_ppr1)
+    if ( has_input_of_call_peak_ppr1 && !has_output_of_call_peak_ppr1 && !align_only && !true_rep_only && num_rep>1 ) {
+        # call peaks on 1st pooled pseudo replicates
+        call call_peak as call_peak_ppr1 { input :
+            peak_caller = peak_caller_,
+            peak_type = peak_type_,
+            tas = flatten([select_all([pool_ta_pr1.ta_pooled]), chosen_ctl_ta_pooled]),
+            gensz = gensz_,
+            chrsz = chrsz_,
+            cap_num_peak = cap_num_peak_,
+            pval_thresh = pval_thresh,
+            ctl_subsample = chosen_ctl_ta_pooled_subsample,
+            ctl_paired_end = chosen_ctl_ta_pooled_paired_end,
+            fdr_thresh = fdr_thresh,
+            fraglen = fraglen_mean.rounded_mean,
+            blacklist = blacklist_,
+            regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
+
+            cpu = call_peak_cpu,
+            mem_mb = call_peak_mem_mb,
+            disks = call_peak_disks,
+            time_hr = call_peak_time_hr,
+        }
+    }
+    File? peak_ppr1_ = if has_output_of_call_peak_ppr1 then peak_ppr1
+        else call_peak_ppr1.peak
+
+    Boolean has_input_of_call_peak_ppr2 = defined(pool_ta_pr2.ta_pooled)
+    Boolean has_output_of_call_peak_ppr2 = defined(peak_ppr2)
+    if ( has_input_of_call_peak_ppr2 && !has_output_of_call_peak_ppr2 && !align_only && !true_rep_only && num_rep>1 ) {
+        # call peaks on 2nd pooled pseudo replicates
+        call call_peak as call_peak_ppr2 { input :
+            peak_caller = peak_caller_,
+            peak_type = peak_type_,
+            tas = flatten([select_all([pool_ta_pr2.ta_pooled]), chosen_ctl_ta_pooled]),
+            gensz = gensz_,
+            chrsz = chrsz_,
+            cap_num_peak = cap_num_peak_,
+            pval_thresh = pval_thresh,
+            ctl_subsample = chosen_ctl_ta_pooled_subsample,
+            ctl_paired_end = chosen_ctl_ta_pooled_paired_end,
+            fdr_thresh = fdr_thresh,
+            fraglen = fraglen_mean.rounded_mean,
+            blacklist = blacklist_,
+            regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
+
+            cpu = call_peak_cpu,
+            mem_mb = call_peak_mem_mb,
+            disks = call_peak_disks,
+            time_hr = call_peak_time_hr,
+        }
+    }
+    File? peak_ppr2_ = if has_output_of_call_peak_ppr2 then peak_ppr2
+        else call_peak_ppr2.peak
+
+    # do IDR/overlap on all pairs of two replicates (i,j)
+    #     where i and j are zero-based indices and 0 <= i < j < num_rep
+    scatter( pair in cross(range(num_rep),range(num_rep)) ) {
+        # pair.left = 0-based index of 1st replicate
+        # pair.right = 0-based index of 2nd replicate
+        File? peak1_ = peak_[pair.left]
+        File? peak2_ = peak_[pair.right]
+        if ( !align_only && pair.left<pair.right ) {
+            # Naive overlap on every pair of true replicates
+            call overlap { input :
+                prefix = 'rep'+(pair.left+1)+'_vs_rep'+(pair.right+1),
+                peak1 = peak1_,
+                peak2 = peak2_,
+                peak_pooled = peak_pooled_,
+                fraglen = fraglen_mean.rounded_mean,
+                peak_type = peak_type_,
+                blacklist = blacklist_,
+                chrsz = chrsz_,
+                regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
+                ta = pool_ta.ta_pooled,
+            }
+        }
+        if ( enable_idr && !align_only && pair.left<pair.right ) {
+            # IDR on every pair of true replicates
+            call idr { input :
+                prefix = 'rep'+(pair.left+1)+'_vs_rep'+(pair.right+1),
+                peak1 = peak1_,
+                peak2 = peak2_,
+                peak_pooled = peak_pooled_,
+                fraglen = fraglen_mean.rounded_mean,
+                idr_thresh = idr_thresh,
+                peak_type = peak_type_,
+                rank = idr_rank_,
+                blacklist = blacklist_,
+                chrsz = chrsz_,
+                regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
+                ta = pool_ta.ta_pooled,
+            }
+        }
+    }
+
+    # overlap on pseudo-replicates (pr1, pr2) for each true replicate
+    if ( !align_only && !true_rep_only ) {
+        scatter( i in range(num_rep) ) {
+            call overlap as overlap_pr { input :
+                prefix = 'rep'+(i+1)+'-pr1_vs_rep'+(i+1)+'-pr2',
+                peak1 = peak_pr1_[i],
+                peak2 = peak_pr2_[i],
+                peak_pooled = peak_[i],
+                fraglen = fraglen_[i],
+                peak_type = peak_type_,
+                blacklist = blacklist_,
+                chrsz = chrsz_,
+                regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
+                ta = ta_[i],
+            }
+        }
+    }
+
+    if ( !align_only && !true_rep_only && enable_idr ) {
+        scatter( i in range(num_rep) ) {
+            # IDR on pseduo replicates
+            call idr as idr_pr { input :
+                prefix = 'rep'+(i+1)+'-pr1_vs_rep'+(i+1)+'-pr2',
+                peak1 = peak_pr1_[i],
+                peak2 = peak_pr2_[i],
+                peak_pooled = peak_[i],
+                fraglen = fraglen_[i],
+                idr_thresh = idr_thresh,
+                peak_type = peak_type_,
+                rank = idr_rank_,
+                blacklist = blacklist_,
+                chrsz = chrsz_,
+                regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
+                ta = ta_[i],
+            }
+        }
+    }
+
+    if ( !align_only && !true_rep_only && num_rep > 1 ) {
+        # Naive overlap on pooled pseudo replicates
+        call overlap as overlap_ppr { input :
+            prefix = 'pooled-pr1_vs_pooled-pr2',
+            peak1 = peak_ppr1_,
+            peak2 = peak_ppr2_,
+            peak_pooled = peak_pooled_,
+            peak_type = peak_type_,
+            fraglen = fraglen_mean.rounded_mean,
+            blacklist = blacklist_,
+            chrsz = chrsz_,
+            regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
+            ta = pool_ta.ta_pooled,
+        }
+    }
+
+    if ( !align_only && !true_rep_only && num_rep > 1 ) {
+        # IDR on pooled pseduo replicates
+        call idr as idr_ppr { input :
+            prefix = 'pooled-pr1_vs_pooled-pr2',
+            peak1 = peak_ppr1_,
+            peak2 = peak_ppr2_,
+            peak_pooled = peak_pooled_,
+            idr_thresh = idr_thresh,
+            peak_type = peak_type_,
+            fraglen = fraglen_mean.rounded_mean,
+            rank = idr_rank_,
+            blacklist = blacklist_,
+            chrsz = chrsz_,
+            regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
+            ta = pool_ta.ta_pooled,
+        }
+    }
+
+    # reproducibility QC for overlap/IDR peaks
+    if ( !align_only && !true_rep_only && num_rep > 0 ) {
+        # reproducibility QC for overlapping peaks
+        call reproducibility as reproducibility_overlap { input :
+            prefix = 'overlap',
+            peaks = select_all(overlap.bfilt_overlap_peak),
+            peaks_pr = overlap_pr.bfilt_overlap_peak,
+            peak_ppr = overlap_ppr.bfilt_overlap_peak,
+            peak_type = peak_type_,
+            chrsz = chrsz_,
+        }
+    }
+
+    if ( !align_only && !true_rep_only && num_rep > 0 && enable_idr ) {
+        # reproducibility QC for IDR peaks
+        call reproducibility as reproducibility_idr { input :
+            prefix = 'idr',
+            peaks = select_all(idr.bfilt_idr_peak),
+            peaks_pr = idr_pr.bfilt_idr_peak,
+            peak_ppr = idr_ppr.bfilt_idr_peak,
+            peak_type = peak_type_,
+            chrsz = chrsz_,
+        }
+    }
+
+    # Generate final QC report and JSON
+    call qc_report { input :
+        pipeline_ver = pipeline_ver,
+        title = title,
+        description = description,
+        genome = genome_name_,
+        paired_ends = paired_end_,
+        ctl_paired_ends = ctl_paired_end_,
+        pipeline_type = pipeline_type,
+        aligner = aligner_,
+        peak_caller = peak_caller_,
+        cap_num_peak = cap_num_peak_,
+        idr_thresh = idr_thresh,
+        pval_thresh = pval_thresh,
+        xcor_trim_bp = xcor_trim_bp,
+        xcor_subsample_reads = xcor_subsample_reads,
+
+        samstat_qcs = select_all(align.samstat_qc),
+        nodup_samstat_qcs = select_all(filter.samstat_qc),
+        dup_qcs = select_all(filter.dup_qc),
+        lib_complexity_qcs = select_all(filter.lib_complexity_qc),
+        xcor_plots = select_all(xcor.plot_png),
+        xcor_scores = select_all(xcor.score),
+
+        ctl_samstat_qcs = select_all(align_ctl.samstat_qc),
+        ctl_nodup_samstat_qcs = select_all(filter_ctl.samstat_qc),
+        ctl_dup_qcs = select_all(filter_ctl.dup_qc),
+        ctl_lib_complexity_qcs = select_all(filter_ctl.lib_complexity_qc),
+
+        jsd_plot = jsd.plot,
+        jsd_qcs = jsd.jsd_qcs,
+
+        frip_qcs = select_all(call_peak.frip_qc),
+        frip_qcs_pr1 = select_all(call_peak_pr1.frip_qc),
+        frip_qcs_pr2 = select_all(call_peak_pr2.frip_qc),
+        frip_qc_pooled = call_peak_pooled.frip_qc,
+        frip_qc_ppr1 = call_peak_ppr1.frip_qc,
+        frip_qc_ppr2 = call_peak_ppr2.frip_qc,
+
+        idr_plots = select_all(idr.idr_plot),
+        idr_plots_pr = idr_pr.idr_plot,
+        idr_plot_ppr = idr_ppr.idr_plot,
+        frip_idr_qcs = select_all(idr.frip_qc),
+        frip_idr_qcs_pr = idr_pr.frip_qc,
+        frip_idr_qc_ppr = idr_ppr.frip_qc,
+        frip_overlap_qcs = select_all(overlap.frip_qc),
+        frip_overlap_qcs_pr = overlap_pr.frip_qc,
+        frip_overlap_qc_ppr = overlap_ppr.frip_qc,
+        idr_reproducibility_qc = reproducibility_idr.reproducibility_qc,
+        overlap_reproducibility_qc = reproducibility_overlap.reproducibility_qc,
+
+        gc_plots = select_all(gc_bias.gc_plot),
+
+        peak_region_size_qcs = select_all(call_peak.peak_region_size_qc),
+        peak_region_size_plots = select_all(call_peak.peak_region_size_plot),
+        num_peak_qcs = select_all(call_peak.num_peak_qc),
+
+        idr_opt_peak_region_size_qc = reproducibility_idr.peak_region_size_qc,
+        idr_opt_peak_region_size_plot = reproducibility_overlap.peak_region_size_plot,
+        idr_opt_num_peak_qc = reproducibility_idr.num_peak_qc,
+
+        overlap_opt_peak_region_size_qc = reproducibility_overlap.peak_region_size_qc,
+        overlap_opt_peak_region_size_plot = reproducibility_overlap.peak_region_size_plot,
+        overlap_opt_num_peak_qc = reproducibility_overlap.num_peak_qc,
+    }
+
+    output {
+        File report = qc_report.report
+        File qc_json = qc_report.qc_json
+        Boolean qc_json_ref_match = qc_report.qc_json_ref_match
+    }
 }
 
 task align {
-	input {
-		Array[File] fastqs_R1		 # [merge_id]
-		Array[File] fastqs_R2
-		Int? trim_bp			# this is for R1 only
-		Int crop_length
-		Int crop_length_tol
-		String aligner
-		String mito_chr_name
-		Int? multimapping
-		File? idx_tar			# reference index tar
-		Boolean paired_end
-		Boolean use_bwa_mem_for_pe
+    input {
+        Array[File] fastqs_R1         # [merge_id]
+        Array[File] fastqs_R2
+        Int? trim_bp            # this is for R1 only
+        Int crop_length
+        Int crop_length_tol
+        String aligner
+        String mito_chr_name
+        Int? multimapping
+        File? idx_tar            # reference index tar
+        Boolean paired_end
+        Boolean use_bwa_mem_for_pe
 
-		String? trimmomatic_java_heap
-		Int cpu
-		Int mem_mb
-		Int time_hr
-		String disks
-	}
+        String? trimmomatic_java_heap
+        Int cpu
+        Int mem_mb
+        Int time_hr
+        String disks
+    }
 
-	Float trimmomatic_java_heap_factor = 0.9
-	Array[Array[File]] tmp_fastqs = if paired_end then transpose([fastqs_R1, fastqs_R2])
-				else transpose([fastqs_R1])
-	command {
-		set -e
+    Float trimmomatic_java_heap_factor = 0.9
+    Array[Array[File]] tmp_fastqs = if paired_end then transpose([fastqs_R1, fastqs_R2])
+                else transpose([fastqs_R1])
+    command {
+        set -e
 
-		# check if pipeline dependencies can be found
-		if [[ -z "$(which encode_task_merge_fastq.py 2> /dev/null || true)" ]]
-		then
-		  echo -e "\n* Error: pipeline dependencies not found." 1>&2
-		  echo 'Conda users: Did you activate Conda environment (conda activate encode-chip-seq-pipeline)?' 1>&2
-		  echo '	Or did you install Conda and environment correctly (bash scripts/install_conda_env.sh)?' 1>&2
-		  echo 'GCP/AWS/Docker users: Did you add --docker flag to Caper command line arg?' 1>&2
-		  echo 'Singularity users: Did you add --singularity flag to Caper command line arg?' 1>&2
-		  echo -e "\n" 1>&2
-		  exit 3
-		fi
-		python3 $(which encode_task_merge_fastq.py) \
-			${write_tsv(tmp_fastqs)} \
-			${if paired_end then '--paired-end' else ''} \
-			${'--nth ' + cpu}
+        # check if pipeline dependencies can be found
+        if [[ -z "$(which encode_task_merge_fastq.py 2> /dev/null || true)" ]]
+        then
+          echo -e "\n* Error: pipeline dependencies not found." 1>&2
+          echo 'Conda users: Did you activate Conda environment (conda activate encode-chip-seq-pipeline)?' 1>&2
+          echo '    Or did you install Conda and environment correctly (bash scripts/install_conda_env.sh)?' 1>&2
+          echo 'GCP/AWS/Docker users: Did you add --docker flag to Caper command line arg?' 1>&2
+          echo 'Singularity users: Did you add --singularity flag to Caper command line arg?' 1>&2
+          echo -e "\n" 1>&2
+          exit 3
+        fi
+        python3 $(which encode_task_merge_fastq.py) \
+            ${write_tsv(tmp_fastqs)} \
+            ${if paired_end then '--paired-end' else ''} \
+            ${'--nth ' + cpu}
 
-		if [ -z '${trim_bp}' ]; then
-			SUFFIX=
-		else
-			SUFFIX=_trimmed
-			python3 $(which encode_task_trim_fastq.py) \
-				R1/*.fastq.gz \
-				--trim-bp ${trim_bp} \
-				--out-dir R1$SUFFIX
-			if [ '${paired_end}' == 'true' ]; then
-				python3 $(which encode_task_trim_fastq.py) \
-					R2/*.fastq.gz \
-					--trim-bp ${trim_bp} \
-					--out-dir R2$SUFFIX
-			fi
-		fi
-		if [ '${crop_length}' == '0' ]; then
-			SUFFIX=$SUFFIX
-		else
-			NEW_SUFFIX="$SUFFIX"_cropped
-			python3 $(which encode_task_trimmomatic.py) \
-				--fastq1 R1$SUFFIX/*.fastq.gz \
-				${if paired_end then '--fastq2 R2$SUFFIX/*.fastq.gz' else ''} \
-				${if paired_end then '--paired-end' else ''} \
-				--crop-length ${crop_length} \
-				--crop-length-tol "${crop_length_tol}" \
-				--out-dir-R1 R1$NEW_SUFFIX \
-				${if paired_end then '--out-dir-R2 R2$NEW_SUFFIX' else ''} \
-				${'--trimmomatic-java-heap ' + if defined(trimmomatic_java_heap) then trimmomatic_java_heap else (round(mem_mb * trimmomatic_java_heap_factor) + 'M')} \
-				${'--nth ' + cpu}
-			SUFFIX=$NEW_SUFFIX
-		fi
+        if [ -z '${trim_bp}' ]; then
+            SUFFIX=
+        else
+            SUFFIX=_trimmed
+            python3 $(which encode_task_trim_fastq.py) \
+                R1/*.fastq.gz \
+                --trim-bp ${trim_bp} \
+                --out-dir R1$SUFFIX
+            if [ '${paired_end}' == 'true' ]; then
+                python3 $(which encode_task_trim_fastq.py) \
+                    R2/*.fastq.gz \
+                    --trim-bp ${trim_bp} \
+                    --out-dir R2$SUFFIX
+            fi
+        fi
+        if [ '${crop_length}' == '0' ]; then
+            SUFFIX=$SUFFIX
+        else
+            NEW_SUFFIX="$SUFFIX"_cropped
+            python3 $(which encode_task_trimmomatic.py) \
+                --fastq1 R1$SUFFIX/*.fastq.gz \
+                ${if paired_end then '--fastq2 R2$SUFFIX/*.fastq.gz' else ''} \
+                ${if paired_end then '--paired-end' else ''} \
+                --crop-length ${crop_length} \
+                --crop-length-tol "${crop_length_tol}" \
+                --out-dir-R1 R1$NEW_SUFFIX \
+                ${if paired_end then '--out-dir-R2 R2$NEW_SUFFIX' else ''} \
+                ${'--trimmomatic-java-heap ' + if defined(trimmomatic_java_heap) then trimmomatic_java_heap else (round(mem_mb * trimmomatic_java_heap_factor) + 'M')} \
+                ${'--nth ' + cpu}
+            SUFFIX=$NEW_SUFFIX
+        fi
 
-		if [ '${aligner}' == 'bwa' ]; then
-			 python3 $(which encode_task_bwa.py) \
-				${idx_tar} \
-				R1$SUFFIX/*.fastq.gz \
-				${if paired_end then 'R2$SUFFIX/*.fastq.gz' else ''} \
-				${if paired_end then '--paired-end' else ''} \
-				${if use_bwa_mem_for_pe then '--use-bwa-mem-for-pe' else ''} \
-				${'--nth ' + cpu}
+        if [ '${aligner}' == 'bwa' ]; then
+             python3 $(which encode_task_bwa.py) \
+                ${idx_tar} \
+                R1$SUFFIX/*.fastq.gz \
+                ${if paired_end then 'R2$SUFFIX/*.fastq.gz' else ''} \
+                ${if paired_end then '--paired-end' else ''} \
+                ${if use_bwa_mem_for_pe then '--use-bwa-mem-for-pe' else ''} \
+                ${'--nth ' + cpu}
 
-		elif [ '${aligner}' == 'bowtie2' ]; then
-			 python3 $(which encode_task_bowtie2.py) \
-				${idx_tar} \
-				R1$SUFFIX/*.fastq.gz \
-				${if paired_end then 'R2$SUFFIX/*.fastq.gz' else ''} \
-				${'--multimapping ' + multimapping} \
-				${if paired_end then '--paired-end' else ''} \
-				${'--nth ' + cpu}
-		fi 
+        elif [ '${aligner}' == 'bowtie2' ]; then
+             python3 $(which encode_task_bowtie2.py) \
+                ${idx_tar} \
+                R1$SUFFIX/*.fastq.gz \
+                ${if paired_end then 'R2$SUFFIX/*.fastq.gz' else ''} \
+                ${'--multimapping ' + multimapping} \
+                ${if paired_end then '--paired-end' else ''} \
+                ${'--nth ' + cpu}
+        fi 
 
-		python3 $(which encode_task_post_align.py) \
-			R1$SUFFIX/*.fastq.gz $(ls *.bam) \
-			${'--mito-chr-name ' + mito_chr_name} \
-			${'--nth ' + cpu}
-		rm -rf R1 R2 R1$SUFFIX R2$SUFFIX
-	}
-	output {
-		File bam = glob('*.bam')[0]
-		File bai = glob('*.bai')[0]
-		File samstat_qc = glob('*.samstats.qc')[0]
-		File read_len_log = glob('*.read_length.txt')[0]
-	}
-	runtime {
-		cpu : cpu
-		memory : '${mem_mb} MB'
-		time : time_hr
-		disks : disks
-		preemptible: 0
-	}
+        python3 $(which encode_task_post_align.py) \
+            R1$SUFFIX/*.fastq.gz $(ls *.bam) \
+            ${'--mito-chr-name ' + mito_chr_name} \
+            ${'--nth ' + cpu}
+        rm -rf R1 R2 R1$SUFFIX R2$SUFFIX
+    }
+    output {
+        File bam = glob('*.bam')[0]
+        File bai = glob('*.bai')[0]
+        File samstat_qc = glob('*.samstats.qc')[0]
+        File read_len_log = glob('*.read_length.txt')[0]
+    }
+    runtime {
+        cpu : cpu
+        memory : '${mem_mb} MB'
+        time : time_hr
+        disks : disks
+        preemptible: 0
+    }
 }
 
 task filter {
-	input {
-		File? bam
-		Boolean paired_end
-		String dup_marker			 # picard.jar MarkDuplicates (picard) or 
-									# sambamba markdup (sambamba)
-		Int mapq_thresh				# threshold for low MAPQ reads removal
-		Array[String] filter_chrs	 # chrs to be removed from final (nodup/filt) BAM
-		File chrsz					# 2-col chromosome sizes file
-		Boolean no_dup_removal		 # no dupe reads removal when filtering BAM
-		String mito_chr_name
+    input {
+        File? bam
+        Boolean paired_end
+        String dup_marker             # picard.jar MarkDuplicates (picard) or 
+                                    # sambamba markdup (sambamba)
+        Int mapq_thresh                # threshold for low MAPQ reads removal
+        Array[String] filter_chrs     # chrs to be removed from final (nodup/filt) BAM
+        File chrsz                    # 2-col chromosome sizes file
+        Boolean no_dup_removal         # no dupe reads removal when filtering BAM
+        String mito_chr_name
 
-		Int cpu
-		Int mem_mb
-		String? picard_java_heap
-		Int time_hr
-		String disks
-	}
-	Float picard_java_heap_factor = 0.9
+        Int cpu
+        Int mem_mb
+        String? picard_java_heap
+        Int time_hr
+        String disks
+    }
+    Float picard_java_heap_factor = 0.9
 
-	command {
-		python3 $(which encode_task_filter.py) \
-			${bam} \
-			${if paired_end then '--paired-end' else ''} \
-			--multimapping 0 \
-			${'--dup-marker ' + dup_marker} \
-			${'--mapq-thresh ' + mapq_thresh} \
-			--filter-chrs ${sep=' ' filter_chrs} \
-			${'--chrsz ' + chrsz} \
-			${if no_dup_removal then '--no-dup-removal' else ''} \
-			${'--mito-chr-name ' + mito_chr_name} \
-			${'--nth ' + cpu} \
-			${'--picard-java-heap ' + if defined(picard_java_heap) then picard_java_heap else (round(mem_mb * picard_java_heap_factor) + 'M')}
-	}
-	output {
-		File nodup_bam = glob('*.bam')[0]
-		File nodup_bai = glob('*.bai')[0]
-		File samstat_qc = glob('*.samstats.qc')[0]
-		File dup_qc = glob('*.dup.qc')[0]
-		File lib_complexity_qc = glob('*.lib_complexity.qc')[0]
-	}
-	runtime {
-		cpu : cpu
-		memory : '${mem_mb} MB'
-		time : time_hr
-		disks : disks
-	}
+    command {
+        python3 $(which encode_task_filter.py) \
+            ${bam} \
+            ${if paired_end then '--paired-end' else ''} \
+            --multimapping 0 \
+            ${'--dup-marker ' + dup_marker} \
+            ${'--mapq-thresh ' + mapq_thresh} \
+            --filter-chrs ${sep=' ' filter_chrs} \
+            ${'--chrsz ' + chrsz} \
+            ${if no_dup_removal then '--no-dup-removal' else ''} \
+            ${'--mito-chr-name ' + mito_chr_name} \
+            ${'--nth ' + cpu} \
+            ${'--picard-java-heap ' + if defined(picard_java_heap) then picard_java_heap else (round(mem_mb * picard_java_heap_factor) + 'M')}
+    }
+    output {
+        File nodup_bam = glob('*.bam')[0]
+        File nodup_bai = glob('*.bai')[0]
+        File samstat_qc = glob('*.samstats.qc')[0]
+        File dup_qc = glob('*.dup.qc')[0]
+        File lib_complexity_qc = glob('*.lib_complexity.qc')[0]
+    }
+    runtime {
+        cpu : cpu
+        memory : '${mem_mb} MB'
+        time : time_hr
+        disks : disks
+    }
 }
 
 task bam2ta {
-	input {
-		File? bam
-		Boolean paired_end
-		String mito_chr_name		 # mito chromosome name
-		Int subsample				 # number of reads to subsample TAGALIGN
-									# this affects all downstream analysis
-		Int cpu
-		Int mem_mb
-		Int time_hr
-		String disks
-	}
+    input {
+        File? bam
+        Boolean paired_end
+        String mito_chr_name         # mito chromosome name
+        Int subsample                 # number of reads to subsample TAGALIGN
+                                    # this affects all downstream analysis
+        Int cpu
+        Int mem_mb
+        Int time_hr
+        String disks
+    }
 
-	command {
-		python3 $(which encode_task_bam2ta.py) \
-			${bam} \
-			--disable-tn5-shift \
-			${if paired_end then '--paired-end' else ''} \
-			${'--mito-chr-name ' + mito_chr_name} \
-			${'--subsample ' + subsample} \
-			${'--nth ' + cpu}
-	}
-	output {
-		File ta = glob('*.tagAlign.gz')[0]
-	}
-	runtime {
-		cpu : cpu
-		memory : '${mem_mb} MB'
-		time : time_hr
-		disks : disks
-	}
+    command {
+        python3 $(which encode_task_bam2ta.py) \
+            ${bam} \
+            --disable-tn5-shift \
+            ${if paired_end then '--paired-end' else ''} \
+            ${'--mito-chr-name ' + mito_chr_name} \
+            ${'--subsample ' + subsample} \
+            ${'--nth ' + cpu}
+    }
+    output {
+        File ta = glob('*.tagAlign.gz')[0]
+    }
+    runtime {
+        cpu : cpu
+        memory : '${mem_mb} MB'
+        time : time_hr
+        disks : disks
+    }
 }
 
 task spr {
-	input {
-		File? ta
-		Boolean paired_end
+    input {
+        File? ta
+        Boolean paired_end
 
-		Int mem_mb
-	}
+        Int mem_mb
+    }
 
-	command {
-		python3 $(which encode_task_spr.py) \
-			${ta} \
-			${if paired_end then '--paired-end' else ''}
-	}
-	output {
-		File ta_pr1 = glob('*.pr1.tagAlign.gz')[0]
-		File ta_pr2 = glob('*.pr2.tagAlign.gz')[0]
-	}
-	runtime {
-		cpu : 1
-		memory : '${mem_mb} MB'
-		time : 1
-		disks : 'local-disk 50 HDD'
-	}
+    command {
+        python3 $(which encode_task_spr.py) \
+            ${ta} \
+            ${if paired_end then '--paired-end' else ''}
+    }
+    output {
+        File ta_pr1 = glob('*.pr1.tagAlign.gz')[0]
+        File ta_pr2 = glob('*.pr2.tagAlign.gz')[0]
+    }
+    runtime {
+        cpu : 1
+        memory : '${mem_mb} MB'
+        time : 1
+        disks : 'local-disk 50 HDD'
+    }
 }
 
 task pool_ta {
-	input {
-		Array[File?] tas
-		Int? col			 # number of columns in pooled TA
-		String? prefix		 # basename prefix
-	}
+    input {
+        Array[File?] tas
+        Int? col             # number of columns in pooled TA
+        String? prefix         # basename prefix
+    }
 
-	command {
-		python3 $(which encode_task_pool_ta.py) \
-			${sep=' ' select_all(tas)} \
-			${'--prefix ' + prefix} \
-			${'--col ' + col}
-	}
-	output {
-		File ta_pooled = glob('*.tagAlign.gz')[0]
-	}
-	runtime {
-		cpu : 1
-		memory : '4000 MB'
-		time : 1
-		disks : 'local-disk 50 HDD'
-	}
+    command {
+        python3 $(which encode_task_pool_ta.py) \
+            ${sep=' ' select_all(tas)} \
+            ${'--prefix ' + prefix} \
+            ${'--col ' + col}
+    }
+    output {
+        File ta_pooled = glob('*.tagAlign.gz')[0]
+    }
+    runtime {
+        cpu : 1
+        memory : '4000 MB'
+        time : 1
+        disks : 'local-disk 50 HDD'
+    }
 }
 
 task xcor {
-	input {
-		File? ta
-		Boolean paired_end
-		String mito_chr_name
-		Int subsample  # number of reads to subsample TAGALIGN
-						# this will be used for xcor only
-						# will not affect any downstream analysis
-		String? chip_seq_type
-		Int? exclusion_range_min
-		Int? exclusion_range_max
+    input {
+        File? ta
+        Boolean paired_end
+        String mito_chr_name
+        Int subsample  # number of reads to subsample TAGALIGN
+                        # this will be used for xcor only
+                        # will not affect any downstream analysis
+        String? chip_seq_type
+        Int? exclusion_range_min
+        Int? exclusion_range_max
 
-		Int cpu
-		Int mem_mb	
-		Int time_hr
-		String disks
-	}
+        Int cpu
+        Int mem_mb    
+        Int time_hr
+        String disks
+    }
 
-	command {
-		python3 $(which encode_task_xcor.py) \
-			${ta} \
-			${if paired_end then '--paired-end' else ''} \
-			${'--mito-chr-name ' + mito_chr_name} \
-			${'--subsample ' + subsample} \
-			${'--chip-seq-type ' + chip_seq_type} \
-			${'--exclusion-range-min ' + exclusion_range_min} \
-			${'--exclusion-range-max ' + exclusion_range_max} \
-			${'--subsample ' + subsample} \
-			${'--nth ' + cpu}
-	}
-	output {
-		File plot_pdf = glob('*.cc.plot.pdf')[0]
-		File plot_png = glob('*.cc.plot.png')[0]
-		File score = glob('*.cc.qc')[0]
-		File fraglen_log = glob('*.cc.fraglen.txt')[0]
-		Int fraglen = read_int(fraglen_log)
-	}
-	runtime {
-		cpu : cpu
-		memory : '${mem_mb} MB'
-		time : time_hr
-		disks : disks
-	}
+    command {
+        python3 $(which encode_task_xcor.py) \
+            ${ta} \
+            ${if paired_end then '--paired-end' else ''} \
+            ${'--mito-chr-name ' + mito_chr_name} \
+            ${'--subsample ' + subsample} \
+            ${'--chip-seq-type ' + chip_seq_type} \
+            ${'--exclusion-range-min ' + exclusion_range_min} \
+            ${'--exclusion-range-max ' + exclusion_range_max} \
+            ${'--subsample ' + subsample} \
+            ${'--nth ' + cpu}
+    }
+    output {
+        File plot_pdf = glob('*.cc.plot.pdf')[0]
+        File plot_png = glob('*.cc.plot.png')[0]
+        File score = glob('*.cc.qc')[0]
+        File fraglen_log = glob('*.cc.fraglen.txt')[0]
+        Int fraglen = read_int(fraglen_log)
+    }
+    runtime {
+        cpu : cpu
+        memory : '${mem_mb} MB'
+        time : time_hr
+        disks : disks
+    }
 }
 
 task jsd {
-	input {
-		Array[File?] nodup_bams
-		Array[File?] ctl_bams
-		File? blacklist
-		Int mapq_thresh
+    input {
+        Array[File?] nodup_bams
+        Array[File?] ctl_bams
+        File? blacklist
+        Int mapq_thresh
 
-		Int cpu
-		Int mem_mb
-		Int time_hr
-		String disks
-	}
+        Int cpu
+        Int mem_mb
+        Int time_hr
+        String disks
+    }
 
-	command {
-		python3 $(which encode_task_jsd.py) \
-			${sep=' ' select_all(nodup_bams)} \
-			${if length(ctl_bams)>0 then '--ctl-bam '+ select_first(ctl_bams) else ''} \
-			${'--mapq-thresh '+ mapq_thresh} \
-			${'--blacklist '+ blacklist} \
-			${'--nth ' + cpu}
-	}
-	output {
-		File plot = glob('*.png')[0]
-		Array[File] jsd_qcs = glob('*.jsd.qc')
-	}
-	runtime {
-		cpu : cpu
-		memory : '${mem_mb} MB'
-		time : time_hr
-		disks : disks
-	}
+    command {
+        python3 $(which encode_task_jsd.py) \
+            ${sep=' ' select_all(nodup_bams)} \
+            ${if length(ctl_bams)>0 then '--ctl-bam '+ select_first(ctl_bams) else ''} \
+            ${'--mapq-thresh '+ mapq_thresh} \
+            ${'--blacklist '+ blacklist} \
+            ${'--nth ' + cpu}
+    }
+    output {
+        File plot = glob('*.png')[0]
+        Array[File] jsd_qcs = glob('*.jsd.qc')
+    }
+    runtime {
+        cpu : cpu
+        memory : '${mem_mb} MB'
+        time : time_hr
+        disks : disks
+    }
 }
 
 task choose_ctl {
-	input {
-		Array[File?] tas
-		Array[File?] ctl_tas
-		File? ta_pooled
-		File? ctl_ta_pooled
-		Boolean always_use_pooled_ctl # always use pooled control for all exp rep.
-		Float ctl_depth_ratio		 # if ratio between controls is higher than this
-									# then always use pooled control for all exp rep.
-		Int ctl_depth_limit
-		Float exp_ctl_depth_ratio_limit
-	}
+    input {
+        Array[File?] tas
+        Array[File?] ctl_tas
+        File? ta_pooled
+        File? ctl_ta_pooled
+        Boolean always_use_pooled_ctl # always use pooled control for all exp rep.
+        Float ctl_depth_ratio         # if ratio between controls is higher than this
+                                    # then always use pooled control for all exp rep.
+        Int ctl_depth_limit
+        Float exp_ctl_depth_ratio_limit
+    }
 
-	command {
-		python3 $(which encode_task_choose_ctl.py) \
-			--tas ${sep=' ' select_all(tas)} \
-			--ctl-tas ${sep=' ' select_all(ctl_tas)} \
-			${'--ta-pooled ' + ta_pooled} \
-			${'--ctl-ta-pooled ' + ctl_ta_pooled} \
-			${if always_use_pooled_ctl then '--always-use-pooled-ctl' else ''} \
-			${'--ctl-depth-ratio ' + ctl_depth_ratio} \
-			${'--ctl-depth-limit ' + ctl_depth_limit} \
-			${'--exp-ctl-depth-ratio-limit ' + exp_ctl_depth_ratio_limit}
-	}
-	output {
-		File chosen_ctl_id_tsv = glob('chosen_ctl.tsv')[0]
-		File chosen_ctl_subsample_tsv = glob('chosen_ctl_subsample.tsv')[0]
-		File chosen_ctl_subsample_pooled_txt = glob('chosen_ctl_subsample_pooled.txt')[0]
-		Array[Int] chosen_ctl_ta_ids = read_lines(chosen_ctl_id_tsv)
-		Array[Int] chosen_ctl_ta_subsample = read_lines(chosen_ctl_subsample_tsv)
-		Int chosen_ctl_ta_subsample_pooled = read_int(chosen_ctl_subsample_pooled_txt)
-	}
-	runtime {
-		cpu : 1
-		memory : '8000 MB'
-		time : 1
-		disks : 'local-disk 50 HDD'
-	}	
+    command {
+        python3 $(which encode_task_choose_ctl.py) \
+            --tas ${sep=' ' select_all(tas)} \
+            --ctl-tas ${sep=' ' select_all(ctl_tas)} \
+            ${'--ta-pooled ' + ta_pooled} \
+            ${'--ctl-ta-pooled ' + ctl_ta_pooled} \
+            ${if always_use_pooled_ctl then '--always-use-pooled-ctl' else ''} \
+            ${'--ctl-depth-ratio ' + ctl_depth_ratio} \
+            ${'--ctl-depth-limit ' + ctl_depth_limit} \
+            ${'--exp-ctl-depth-ratio-limit ' + exp_ctl_depth_ratio_limit}
+    }
+    output {
+        File chosen_ctl_id_tsv = glob('chosen_ctl.tsv')[0]
+        File chosen_ctl_subsample_tsv = glob('chosen_ctl_subsample.tsv')[0]
+        File chosen_ctl_subsample_pooled_txt = glob('chosen_ctl_subsample_pooled.txt')[0]
+        Array[Int] chosen_ctl_ta_ids = read_lines(chosen_ctl_id_tsv)
+        Array[Int] chosen_ctl_ta_subsample = read_lines(chosen_ctl_subsample_tsv)
+        Int chosen_ctl_ta_subsample_pooled = read_int(chosen_ctl_subsample_pooled_txt)
+    }
+    runtime {
+        cpu : 1
+        memory : '8000 MB'
+        time : 1
+        disks : 'local-disk 50 HDD'
+    }    
 }
 
 task count_signal_track {
-	input {
-		File? ta			 # tag-align
-		File chrsz			# 2-col chromosome sizes file
-	}
+    input {
+        File? ta             # tag-align
+        File chrsz            # 2-col chromosome sizes file
+    }
 
-	command {
-		python3 $(which encode_task_count_signal_track.py) \
-			${ta} \
-			${'--chrsz ' + chrsz}
-	}
-	output {
-		File pos_bw = glob('*.positive.bigwig')[0]
-		File neg_bw = glob('*.negative.bigwig')[0]
-	}
-	runtime {
-		cpu : 1
-		memory : '8000 MB'
-		time : 4
-		disks : 'local-disk 50 HDD'
-	}
+    command {
+        python3 $(which encode_task_count_signal_track.py) \
+            ${ta} \
+            ${'--chrsz ' + chrsz}
+    }
+    output {
+        File pos_bw = glob('*.positive.bigwig')[0]
+        File neg_bw = glob('*.negative.bigwig')[0]
+    }
+    runtime {
+        cpu : 1
+        memory : '8000 MB'
+        time : 4
+        disks : 'local-disk 50 HDD'
+    }
 }
 
 task call_peak {
-	input {
-		String peak_caller
-		String peak_type
-		Array[File?] tas	# [ta, control_ta]. control_ta is optional
-		Int fraglen		 # fragment length from xcor
-		String gensz		# Genome size (sum of entries in 2nd column of 
-							# chr. sizes file, or hs for human, ms for mouse)
-		File chrsz			# 2-col chromosome sizes file
-		Int cap_num_peak	# cap number of raw peaks called from MACS2
-		Int ctl_subsample	# subsample control if >0. 0: no subsampling
-		Boolean ctl_paired_end # control is paired end
-		Float pval_thresh	 # p.value threshold for MACS2
-		Float? fdr_thresh	 # FDR threshold for SPP
+    input {
+        String peak_caller
+        String peak_type
+        Array[File?] tas    # [ta, control_ta]. control_ta is optional
+        Int fraglen         # fragment length from xcor
+        String gensz        # Genome size (sum of entries in 2nd column of 
+                            # chr. sizes file, or hs for human, ms for mouse)
+        File chrsz            # 2-col chromosome sizes file
+        Int cap_num_peak    # cap number of raw peaks called from MACS2
+        Int ctl_subsample    # subsample control if >0. 0: no subsampling
+        Boolean ctl_paired_end # control is paired end
+        Float pval_thresh     # p.value threshold for MACS2
+        Float? fdr_thresh     # FDR threshold for SPP
 
-		File? blacklist	 # blacklist BED to filter raw peaks
-		String? regex_bfilt_peak_chr_name
+        File? blacklist     # blacklist BED to filter raw peaks
+        String? regex_bfilt_peak_chr_name
 
-		Int cpu	
-		Int mem_mb
-		Int time_hr
-		String disks
-	}
+        Int cpu    
+        Int mem_mb
+        Int time_hr
+        String disks
+    }
 
-	command {
-		set -e
+    command {
+        set -e
 
-		if [ '${peak_caller}' == 'macs2' ]; then
-			python3 $(which encode_task_macs2_chip.py) \
-				${sep=' ' select_all(tas)} \
-				${'--gensz '+ gensz} \
-				${'--chrsz ' + chrsz} \
-				${'--fraglen ' + fraglen} \
-				${'--cap-num-peak ' + cap_num_peak} \
-				${'--ctl-subsample ' + ctl_subsample} \
-				${if ctl_paired_end then '--ctl-paired-end' else ''} \
-				${'--pval-thresh '+ pval_thresh}
+        if [ '${peak_caller}' == 'macs2' ]; then
+            python3 $(which encode_task_macs2_chip.py) \
+                ${sep=' ' select_all(tas)} \
+                ${'--gensz '+ gensz} \
+                ${'--chrsz ' + chrsz} \
+                ${'--fraglen ' + fraglen} \
+                ${'--cap-num-peak ' + cap_num_peak} \
+                ${'--ctl-subsample ' + ctl_subsample} \
+                ${if ctl_paired_end then '--ctl-paired-end' else ''} \
+                ${'--pval-thresh '+ pval_thresh}
 
-		elif [ '${peak_caller}' == 'spp' ]; then
-			python3 $(which encode_task_spp.py) \
-				${sep=' ' select_all(tas)} \
-				${'--fraglen ' + fraglen} \
-				${'--cap-num-peak ' + cap_num_peak} \
-				${'--ctl-subsample ' + ctl_subsample} \
-				${if ctl_paired_end then '--ctl-paired-end' else ''} \
-				${'--fdr-thresh '+ fdr_thresh} \
-				${'--nth ' + cpu}
-		fi
+        elif [ '${peak_caller}' == 'spp' ]; then
+            python3 $(which encode_task_spp.py) \
+                ${sep=' ' select_all(tas)} \
+                ${'--fraglen ' + fraglen} \
+                ${'--cap-num-peak ' + cap_num_peak} \
+                ${'--ctl-subsample ' + ctl_subsample} \
+                ${if ctl_paired_end then '--ctl-paired-end' else ''} \
+                ${'--fdr-thresh '+ fdr_thresh} \
+                ${'--nth ' + cpu}
+        fi
 
-		python3 $(which encode_task_post_call_peak_chip.py) \
-			$(ls *Peak.gz) \
-			${'--ta ' + tas[0]} \
-			${'--regex-bfilt-peak-chr-name \'' + regex_bfilt_peak_chr_name + '\''} \
-			${'--chrsz ' + chrsz} \
-			${'--fraglen ' + fraglen} \
-			${'--peak-type ' + peak_type} \
-			${'--blacklist ' + blacklist}		
-	}
-	output {
-		File peak = glob('*[!.][!b][!f][!i][!l][!t].'+peak_type+'.gz')[0]
-		# generated by post_call_peak py
-		File bfilt_peak = glob('*.bfilt.'+peak_type+'.gz')[0]
-		File bfilt_peak_bb = glob('*.bfilt.'+peak_type+'.bb')[0]
-		File bfilt_peak_hammock = glob('*.bfilt.'+peak_type+'.hammock.gz*')[0]
-		File bfilt_peak_hammock_tbi = glob('*.bfilt.'+peak_type+'.hammock.gz*')[1]
-		File frip_qc = glob('*.frip.qc')[0]
-		File peak_region_size_qc = glob('*.peak_region_size.qc')[0]
-		File peak_region_size_plot = glob('*.peak_region_size.png')[0]
-		File num_peak_qc = glob('*.num_peak.qc')[0]
-	}
-	runtime {
-		cpu : if peak_caller == 'macs2' then 1 else cpu
-		memory : '${mem_mb} MB'
-		time : time_hr
-		disks : disks
-		preemptible: 0		
-	}
+        python3 $(which encode_task_post_call_peak_chip.py) \
+            $(ls *Peak.gz) \
+            ${'--ta ' + tas[0]} \
+            ${'--regex-bfilt-peak-chr-name \'' + regex_bfilt_peak_chr_name + '\''} \
+            ${'--chrsz ' + chrsz} \
+            ${'--fraglen ' + fraglen} \
+            ${'--peak-type ' + peak_type} \
+            ${'--blacklist ' + blacklist}        
+    }
+    output {
+        File peak = glob('*[!.][!b][!f][!i][!l][!t].'+peak_type+'.gz')[0]
+        # generated by post_call_peak py
+        File bfilt_peak = glob('*.bfilt.'+peak_type+'.gz')[0]
+        File bfilt_peak_bb = glob('*.bfilt.'+peak_type+'.bb')[0]
+        File bfilt_peak_hammock = glob('*.bfilt.'+peak_type+'.hammock.gz*')[0]
+        File bfilt_peak_hammock_tbi = glob('*.bfilt.'+peak_type+'.hammock.gz*')[1]
+        File frip_qc = glob('*.frip.qc')[0]
+        File peak_region_size_qc = glob('*.peak_region_size.qc')[0]
+        File peak_region_size_plot = glob('*.peak_region_size.png')[0]
+        File num_peak_qc = glob('*.num_peak.qc')[0]
+    }
+    runtime {
+        cpu : if peak_caller == 'macs2' then 1 else cpu
+        memory : '${mem_mb} MB'
+        time : time_hr
+        disks : disks
+        preemptible: 0        
+    }
 }
 
 task macs2_signal_track {
-	input {
-		Array[File?] tas	# [ta, control_ta]. control_ta is optional
-		Int fraglen		 # fragment length from xcor
-		String gensz		# Genome size (sum of entries in 2nd column of 
-							# chr. sizes file, or hs for human, ms for mouse)
-		File chrsz			# 2-col chromosome sizes file
-		Int ctl_subsample	# subsample control if >0. 0: no subsampling
-		Boolean ctl_paired_end # control is paired end	
-		Float pval_thresh	 # p.value threshold
+    input {
+        Array[File?] tas    # [ta, control_ta]. control_ta is optional
+        Int fraglen         # fragment length from xcor
+        String gensz        # Genome size (sum of entries in 2nd column of 
+                            # chr. sizes file, or hs for human, ms for mouse)
+        File chrsz            # 2-col chromosome sizes file
+        Int ctl_subsample    # subsample control if >0. 0: no subsampling
+        Boolean ctl_paired_end # control is paired end    
+        Float pval_thresh     # p.value threshold
 
-		Int mem_mb
-		Int time_hr
-		String disks
-	}
+        Int mem_mb
+        Int time_hr
+        String disks
+    }
 
-	command {
-		python3 $(which encode_task_macs2_signal_track_chip.py) \
-			${sep=' ' select_all(tas)} \
-			${'--gensz '+ gensz} \
-			${'--chrsz ' + chrsz} \
-			${'--fraglen ' + fraglen} \
-			${'--pval-thresh '+ pval_thresh} \
-			${'--ctl-subsample ' + ctl_subsample} \
-			${if ctl_paired_end then '--ctl-paired-end' else ''}
-	}
-	output {
-		File pval_bw = glob('*.pval.signal.bigwig')[0]
-		File fc_bw = glob('*.fc.signal.bigwig')[0]
-	}
-	runtime {
-		cpu : 1
-		memory : '${mem_mb} MB'
-		time : time_hr
-		disks : disks
-		preemptible: 0
-	}
+    command {
+        python3 $(which encode_task_macs2_signal_track_chip.py) \
+            ${sep=' ' select_all(tas)} \
+            ${'--gensz '+ gensz} \
+            ${'--chrsz ' + chrsz} \
+            ${'--fraglen ' + fraglen} \
+            ${'--pval-thresh '+ pval_thresh} \
+            ${'--ctl-subsample ' + ctl_subsample} \
+            ${if ctl_paired_end then '--ctl-paired-end' else ''}
+    }
+    output {
+        File pval_bw = glob('*.pval.signal.bigwig')[0]
+        File fc_bw = glob('*.fc.signal.bigwig')[0]
+    }
+    runtime {
+        cpu : 1
+        memory : '${mem_mb} MB'
+        time : time_hr
+        disks : disks
+        preemptible: 0
+    }
 }
 
 task idr {
-	input {
-		String prefix		 # prefix for IDR output file
-		File? peak1
-		File? peak2
-		File? peak_pooled
-		Float idr_thresh
-		File? blacklist	 # blacklist BED to filter raw peaks
-		String regex_bfilt_peak_chr_name
-		# parameters to compute FRiP
-		File? ta			# to calculate FRiP
-		Int? fraglen		 # fragment length from xcor
-		File chrsz			# 2-col chromosome sizes file
-		String peak_type
-		String rank
-	}
+    input {
+        String prefix         # prefix for IDR output file
+        File? peak1
+        File? peak2
+        File? peak_pooled
+        Float idr_thresh
+        File? blacklist     # blacklist BED to filter raw peaks
+        String regex_bfilt_peak_chr_name
+        # parameters to compute FRiP
+        File? ta            # to calculate FRiP
+        Int? fraglen         # fragment length from xcor
+        File chrsz            # 2-col chromosome sizes file
+        String peak_type
+        String rank
+    }
 
-	command {
-		${if defined(ta) then '' else 'touch null.frip.qc'}
-		touch null 
-		python3 $(which encode_task_idr.py) \
-			${peak1} ${peak2} ${peak_pooled} \
-			${'--prefix ' + prefix} \
-			${'--idr-thresh ' + idr_thresh} \
-			${'--peak-type ' + peak_type} \
-			--idr-rank ${rank} \
-			${'--fraglen ' + fraglen} \
-			${'--chrsz ' + chrsz} \
-			${'--blacklist '+ blacklist} \
-			${'--regex-bfilt-peak-chr-name \'' + regex_bfilt_peak_chr_name + '\''} \
-			${'--ta ' + ta}
-	}
-	output {
-		File idr_peak = glob('*[!.][!b][!f][!i][!l][!t].'+peak_type+'.gz')[0]
-		File bfilt_idr_peak = glob('*.bfilt.'+peak_type+'.gz')[0]
-		File bfilt_idr_peak_bb = glob('*.bfilt.'+peak_type+'.bb')[0]
-		File bfilt_idr_peak_hammock = glob('*.bfilt.'+peak_type+'.hammock.gz*')[0]
-		File bfilt_idr_peak_hammock_tbi = glob('*.bfilt.'+peak_type+'.hammock.gz*')[1]
-		File idr_plot = glob('*.txt.png')[0]
-		File idr_unthresholded_peak = glob('*.txt.gz')[0]
-		File idr_log = glob('*.idr*.log')[0]
-		File frip_qc = if defined(ta) then glob('*.frip.qc')[0] else glob('null')[0]
-	}
-	runtime {
-		cpu : 1
-		memory : '4000 MB'
-		time : 1
-		disks : 'local-disk 50 HDD'
-	}	
+    command {
+        ${if defined(ta) then '' else 'touch null.frip.qc'}
+        touch null 
+        python3 $(which encode_task_idr.py) \
+            ${peak1} ${peak2} ${peak_pooled} \
+            ${'--prefix ' + prefix} \
+            ${'--idr-thresh ' + idr_thresh} \
+            ${'--peak-type ' + peak_type} \
+            --idr-rank ${rank} \
+            ${'--fraglen ' + fraglen} \
+            ${'--chrsz ' + chrsz} \
+            ${'--blacklist '+ blacklist} \
+            ${'--regex-bfilt-peak-chr-name \'' + regex_bfilt_peak_chr_name + '\''} \
+            ${'--ta ' + ta}
+    }
+    output {
+        File idr_peak = glob('*[!.][!b][!f][!i][!l][!t].'+peak_type+'.gz')[0]
+        File bfilt_idr_peak = glob('*.bfilt.'+peak_type+'.gz')[0]
+        File bfilt_idr_peak_bb = glob('*.bfilt.'+peak_type+'.bb')[0]
+        File bfilt_idr_peak_hammock = glob('*.bfilt.'+peak_type+'.hammock.gz*')[0]
+        File bfilt_idr_peak_hammock_tbi = glob('*.bfilt.'+peak_type+'.hammock.gz*')[1]
+        File idr_plot = glob('*.txt.png')[0]
+        File idr_unthresholded_peak = glob('*.txt.gz')[0]
+        File idr_log = glob('*.idr*.log')[0]
+        File frip_qc = if defined(ta) then glob('*.frip.qc')[0] else glob('null')[0]
+    }
+    runtime {
+        cpu : 1
+        memory : '4000 MB'
+        time : 1
+        disks : 'local-disk 50 HDD'
+    }    
 }
 
 task overlap {
-	input {
-		String prefix	 # prefix for IDR output file
-		File? peak1
-		File? peak2
-		File? peak_pooled
-		File? blacklist # blacklist BED to filter raw peaks
-		String regex_bfilt_peak_chr_name
-		# parameters to compute FRiP
-		File? ta		# to calculate FRiP
-		Int? fraglen	 # fragment length from xcor (for FRIP)
-		File chrsz		# 2-col chromosome sizes file
-		String peak_type
-	}
+    input {
+        String prefix     # prefix for IDR output file
+        File? peak1
+        File? peak2
+        File? peak_pooled
+        File? blacklist # blacklist BED to filter raw peaks
+        String regex_bfilt_peak_chr_name
+        # parameters to compute FRiP
+        File? ta        # to calculate FRiP
+        Int? fraglen     # fragment length from xcor (for FRIP)
+        File chrsz        # 2-col chromosome sizes file
+        String peak_type
+    }
 
-	command {
-		${if defined(ta) then '' else 'touch null.frip.qc'}
-		touch null 
-		python3 $(which encode_task_overlap.py) \
-			${peak1} ${peak2} ${peak_pooled} \
-			${'--prefix ' + prefix} \
-			${'--peak-type ' + peak_type} \
-			${'--fraglen ' + fraglen} \
-			${'--chrsz ' + chrsz} \
-			${'--blacklist '+ blacklist} \
-			--nonamecheck \
-			${'--regex-bfilt-peak-chr-name \'' + regex_bfilt_peak_chr_name + '\''} \
-			${'--ta ' + ta}
-	}
-	output {
-		File overlap_peak = glob('*[!.][!b][!f][!i][!l][!t].'+peak_type+'.gz')[0]
-		File bfilt_overlap_peak = glob('*.bfilt.'+peak_type+'.gz')[0]
-		File bfilt_overlap_peak_bb = glob('*.bfilt.'+peak_type+'.bb')[0]
-		File bfilt_overlap_peak_hammock = glob('*.bfilt.'+peak_type+'.hammock.gz*')[0]
-		File bfilt_overlap_peak_hammock_tbi = glob('*.bfilt.'+peak_type+'.hammock.gz*')[1]
-		File frip_qc = if defined(ta) then glob('*.frip.qc')[0] else glob('null')[0]
-	}
-	runtime {
-		cpu : 1
-		memory : '4000 MB'
-		time : 1
-		disks : 'local-disk 50 HDD'
-	}	
+    command {
+        ${if defined(ta) then '' else 'touch null.frip.qc'}
+        touch null 
+        python3 $(which encode_task_overlap.py) \
+            ${peak1} ${peak2} ${peak_pooled} \
+            ${'--prefix ' + prefix} \
+            ${'--peak-type ' + peak_type} \
+            ${'--fraglen ' + fraglen} \
+            ${'--chrsz ' + chrsz} \
+            ${'--blacklist '+ blacklist} \
+            --nonamecheck \
+            ${'--regex-bfilt-peak-chr-name \'' + regex_bfilt_peak_chr_name + '\''} \
+            ${'--ta ' + ta}
+    }
+    output {
+        File overlap_peak = glob('*[!.][!b][!f][!i][!l][!t].'+peak_type+'.gz')[0]
+        File bfilt_overlap_peak = glob('*.bfilt.'+peak_type+'.gz')[0]
+        File bfilt_overlap_peak_bb = glob('*.bfilt.'+peak_type+'.bb')[0]
+        File bfilt_overlap_peak_hammock = glob('*.bfilt.'+peak_type+'.hammock.gz*')[0]
+        File bfilt_overlap_peak_hammock_tbi = glob('*.bfilt.'+peak_type+'.hammock.gz*')[1]
+        File frip_qc = if defined(ta) then glob('*.frip.qc')[0] else glob('null')[0]
+    }
+    runtime {
+        cpu : 1
+        memory : '4000 MB'
+        time : 1
+        disks : 'local-disk 50 HDD'
+    }    
 }
 
 task reproducibility {
-	input {
-		String prefix
-		Array[File] peaks # peak files from pair of true replicates
-							# in a sorted order. for example of 4 replicates,
-							# 1,2 1,3 1,4 2,3 2,4 3,4.
-							# x,y means peak file from rep-x vs rep-y
-		Array[File]? peaks_pr	# peak files from pseudo replicates
-		File? peak_ppr			# Peak file from pooled pseudo replicate.
-		String peak_type
-		File chrsz			# 2-col chromosome sizes file
-	}
+    input {
+        String prefix
+        Array[File] peaks # peak files from pair of true replicates
+                            # in a sorted order. for example of 4 replicates,
+                            # 1,2 1,3 1,4 2,3 2,4 3,4.
+                            # x,y means peak file from rep-x vs rep-y
+        Array[File]? peaks_pr    # peak files from pseudo replicates
+        File? peak_ppr            # Peak file from pooled pseudo replicate.
+        String peak_type
+        File chrsz            # 2-col chromosome sizes file
+    }
 
-	command {
-		python3 $(which encode_task_reproducibility.py) \
-			${sep=' ' peaks} \
-			--peaks-pr ${sep=' ' peaks_pr} \
-			${'--peak-ppr '+ peak_ppr} \
-			--prefix ${prefix} \
-			${'--peak-type ' + peak_type} \
-			${'--chrsz ' + chrsz}
-	}
-	output {
-		File optimal_peak = glob('*optimal_peak.*.gz')[0]
-		File optimal_peak_bb = glob('*optimal_peak.*.bb')[0]
-		File optimal_peak_hammock = glob('*optimal_peak.*.hammock.gz*')[0]
-		File optimal_peak_hammock_tbi = glob('*optimal_peak.*.hammock.gz*')[1]
-		File conservative_peak = glob('*conservative_peak.*.gz')[0]
-		File conservative_peak_bb = glob('*conservative_peak.*.bb')[0]
-		File conservative_peak_hammock = glob('*conservative_peak.*.hammock.gz*')[0]
-		File conservative_peak_hammock_tbi = glob('*conservative_peak.*.hammock.gz*')[1]
-		File reproducibility_qc = glob('*reproducibility.qc')[0]
-		# QC metrics for optimal peak
-		File peak_region_size_qc = glob('*.peak_region_size.qc')[0]
-		File peak_region_size_plot = glob('*.peak_region_size.png')[0]
-		File num_peak_qc = glob('*.num_peak.qc')[0]
-	}
-	runtime {
-		cpu : 1
-		memory : '4000 MB'
-		time : 1
-		disks : 'local-disk 50 HDD'
-	}	
+    command {
+        python3 $(which encode_task_reproducibility.py) \
+            ${sep=' ' peaks} \
+            --peaks-pr ${sep=' ' peaks_pr} \
+            ${'--peak-ppr '+ peak_ppr} \
+            --prefix ${prefix} \
+            ${'--peak-type ' + peak_type} \
+            ${'--chrsz ' + chrsz}
+    }
+    output {
+        File optimal_peak = glob('*optimal_peak.*.gz')[0]
+        File optimal_peak_bb = glob('*optimal_peak.*.bb')[0]
+        File optimal_peak_hammock = glob('*optimal_peak.*.hammock.gz*')[0]
+        File optimal_peak_hammock_tbi = glob('*optimal_peak.*.hammock.gz*')[1]
+        File conservative_peak = glob('*conservative_peak.*.gz')[0]
+        File conservative_peak_bb = glob('*conservative_peak.*.bb')[0]
+        File conservative_peak_hammock = glob('*conservative_peak.*.hammock.gz*')[0]
+        File conservative_peak_hammock_tbi = glob('*conservative_peak.*.hammock.gz*')[1]
+        File reproducibility_qc = glob('*reproducibility.qc')[0]
+        # QC metrics for optimal peak
+        File peak_region_size_qc = glob('*.peak_region_size.qc')[0]
+        File peak_region_size_plot = glob('*.peak_region_size.png')[0]
+        File num_peak_qc = glob('*.num_peak.qc')[0]
+    }
+    runtime {
+        cpu : 1
+        memory : '4000 MB'
+        time : 1
+        disks : 'local-disk 50 HDD'
+    }    
 }
 
 task gc_bias {
-	input {
-		File? nodup_bam
-		File ref_fa
+    input {
+        File? nodup_bam
+        File ref_fa
 
-		String? picard_java_heap
-	}
-	Int mem_mb = 10000
-	Float picard_java_heap_factor = 0.9
+        String? picard_java_heap
+    }
+    Int mem_mb = 10000
+    Float picard_java_heap_factor = 0.9
 
-	command {
-		python3 $(which encode_task_gc_bias.py) \
-			${'--nodup-bam ' + nodup_bam} \
-			${'--ref-fa ' + ref_fa} \
-			${'--picard-java-heap ' + if defined(picard_java_heap) then picard_java_heap else (round(mem_mb * picard_java_heap_factor) + 'M')}
-	}
-	output {
-		File gc_plot = glob('*.gc_plot.png')[0]
-		File gc_log = glob('*.gc.txt')[0]
-	}
-	runtime {
-		cpu : 1
-		memory : '${mem_mb} MB'
-		time : 6
-		disks : 'local-disk 100 HDD'
-	}
+    command {
+        python3 $(which encode_task_gc_bias.py) \
+            ${'--nodup-bam ' + nodup_bam} \
+            ${'--ref-fa ' + ref_fa} \
+            ${'--picard-java-heap ' + if defined(picard_java_heap) then picard_java_heap else (round(mem_mb * picard_java_heap_factor) + 'M')}
+    }
+    output {
+        File gc_plot = glob('*.gc_plot.png')[0]
+        File gc_log = glob('*.gc.txt')[0]
+    }
+    runtime {
+        cpu : 1
+        memory : '${mem_mb} MB'
+        time : 6
+        disks : 'local-disk 100 HDD'
+    }
 }
 
 task qc_report {
-	input {
-		# optional metadata
-		String pipeline_ver
-		String title # name of sample
-		String description # description for sample
-		String? genome
-		#String? encode_accession_id	# ENCODE accession ID of sample
-		# workflow params
-		Array[Boolean] paired_ends
-		Array[Boolean] ctl_paired_ends
-		String pipeline_type
-		String aligner
-		String peak_caller
-		Int cap_num_peak
-		Float idr_thresh
-		Float pval_thresh
-		Int xcor_trim_bp
-		Int xcor_subsample_reads
-		# QCs
-		Array[File] samstat_qcs
-		Array[File] nodup_samstat_qcs
-		Array[File] dup_qcs
-		Array[File] lib_complexity_qcs
-		Array[File] ctl_samstat_qcs
-		Array[File] ctl_nodup_samstat_qcs
-		Array[File] ctl_dup_qcs
-		Array[File] ctl_lib_complexity_qcs
-		Array[File] xcor_plots
-		Array[File] xcor_scores
-		File? jsd_plot
-		Array[File]? jsd_qcs
-		Array[File] idr_plots
-		Array[File]? idr_plots_pr
-		File? idr_plot_ppr
-		Array[File] frip_qcs
-		Array[File] frip_qcs_pr1
-		Array[File] frip_qcs_pr2
-		File? frip_qc_pooled
-		File? frip_qc_ppr1 
-		File? frip_qc_ppr2 
-		Array[File] frip_idr_qcs
-		Array[File]? frip_idr_qcs_pr
-		File? frip_idr_qc_ppr 
-		Array[File] frip_overlap_qcs
-		Array[File]? frip_overlap_qcs_pr
-		File? frip_overlap_qc_ppr
-		File? idr_reproducibility_qc
-		File? overlap_reproducibility_qc
+    input {
+        # optional metadata
+        String pipeline_ver
+        String title # name of sample
+        String description # description for sample
+        String? genome
+        #String? encode_accession_id    # ENCODE accession ID of sample
+        # workflow params
+        Array[Boolean] paired_ends
+        Array[Boolean] ctl_paired_ends
+        String pipeline_type
+        String aligner
+        String peak_caller
+        Int cap_num_peak
+        Float idr_thresh
+        Float pval_thresh
+        Int xcor_trim_bp
+        Int xcor_subsample_reads
+        # QCs
+        Array[File] samstat_qcs
+        Array[File] nodup_samstat_qcs
+        Array[File] dup_qcs
+        Array[File] lib_complexity_qcs
+        Array[File] ctl_samstat_qcs
+        Array[File] ctl_nodup_samstat_qcs
+        Array[File] ctl_dup_qcs
+        Array[File] ctl_lib_complexity_qcs
+        Array[File] xcor_plots
+        Array[File] xcor_scores
+        File? jsd_plot
+        Array[File]? jsd_qcs
+        Array[File] idr_plots
+        Array[File]? idr_plots_pr
+        File? idr_plot_ppr
+        Array[File] frip_qcs
+        Array[File] frip_qcs_pr1
+        Array[File] frip_qcs_pr2
+        File? frip_qc_pooled
+        File? frip_qc_ppr1 
+        File? frip_qc_ppr2 
+        Array[File] frip_idr_qcs
+        Array[File]? frip_idr_qcs_pr
+        File? frip_idr_qc_ppr 
+        Array[File] frip_overlap_qcs
+        Array[File]? frip_overlap_qcs_pr
+        File? frip_overlap_qc_ppr
+        File? idr_reproducibility_qc
+        File? overlap_reproducibility_qc
 
-		Array[File] gc_plots
+        Array[File] gc_plots
 
-		Array[File] peak_region_size_qcs
-		Array[File] peak_region_size_plots
-		Array[File] num_peak_qcs
+        Array[File] peak_region_size_qcs
+        Array[File] peak_region_size_plots
+        Array[File] num_peak_qcs
 
-		File? idr_opt_peak_region_size_qc
-		File? idr_opt_peak_region_size_plot
-		File? idr_opt_num_peak_qc
+        File? idr_opt_peak_region_size_qc
+        File? idr_opt_peak_region_size_plot
+        File? idr_opt_num_peak_qc
 
-		File? overlap_opt_peak_region_size_qc
-		File? overlap_opt_peak_region_size_plot
-		File? overlap_opt_num_peak_qc
+        File? overlap_opt_peak_region_size_qc
+        File? overlap_opt_peak_region_size_plot
+        File? overlap_opt_num_peak_qc
 
-		File? qc_json_ref
-	}
+        File? qc_json_ref
+    }
 
-	command {
-		python3 $(which encode_task_qc_report.py) \
-			${'--pipeline-ver ' + pipeline_ver} \
-			${"--title '" + sub(title,"'","_") + "'"} \
-			${"--desc '" + sub(description,"'","_") + "'"} \
-			${'--genome ' + genome} \
-			${'--multimapping ' + 0} \
-			--paired-ends ${sep=' ' paired_ends} \
-			--ctl-paired-ends ${sep=' ' ctl_paired_ends} \
-			--pipeline-type ${pipeline_type} \
-			--aligner ${aligner} \
-			--peak-caller ${peak_caller} \
-			${'--cap-num-peak ' + cap_num_peak} \
-			--idr-thresh ${idr_thresh} \
-			--pval-thresh ${pval_thresh} \
-			--xcor-trim-bp ${xcor_trim_bp} \
-			--xcor-subsample-reads ${xcor_subsample_reads} \
-			--samstat-qcs ${sep='_:_' samstat_qcs} \
-			--nodup-samstat-qcs ${sep='_:_' nodup_samstat_qcs} \
-			--dup-qcs ${sep='_:_' dup_qcs} \
-			--lib-complexity-qcs ${sep='_:_' lib_complexity_qcs} \
-			--xcor-plots ${sep='_:_' xcor_plots} \
-			--xcor-scores ${sep='_:_' xcor_scores} \
-			--idr-plots ${sep='_:_' idr_plots} \
-			--idr-plots-pr ${sep='_:_' idr_plots_pr} \
-			--ctl-samstat-qcs ${sep='_:_' ctl_samstat_qcs} \
-			--ctl-nodup-samstat-qcs ${sep='_:_' ctl_nodup_samstat_qcs} \
-			--ctl-dup-qcs ${sep='_:_' ctl_dup_qcs} \
-			--ctl-lib-complexity-qcs ${sep='_:_' ctl_lib_complexity_qcs} \
-			${'--jsd-plot ' + jsd_plot} \
-			--jsd-qcs ${sep='_:_' jsd_qcs} \
-			${'--idr-plot-ppr ' + idr_plot_ppr} \
-			--frip-qcs ${sep='_:_' frip_qcs} \
-			--frip-qcs-pr1 ${sep='_:_' frip_qcs_pr1} \
-			--frip-qcs-pr2 ${sep='_:_' frip_qcs_pr2} \
-			${'--frip-qc-pooled ' + frip_qc_pooled} \
-			${'--frip-qc-ppr1 ' + frip_qc_ppr1} \
-			${'--frip-qc-ppr2 ' + frip_qc_ppr2} \
-			--frip-idr-qcs ${sep='_:_' frip_idr_qcs} \
-			--frip-idr-qcs-pr ${sep='_:_' frip_idr_qcs_pr} \
-			${'--frip-idr-qc-ppr ' + frip_idr_qc_ppr} \
-			--frip-overlap-qcs ${sep='_:_' frip_overlap_qcs} \
-			--frip-overlap-qcs-pr ${sep='_:_' frip_overlap_qcs_pr} \
-			${'--frip-overlap-qc-ppr ' + frip_overlap_qc_ppr} \
-			${'--idr-reproducibility-qc ' + idr_reproducibility_qc} \
-			${'--overlap-reproducibility-qc ' + overlap_reproducibility_qc} \
-			--gc-plots ${sep='_:_' gc_plots} \
-			--peak-region-size-qcs ${sep='_:_' peak_region_size_qcs} \
-			--peak-region-size-plots ${sep='_:_' peak_region_size_plots} \
-			--num-peak-qcs ${sep='_:_' num_peak_qcs} \
-			${'--idr-opt-peak-region-size-qc ' + idr_opt_peak_region_size_qc} \
-			${'--idr-opt-peak-region-size-plot ' + idr_opt_peak_region_size_plot} \
-			${'--idr-opt-num-peak-qc ' + idr_opt_num_peak_qc} \
-			${'--overlap-opt-peak-region-size-qc ' + overlap_opt_peak_region_size_qc} \
-			${'--overlap-opt-peak-region-size-plot ' + overlap_opt_peak_region_size_plot} \
-			${'--overlap-opt-num-peak-qc ' + overlap_opt_num_peak_qc} \
-			--out-qc-html qc.html \
-			--out-qc-json qc.json \
-			${'--qc-json-ref ' + qc_json_ref}
-	}
-	output {
-		File report = glob('*qc.html')[0]
-		File qc_json = glob('*qc.json')[0]
-		Boolean qc_json_ref_match = read_string('qc_json_ref_match.txt')=='True'
-	}
-	runtime {
-		cpu : 1
-		memory : '4000 MB'
-		time : 1
-		disks : 'local-disk 50 HDD'
-	}	
+    command {
+        python3 $(which encode_task_qc_report.py) \
+            ${'--pipeline-ver ' + pipeline_ver} \
+            ${"--title '" + sub(title,"'","_") + "'"} \
+            ${"--desc '" + sub(description,"'","_") + "'"} \
+            ${'--genome ' + genome} \
+            ${'--multimapping ' + 0} \
+            --paired-ends ${sep=' ' paired_ends} \
+            --ctl-paired-ends ${sep=' ' ctl_paired_ends} \
+            --pipeline-type ${pipeline_type} \
+            --aligner ${aligner} \
+            --peak-caller ${peak_caller} \
+            ${'--cap-num-peak ' + cap_num_peak} \
+            --idr-thresh ${idr_thresh} \
+            --pval-thresh ${pval_thresh} \
+            --xcor-trim-bp ${xcor_trim_bp} \
+            --xcor-subsample-reads ${xcor_subsample_reads} \
+            --samstat-qcs ${sep='_:_' samstat_qcs} \
+            --nodup-samstat-qcs ${sep='_:_' nodup_samstat_qcs} \
+            --dup-qcs ${sep='_:_' dup_qcs} \
+            --lib-complexity-qcs ${sep='_:_' lib_complexity_qcs} \
+            --xcor-plots ${sep='_:_' xcor_plots} \
+            --xcor-scores ${sep='_:_' xcor_scores} \
+            --idr-plots ${sep='_:_' idr_plots} \
+            --idr-plots-pr ${sep='_:_' idr_plots_pr} \
+            --ctl-samstat-qcs ${sep='_:_' ctl_samstat_qcs} \
+            --ctl-nodup-samstat-qcs ${sep='_:_' ctl_nodup_samstat_qcs} \
+            --ctl-dup-qcs ${sep='_:_' ctl_dup_qcs} \
+            --ctl-lib-complexity-qcs ${sep='_:_' ctl_lib_complexity_qcs} \
+            ${'--jsd-plot ' + jsd_plot} \
+            --jsd-qcs ${sep='_:_' jsd_qcs} \
+            ${'--idr-plot-ppr ' + idr_plot_ppr} \
+            --frip-qcs ${sep='_:_' frip_qcs} \
+            --frip-qcs-pr1 ${sep='_:_' frip_qcs_pr1} \
+            --frip-qcs-pr2 ${sep='_:_' frip_qcs_pr2} \
+            ${'--frip-qc-pooled ' + frip_qc_pooled} \
+            ${'--frip-qc-ppr1 ' + frip_qc_ppr1} \
+            ${'--frip-qc-ppr2 ' + frip_qc_ppr2} \
+            --frip-idr-qcs ${sep='_:_' frip_idr_qcs} \
+            --frip-idr-qcs-pr ${sep='_:_' frip_idr_qcs_pr} \
+            ${'--frip-idr-qc-ppr ' + frip_idr_qc_ppr} \
+            --frip-overlap-qcs ${sep='_:_' frip_overlap_qcs} \
+            --frip-overlap-qcs-pr ${sep='_:_' frip_overlap_qcs_pr} \
+            ${'--frip-overlap-qc-ppr ' + frip_overlap_qc_ppr} \
+            ${'--idr-reproducibility-qc ' + idr_reproducibility_qc} \
+            ${'--overlap-reproducibility-qc ' + overlap_reproducibility_qc} \
+            --gc-plots ${sep='_:_' gc_plots} \
+            --peak-region-size-qcs ${sep='_:_' peak_region_size_qcs} \
+            --peak-region-size-plots ${sep='_:_' peak_region_size_plots} \
+            --num-peak-qcs ${sep='_:_' num_peak_qcs} \
+            ${'--idr-opt-peak-region-size-qc ' + idr_opt_peak_region_size_qc} \
+            ${'--idr-opt-peak-region-size-plot ' + idr_opt_peak_region_size_plot} \
+            ${'--idr-opt-num-peak-qc ' + idr_opt_num_peak_qc} \
+            ${'--overlap-opt-peak-region-size-qc ' + overlap_opt_peak_region_size_qc} \
+            ${'--overlap-opt-peak-region-size-plot ' + overlap_opt_peak_region_size_plot} \
+            ${'--overlap-opt-num-peak-qc ' + overlap_opt_num_peak_qc} \
+            --out-qc-html qc.html \
+            --out-qc-json qc.json \
+            ${'--qc-json-ref ' + qc_json_ref}
+    }
+    output {
+        File report = glob('*qc.html')[0]
+        File qc_json = glob('*qc.json')[0]
+        Boolean qc_json_ref_match = read_string('qc_json_ref_match.txt')=='True'
+    }
+    runtime {
+        cpu : 1
+        memory : '4000 MB'
+        time : 1
+        disks : 'local-disk 50 HDD'
+    }    
 }
 
 ### workflow system tasks
 task read_genome_tsv {
-	input {
-		File? genome_tsv
-		String? null_s
-	}
-	command <<<
-		echo "$(basename ~{genome_tsv})" > genome_name
-		# create empty files for all entries
-		touch ref_fa bowtie2_idx_tar bwa_idx_tar chrsz gensz blacklist blacklist2
-		touch tss tss_enrich # for backward compatibility
-		touch dnase prom enh reg2map reg2map_bed roadmap_meta
-		touch mito_chr_name
-		touch regex_bfilt_peak_chr_name
+    input {
+        File? genome_tsv
+        String? null_s
+    }
+    command <<<
+        echo "$(basename ~{genome_tsv})" > genome_name
+        # create empty files for all entries
+        touch ref_fa bowtie2_idx_tar bwa_idx_tar chrsz gensz blacklist blacklist2
+        touch tss tss_enrich # for backward compatibility
+        touch dnase prom enh reg2map reg2map_bed roadmap_meta
+        touch mito_chr_name
+        touch regex_bfilt_peak_chr_name
 
-		python <<CODE
-		import os
-		with open('~{genome_tsv}','r') as fp:
-			for line in fp:
-				arr = line.strip('\n').split('\t')
-				if arr:
-					key, val = arr
-					with open(key,'w') as fp2:
-						fp2.write(val)
-		CODE
-	>>>
-	output {
-		String? genome_name = read_string('genome_name')
-		String? ref_fa = if size('ref_fa')==0 then null_s else read_string('ref_fa')
-		String? bwa_idx_tar = if size('bwa_idx_tar')==0 then null_s else read_string('bwa_idx_tar')
-		String? bowtie2_idx_tar = if size('bowtie2_idx_tar')==0 then null_s else read_string('bowtie2_idx_tar')
-		String? chrsz = if size('chrsz')==0 then null_s else read_string('chrsz')
-		String? gensz = if size('gensz')==0 then null_s else read_string('gensz')
-		String? blacklist = if size('blacklist')==0 then null_s else read_string('blacklist')
-		String? blacklist2 = if size('blacklist2')==0 then null_s else read_string('blacklist2')
-		String? mito_chr_name = if size('mito_chr_name')==0 then null_s else read_string('mito_chr_name')
-		String? regex_bfilt_peak_chr_name = if size('regex_bfilt_peak_chr_name')==0 then 'chr[\\dXY]+'
-			else read_string('regex_bfilt_peak_chr_name')
-		String? tss = if size('tss')!=0 then read_string('tss')
-			else if size('tss_enrich')!=0 then read_string('tss_enrich') else null_s
-		String? dnase = if size('dnase')==0 then null_s else read_string('dnase')
-		String? prom = if size('prom')==0 then null_s else read_string('prom')
-		String? enh = if size('enh')==0 then null_s else read_string('enh')
-		String? reg2map = if size('reg2map')==0 then null_s else read_string('reg2map')
-		String? reg2map_bed = if size('reg2map_bed')==0 then null_s else read_string('reg2map_bed')
-		String? roadmap_meta = if size('roadmap_meta')==0 then null_s else read_string('roadmap_meta')
-	}
-	runtime {
-		maxRetries : 0
-		cpu : 1
-		memory : '4000 MB'
-		time : 1
-		disks : 'local-disk 50 HDD'		
-	}
+        python <<CODE
+        import os
+        with open('~{genome_tsv}','r') as fp:
+            for line in fp:
+                arr = line.strip('\n').split('\t')
+                if arr:
+                    key, val = arr
+                    with open(key,'w') as fp2:
+                        fp2.write(val)
+        CODE
+    >>>
+    output {
+        String? genome_name = read_string('genome_name')
+        String? ref_fa = if size('ref_fa')==0 then null_s else read_string('ref_fa')
+        String? bwa_idx_tar = if size('bwa_idx_tar')==0 then null_s else read_string('bwa_idx_tar')
+        String? bowtie2_idx_tar = if size('bowtie2_idx_tar')==0 then null_s else read_string('bowtie2_idx_tar')
+        String? chrsz = if size('chrsz')==0 then null_s else read_string('chrsz')
+        String? gensz = if size('gensz')==0 then null_s else read_string('gensz')
+        String? blacklist = if size('blacklist')==0 then null_s else read_string('blacklist')
+        String? blacklist2 = if size('blacklist2')==0 then null_s else read_string('blacklist2')
+        String? mito_chr_name = if size('mito_chr_name')==0 then null_s else read_string('mito_chr_name')
+        String? regex_bfilt_peak_chr_name = if size('regex_bfilt_peak_chr_name')==0 then 'chr[\\dXY]+'
+            else read_string('regex_bfilt_peak_chr_name')
+        String? tss = if size('tss')!=0 then read_string('tss')
+            else if size('tss_enrich')!=0 then read_string('tss_enrich') else null_s
+        String? dnase = if size('dnase')==0 then null_s else read_string('dnase')
+        String? prom = if size('prom')==0 then null_s else read_string('prom')
+        String? enh = if size('enh')==0 then null_s else read_string('enh')
+        String? reg2map = if size('reg2map')==0 then null_s else read_string('reg2map')
+        String? reg2map_bed = if size('reg2map_bed')==0 then null_s else read_string('reg2map_bed')
+        String? roadmap_meta = if size('roadmap_meta')==0 then null_s else read_string('roadmap_meta')
+    }
+    runtime {
+        maxRetries : 0
+        cpu : 1
+        memory : '4000 MB'
+        time : 1
+        disks : 'local-disk 50 HDD'        
+    }
 }
 
 task rounded_mean {
-	input {
-		Array[Int] ints
-	}
-	command <<<
-		python <<CODE
-		arr = [~{sep=',' ints}]
-		with open('tmp.txt','w') as fp:
-			if len(arr):
-				sum_ = sum(arr)
-				mean_ = sum(arr)/float(len(arr))
-				fp.write('{}'.format(int(round(mean_))))
-			else:
-				fp.write('0')
-		CODE
-	>>>
-	output {
-		Int rounded_mean = read_int('tmp.txt')
-	}
-	runtime {
-		cpu : 1
-		memory : '4000 MB'
-		time : 1
-		disks : 'local-disk 50 HDD'
-	}	
+    input {
+        Array[Int] ints
+    }
+    command <<<
+        python <<CODE
+        arr = [~{sep=',' ints}]
+        with open('tmp.txt','w') as fp:
+            if len(arr):
+                sum_ = sum(arr)
+                mean_ = sum(arr)/float(len(arr))
+                fp.write('{}'.format(int(round(mean_))))
+            else:
+                fp.write('0')
+        CODE
+    >>>
+    output {
+        Int rounded_mean = read_int('tmp.txt')
+    }
+    runtime {
+        cpu : 1
+        memory : '4000 MB'
+        time : 1
+        disks : 'local-disk 50 HDD'
+    }    
 }
 
 task raise_exception {
-	input {
-		String msg
-		Array[String]? vals
-	}
-	command {
-		echo -e "\n* Error: ${msg}\n" >&2
-		echo -e "* Vals: ${sep=',' vals}\n" >&2
-		exit 2
-	}
-	output {
-		String error_msg = '${msg}'
-	}
-	runtime {
-		maxRetries : 0
-	}
+    input {
+        String msg
+        Array[String]? vals
+    }
+    command {
+        echo -e "\n* Error: ${msg}\n" >&2
+        echo -e "* Vals: ${sep=',' vals}\n" >&2
+        exit 2
+    }
+    output {
+        String error_msg = '${msg}'
+    }
+    runtime {
+        maxRetries : 0
+    }
 }

--- a/chip.wdl
+++ b/chip.wdl
@@ -1,235 +1,878 @@
-#CAPER docker quay.io/encode-dcc/chip-seq-pipeline:v1.4.0.1
-#CAPER singularity docker://quay.io/encode-dcc/chip-seq-pipeline:v1.4.0.1
-#CROO out_def https://storage.googleapis.com/encode-pipeline-output-definition/chip.croo.v4.json
+version 1.0
 
 workflow chip {
+	String pipeline_ver = 'v1.4.0.1'
+
 	meta {
 		author: 'Jin wook Lee (leepc12@gmail.com) at ENCODE-DCC'
 		description: 'ENCODE TF/Histone ChIP-Seq pipeline'
+		specification_document: 'https://docs.google.com/document/d/1lG_Rd7fnYgRpSIqrIfuVlAz2dW1VaSQThzk836Db99c/edit?usp=sharing'
 
 		caper_docker: 'quay.io/encode-dcc/chip-seq-pipeline:v1.4.0.1'
 		caper_singularity: 'docker://quay.io/encode-dcc/chip-seq-pipeline:v1.4.0.1'
 		croo_out_def: 'https://storage.googleapis.com/encode-pipeline-output-definition/chip.croo.v4.json'
 	}
-	# pipeline version
-	String pipeline_ver = 'v1.4.0.1'
-	### sample name, description
-	String title = 'Untitled'
-	String description = 'No description'
+	input {
+		# group: pipeline_metadata
+		String title = 'Untitled'
+		String description = 'No description'
 
-	# endedness for input data
-	Boolean? paired_end				# to define endedness for all replciates
-									#	if defined, this will override individual endedness below
-	Array[Boolean] paired_ends = []	# to define endedness for individual replicate
-	Boolean? ctl_paired_end
-	Array[Boolean] ctl_paired_ends = []
+		# group: reference_genome
+		File? genome_tsv
+		String? genome_name
+		File? ref_fa
+		File? bwa_idx_tar
+		File? bowtie2_idx_tar
+		File? chrsz
+		File? blacklist
+		File? blacklist2
+		String? mito_chr_name
+		String? regex_bfilt_peak_chr_name
+		String? gensz
+		File? tss
+		File? dnase
+		File? prom
+		File? enh
+		File? reg2map
+		File? reg2map_bed
+		File? roadmap_meta
 
-	### mandatory genome param
-	File? genome_tsv 				# reference genome data TSV file including
-									# all genome-specific file paths and parameters
-	# individual genome parameters
-	String? genome_name				# genome name
-	File? ref_fa					# reference fasta (*.fa.gz)
-	File? bwa_idx_tar 				# bwa index tar (uncompressed .tar)
-	File? bowtie2_idx_tar 			# bowtie2 index tar (uncompressed .tar)
-	File? custom_aligner_idx_tar 	# custom aligner's index tar (uncompressed .tar)
-	File? chrsz 					# 2-col chromosome sizes file
-	File? blacklist 				# blacklist BED (peaks overlapping will be filtered out)
-	File? blacklist2 				# 2nd blacklist (will be merged with 1st one)
-	String? mito_chr_name
-	String? regex_bfilt_peak_chr_name
-	String? gensz 					# genome sizes (hs for human, mm for mouse or sum of 2nd col in chrsz)
-	File? tss 						# TSS BED file
-	File? dnase 					# open chromatin region BED file
-	File? prom 						# promoter region BED file
-	File? enh 						# enhancer region BED file
-	File? reg2map 					# file with cell type signals
-	File? reg2map_bed 				# file of regions used to generate reg2map signals
-	File? roadmap_meta 				# roadmap metedata
+		# group: input_genomic_data
+		Boolean? paired_end
+		Array[Boolean] paired_ends = []
+		Array[File] fastqs_rep1_R1 = []
+		Array[File] fastqs_rep1_R2 = []
+		Array[File] fastqs_rep2_R1 = []
+		Array[File] fastqs_rep2_R2 = []
+		Array[File] fastqs_rep3_R1 = []
+		Array[File] fastqs_rep3_R2 = []
+		Array[File] fastqs_rep4_R1 = []
+		Array[File] fastqs_rep4_R2 = []
+		Array[File] fastqs_rep5_R1 = []
+		Array[File] fastqs_rep5_R2 = []
+		Array[File] fastqs_rep6_R1 = []
+		Array[File] fastqs_rep6_R2 = []
+		Array[File] fastqs_rep7_R1 = []
+		Array[File] fastqs_rep7_R2 = []
+		Array[File] fastqs_rep8_R1 = []
+		Array[File] fastqs_rep8_R2 = []
+		Array[File] fastqs_rep9_R1 = []
+		Array[File] fastqs_rep9_R2 = []
+		Array[File] fastqs_rep10_R1 = []
+		Array[File] fastqs_rep10_R2 = []
+		Array[File?] bams = []
+		Array[File?] nodup_bams = []
+		Array[File?] tas = []
+		Array[File?] peaks = []
+		Array[File?] peaks_pr1 = []
+		Array[File?] peaks_pr2 = []
+		File? peak_ppr1
+		File? peak_ppr2
+		File? peak_pooled
 
-	### pipeline type
-	String pipeline_type  			# tf or histone chip-seq
+		Boolean? ctl_paired_end
+		Array[Boolean] ctl_paired_ends = []
+		Array[File] ctl_fastqs_rep1_R1 = []
+		Array[File] ctl_fastqs_rep1_R2 = []
+		Array[File] ctl_fastqs_rep2_R1 = []
+		Array[File] ctl_fastqs_rep2_R2 = []
+		Array[File] ctl_fastqs_rep3_R1 = []
+		Array[File] ctl_fastqs_rep3_R2 = []
+		Array[File] ctl_fastqs_rep4_R1 = []
+		Array[File] ctl_fastqs_rep4_R2 = []
+		Array[File] ctl_fastqs_rep5_R1 = []
+		Array[File] ctl_fastqs_rep5_R2 = []
+		Array[File] ctl_fastqs_rep6_R1 = []
+		Array[File] ctl_fastqs_rep6_R2 = []
+		Array[File] ctl_fastqs_rep7_R1 = []
+		Array[File] ctl_fastqs_rep7_R2 = []
+		Array[File] ctl_fastqs_rep8_R1 = []
+		Array[File] ctl_fastqs_rep8_R2 = []
+		Array[File] ctl_fastqs_rep9_R1 = []
+		Array[File] ctl_fastqs_rep9_R2 = []
+		Array[File] ctl_fastqs_rep10_R1 = []
+		Array[File] ctl_fastqs_rep10_R2 = []
+		Array[File?] ctl_bams = []
+		Array[File?] ctl_nodup_bams = []
+		Array[File?] ctl_tas = []
 
-	String aligner = 'bowtie2'
-	File? custom_align_py 			# custom align python script
+		# group: pipeline_parameter
+		String pipeline_type
+		Boolean align_only = false
+		Boolean true_rep_only = false
+		Boolean enable_count_signal_track = false
+		Boolean enable_jsd = true
+		Boolean enable_gc_bias = true
 
-	String? peak_caller 			# default: (spp for tf) and (macs2 for histone)
-									# this will override the above defaults
-	String? peak_type 				# default: narrowPeak for macs2, regionPeak for spp
-									# this will override the above defaults
-	File? custom_call_peak_py 		# custom call_peak python script
+		# group: alignment
+		String aligner = 'bowtie2'
+		Boolean use_bwa_mem_for_pe = false
+		Int crop_length = 0
+		Int crop_length_tol = 2
+		Int xcor_trim_bp = 50
+		Boolean use_filt_pe_ta_for_xcor = false
+		String dup_marker = 'picard'
+		Boolean no_dup_removal = false
+		Int mapq_thresh = 30
+		Array[String] filter_chrs = []
+		Int subsample_reads = 0
+		Int ctl_subsample_reads = 0
+		Int ctl_depth_limit = 200000000
+		Float exp_ctl_depth_ratio_limit = 5.0
 
-	## parameters for alignment
-	Boolean align_only = false 		# disable all post-align analysis (peak-calling, overlap, idr, ...)
-	Boolean true_rep_only = false 	# disable all analyses involving pseudo replicates (including overlap/idr)
-	Boolean enable_count_signal_track = false 		# generate count signal track
-	Boolean enable_jsd = true 		# enable JSD plot generation (deeptools fingerprint)
-	Boolean enable_gc_bias = true
+		Int xcor_subsample_reads = 15000000
+		Int xcor_exclusion_range_min = -500
+		Int? xcor_exclusion_range_max
 
-	# parameters for aligner and filter
-	Boolean use_bwa_mem_for_pe = false # THIS IS EXPERIMENTAL and BWA ONLY (use bwa mem instead of bwa aln/sam)
-									# available only for PE dataset with READ_LEN>=70bp
-	Int crop_length = 0 			# crop reads in FASTQs with Trimmomatic (0 by default, i.e. disabled)
-	Int crop_length_tol = 2 	# keep shorter reads around crop_length
-	Int xcor_trim_bp = 50 			# for cross-correlation analysis only (R1 of paired-end fastqs)
-	Boolean use_filt_pe_ta_for_xcor = false # PE only. use filtered PE BAM for cross-corr.
-	String dup_marker = 'picard'	# picard, sambamba
-	Boolean no_dup_removal = false	# keep all dups in final BAM
-	Int? mapq_thresh 				# threshold for low MAPQ reads removal
-	Int mapq_thresh_bwa = 30
-	Int mapq_thresh_bowtie2 = 30
-	Array[String] filter_chrs = [] 	# array of chromosomes to be removed from nodup/filt BAM
-									# chromosomes will be removed from both BAM header/contents
-									# e.g. ['chrM', 'MT']
-	Int subsample_reads = 0			# number of reads to subsample TAGALIGN
-									# 0 for no subsampling. this affects all downstream analysis
-	Int ctl_subsample_reads = 0		# number of reads to subsample control TAGALIGN
-	Int ctl_depth_limit = 200000000
-	Float exp_ctl_depth_ratio_limit = 5.0
+		# group: peak_calling
+		Array[Int?] fraglen = []
+		String? peak_caller
+		Boolean always_use_pooled_ctl = false # always use pooled control for all exp rep.
+		Float ctl_depth_ratio = 1.2	 # if ratio between controls is higher than this
+										# then always use pooled control for all exp rep.
+		Int? cap_num_peak
+		Float pval_thresh = 0.01		# p.value threshold (for MACS2 peak caller only)
+		Float fdr_thresh = 0.01			# FDR threshold (for SPP peak caller only: Rscript run_spp.R -fdr)
+		Float idr_thresh = 0.05			# IDR threshold
 
-	Int xcor_subsample_reads = 15000000 # subsample TAG-ALIGN for xcor only (not used for other downsteam analyses)
-	Int xcor_exclusion_range_min = -500
-	Int? xcor_exclusion_range_max
+		# group: resource_parameter
+		Int align_cpu = 4
+		Int align_mem_mb = 20000
+		Int align_time_hr = 48
+		String align_disks = 'local-disk 400 HDD'
 
-	# parameters for peak calling
-	Boolean always_use_pooled_ctl = false # always use pooled control for all exp rep.
-	Float ctl_depth_ratio = 1.2 	# if ratio between controls is higher than this
-									# then always use pooled control for all exp rep.
-	Int? cap_num_peak
-	Int cap_num_peak_spp = 300000	# cap number of raw peaks called from SPP
-	Int cap_num_peak_macs2 = 500000	# cap number of raw peaks called from MACS2
-	Float pval_thresh = 0.01		# p.value threshold (for MACS2 peak caller only)
-	Float fdr_thresh = 0.01			# FDR threshold (for SPP peak caller only: Rscript run_spp.R -fdr)
-	Float idr_thresh = 0.05			# IDR threshold
+		Int filter_cpu = 2
+		Int filter_mem_mb = 20000
+		Int filter_time_hr = 24
+		String filter_disks = 'local-disk 400 HDD'
 
-	### resources
-	Int align_cpu = 4
-	Int align_mem_mb = 20000
-	Int align_time_hr = 48
-	String align_disks = 'local-disk 400 HDD'
+		Int bam2ta_cpu = 2
+		Int bam2ta_mem_mb = 10000
+		Int bam2ta_time_hr = 6
+		String bam2ta_disks = 'local-disk 100 HDD'
 
-	Int filter_cpu = 2
-	Int filter_mem_mb = 20000
-	Int filter_time_hr = 24
-	String filter_disks = 'local-disk 400 HDD'
+		Int spr_mem_mb = 16000
 
-	Int bam2ta_cpu = 2
-	Int bam2ta_mem_mb = 10000
-	Int bam2ta_time_hr = 6
-	String bam2ta_disks = 'local-disk 100 HDD'
+		Int jsd_cpu = 2
+		Int jsd_mem_mb = 12000
+		Int jsd_time_hr = 6
+		String jsd_disks = 'local-disk 200 HDD'
 
-	Int spr_mem_mb = 16000
+		Int xcor_cpu = 2
+		Int xcor_mem_mb = 16000	
+		Int xcor_time_hr = 24
+		String xcor_disks = 'local-disk 100 HDD'
 
-	Int jsd_cpu = 2
-	Int jsd_mem_mb = 12000
-	Int jsd_time_hr = 6
-	String jsd_disks = 'local-disk 200 HDD'
+		Int macs2_signal_track_mem_mb = 16000
+		Int macs2_signal_track_time_hr = 24
+		String macs2_signal_track_disks = 'local-disk 400 HDD'
 
-	Int xcor_cpu = 2
-	Int xcor_mem_mb = 16000	
-	Int xcor_time_hr = 24
-	String xcor_disks = 'local-disk 100 HDD'
+		Int call_peak_cpu = 2
+		Int call_peak_mem_mb = 16000
+		Int call_peak_time_hr = 72
+		String call_peak_disks = 'local-disk 200 HDD'
 
-	Int macs2_signal_track_mem_mb = 16000
-	Int macs2_signal_track_time_hr = 24
-	String macs2_signal_track_disks = 'local-disk 400 HDD'
+		String? align_trimmomatic_java_heap
+		String? filter_picard_java_heap
+		String? gc_bias_picard_java_heap
+	}
 
-	Int call_peak_cpu = 2
-	Int call_peak_mem_mb = 16000
-	Int call_peak_time_hr = 72
-	String call_peak_disks = 'local-disk 200 HDD'
+	parameter_meta {
+		title: {
+			description: 'Experiment title.',
+			group: 'pipeline_metadata',
+		}
+		description: {
+			description: 'Experiment description.',
+			group: 'pipeline_metadata',
+		}
+		genome_tsv: {
+			description: 'Reference genome database TSV.',
+			group: 'reference_genome',
+			help: 'This TSV files includes all genome specific parameters (e.g. reference FASTA, bowtie2 index). You can still invidiaully define any parameters in it. Parameters defined in input JSON will override those defined in genome TSV.'
+		}
+		genome_name: {
+			description: 'Genome name.',
+			group: 'reference_genome'
+		}
+		ref_fa: {
+			description: 'Reference FASTA file.',
+			group: 'reference_genome'
+		}
+		ref_mito_fa: {
+			description: 'Reference FASTA file (mitochondrial reads only).',
+			group: 'reference_genome'
+		}
+		bowtie2_idx_tar: {
+			description: 'BWA index TAR file.',
+			group: 'reference_genome'
+		}
+		bowtie2_mito_idx_tar: {
+			description: 'BWA index TAR file (mitochondrial reads only).',
+			group: 'reference_genome'
+		}
+		chrsz: {
+			description: '2-col chromosome sizes file.',
+			group: 'reference_genome'
+		}
+		blacklist: {
+			description: 'Blacklist file in BED format.',
+			group: 'reference_genome',
+			help: 'Peaks will be filtered with this file.'
+		}
+		blacklist2: {
+			description: 'Secondary blacklist file in BED format.',
+			group: 'reference_genome',
+			help: 'If it is defined, it will be merged with chip.blacklist. Peaks will be filtered with merged blacklist.'
+		}
+		mito_chr_name: {
+			description: 'Mitochondrial chromosome name.',
+			group: 'reference_genome',
+			help: 'e.g. chrM, MT. Mitochondrial reads defined here will be filtered out during filtering BAMs in "filter" task.'
+		}
+		regex_bfilt_peak_chr_name: {
+			description: 'Reg-ex for chromosomes to keep while filtering peaks.',
+			group: 'reference_genome',
+			help: 'Chromosomes defined here will be kept. All other chromosomes will be filtered out in .bfilt. peak file. This is done along with blacklist filtering peak file.'
+		}
+		gensz: {
+			description: 'Genome sizes. "hs" for human, "mm" for mouse or sum of 2nd columnin chromosome sizes file.',
+			group: 'reference_genome'
+		}
+		tss: {
+			description: 'TSS file in BED format.',
+			group: 'reference_genome'
+		}
+		dnase: {
+			description: 'Open chromatin regions file in BED format.',
+			group: 'reference_genome'
+		}
+		prom: {
+			description: 'Promoter regions file in BED format.',
+			group: 'reference_genome'
+		}
+		enh: {
+			description: 'Enhancer regions file in BED format.',
+			group: 'reference_genome'
+		}
+		reg2map: {
+			description: 'Cell type signals file.',
+			group: 'reference_genome'
+		}
+		reg2map_bed: {
+			description: 'File of regions used to generate reg2map signals.',
+			group: 'reference_genome'
+		}
+		roadmap_meta: {
+			description: 'Roadmap metadata.',
+			group: 'reference_genome'
+		}
+		paired_end: {
+			description: 'Sequencing endedness.',
+			group: 'input_genomic_data',
+			help: 'Setting this on means that all replicates are paired ended. For mixed samples, use chip.paired_ends array instead.'
+		}
+		paired_ends: {
+			description: 'Sequencing endedness array (for mixed SE/PE datasets).',
+			group: 'input_genomic_data',
+			help: 'Whether each biological replicate is paired ended or not.'
+		}
+		fastqs_rep1_R1: {
+			description: 'Read1 FASTQs to be merged for a biological replicate 1.',
+			group: 'input_genomic_data',
+			help: 'Define if you want to start pipeline from FASTQs files. Pipeline can start from any type of inputs (e.g. FASTQs, BAMs, ...). Choose one type and fill paramters for that type and leave other undefined. Especially for FASTQs, we have individual variable for each biological replicate to allow FASTQs of technical replicates can be merged. Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep1_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep1_R1: {
+			description: 'Read2 FASTQs to be merged for a biological replicate 1.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep1_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep2_R1: {
+			description: 'Read1 FASTQs to be merged for a biological replicate 2.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep2_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep2_R1: {
+			description: 'Read2 FASTQs to be merged for a biological replicate 2.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep2_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep3_R1: {
+			description: 'Read1 FASTQs to be merged for a biological replicate 3.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep3_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep3_R1: {
+			description: 'Read2 FASTQs to be merged for a biological replicate 3.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep3_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep4_R1: {
+			description: 'Read1 FASTQs to be merged for a biological replicate 4.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep4_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep4_R1: {
+			description: 'Read2 FASTQs to be merged for a biological replicate 4.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep4_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep5_R1: {
+			description: 'Read1 FASTQs to be merged for a biological replicate 5.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep5_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep5_R1: {
+			description: 'Read2 FASTQs to be merged for a biological replicate 5.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep5_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep6_R1: {
+			description: 'Read1 FASTQs to be merged for a biological replicate 6.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep6_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep6_R1: {
+			description: 'Read2 FASTQs to be merged for a biological replicate 6.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep6_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep7_R1: {
+			description: 'Read1 FASTQs to be merged for a biological replicate 7.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep7_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep7_R2: {
+			description: 'Read2 FASTQs to be merged for a biological replicate 7.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep7_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep8_R1: {
+			description: 'Read1 FASTQs to be merged for a biological replicate 8.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep8_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep8_R2: {
+			description: 'Read2 FASTQs to be merged for a biological replicate 8.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep8_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep9_R1: {
+			description: 'Read1 FASTQs to be merged for a biological replicate 9.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep9_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep9_R2: {
+			description: 'Read2 FASTQs to be merged for a biological replicate 9.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep9_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep10_R1: {
+			description: 'Read1 FASTQs to be merged for a biological replicate 10.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read2 FASTQs (chip.fastqs_rep10_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep10_R2: {
+			description: 'Read2 FASTQs to be merged for a biological replicate 10.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read1 FASTQs (chip.fastqs_rep10_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		bams: {
+			description: 'List of unfiltered/raw BAM files for each biological replicate.',
+			group: 'input_genomic_data',
+			help: 'Define if you want to start pipeline from BAM files. Unfiltered/raw BAM file generated from aligner (e.g. bowtie2). Each entry for each biological replicate. e.g. [rep1.bam, rep2.bam, rep3.bam, ...].'
+		}
+		nodup_bams: {
+			description: 'List of filtered/deduped BAM files for each biological replicate',
+			group: 'input_genomic_data',
+			help: 'Define if you want to start pipeline from filtered BAM files. Filtered/deduped BAM file. Each entry for each biological replicate. e.g. [rep1.nodup.bam, rep2.nodup.bam, rep3.nodup.bam, ...].'
+		}
+		tas: {
+			description: 'List of TAG-ALIGN files for each biological replicate.',
+			group: 'input_genomic_data',
+			help: 'Define if you want to start pipeline from TAG-ALIGN files. TAG-ALIGN is in a 6-col BED format. It is a simplified version of BAM. Each entry for each biological replicate. e.g. [rep1.tagAlign.gz, rep2.tagAlign.gz, ...].'
+		}
+		peaks: {
+			description: 'List of NARROWPEAK files (not blacklist filtered) for each biological replicate.',
+			group: 'input_genomic_data',
+			help: 'Define if you want to start pipeline from PEAK files. Each entry for each biological replicate. e.g. [rep1.narrowPeak.gz, rep2.narrowPeak.gz, ...]. Define other PEAK parameters (e.g. chip.peaks_pr1, chip.peak_pooled) according to your flag settings (e.g. chip.true_rep_only) and number of replicates. If you have more than one replicate then define chip.peak_pooled, chip.peak_ppr1 and chip.peak_ppr2. If chip.true_rep_only flag is on then do not define any parameters (chip.peaks_pr1, chip.peaks_pr2, chip.peak_ppr1 and chip.peak_ppr2) related to pseudo replicates.'
+		}
+		peaks_pr1: {
+			description: 'List of NARROWPEAK files (not blacklist filtered) for pseudo-replicate 1 of each biological replicate.',
+			group: 'input_genomic_data',
+			help: 'Define if you want to start pipeline from PEAK files. Define if chip.true_rep_only flag is off.'
+		}
+		peaks_pr2: {
+			description: 'List of NARROWPEAK files (not blacklist filtered) for pseudo-replicate 2 of each biological replicate.',
+			group: 'input_genomic_data',
+			help: 'Define if you want to start pipeline from PEAK files. Define if chip.true_rep_only flag is off.'
+		}
+		peak_pooled: {
+			description: 'NARROWPEAK file for pooled true replicate.',
+			group: 'input_genomic_data',
+			help: 'Define if you want to start pipeline from PEAK files. Define if you have multiple biological replicates. Pooled true replicate means analysis on pooled biological replicates.'
+		}
+		peak_ppr1: {
+			description: 'NARROWPEAK file for pooled pseudo replicate 1.',
+			group: 'input_genomic_data',
+			help: 'Define if you want to start pipeline from PEAK files. Define if you have multiple biological replicates and chip.true_rep_only flag is off. PPR1 means analysis on pooled 1st pseudo replicates. Each biological replicate is shuf/split into two pseudos. This is a pooling of each replicate\'s 1st pseudos.'
+		}
+		peak_ppr2: {
+			description: 'NARROWPEAK file for pooled pseudo replicate 2.',
+			group: 'input_genomic_data',
+			help: 'Define if you want to start pipeline from PEAK files. Define if you have multiple biological replicates and chip.true_rep_only flag is off. PPR1 means analysis on pooled 2nd pseudo replicates. Each biological replicate is shuf/split into two pseudos. This is a pooling of each replicate\'s 2nd pseudos.'
+		}
 
-	String? align_trimmomatic_java_heap
-	String? filter_picard_java_heap
-	String? gc_bias_picard_java_heap
+		ctl_paired_end: {
+			description: 'Sequencing endedness for all controls.',
+			group: 'input_genomic_data_control',
+			help: 'Setting this on means that all control replicates are paired ended. For mixed controls, use chip.ctl_paired_ends array instead.'
+		}
+		ctl_paired_ends: {
+			description: 'Sequencing endedness array for mixed SE/PE controls.',
+			group: 'input_genomic_data_control',
+			help: 'Whether each control replicate is paired ended or not.'
+		}
+		ctl_fastqs_rep1_R1: {
+			description: 'Read1 FASTQs to be merged for a control replicate 1.',
+			group: 'input_genomic_data_control',
+			help: 'Define if you want to start pipeline from FASTQs files. Pipeline can start from any type of controls (e.g. FASTQs, BAMs, ...). Choose one type and fill paramters for that type and leave other undefined.  Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep1_R2).'
+		}
+		ctl_fastqs_rep1_R1: {
+			description: 'Read2 FASTQs to be merged for a control replicate 1.',
+			group: 'input_genomic_data_control',
+			help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep1_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		ctl_fastqs_rep2_R1: {
+			description: 'Read1 FASTQs to be merged for a control replicate 2.',
+			group: 'input_genomic_data_control',
+			help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep2_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		ctl_fastqs_rep2_R1: {
+			description: 'Read2 FASTQs to be merged for a control replicate 2.',
+			group: 'input_genomic_data_control',
+			help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep2_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		ctl_fastqs_rep3_R1: {
+			description: 'Read1 FASTQs to be merged for a control replicate 3.',
+			group: 'input_genomic_data_control',
+			help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep3_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		ctl_fastqs_rep3_R1: {
+			description: 'Read2 FASTQs to be merged for a control replicate 3.',
+			group: 'input_genomic_data_control',
+			help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep3_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		ctl_fastqs_rep4_R1: {
+			description: 'Read1 FASTQs to be merged for a control replicate 4.',
+			group: 'input_genomic_data_control',
+			help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep4_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		ctl_fastqs_rep4_R1: {
+			description: 'Read2 FASTQs to be merged for a control replicate 4.',
+			group: 'input_genomic_data_control',
+			help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep4_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		ctl_fastqs_rep5_R1: {
+			description: 'Read1 FASTQs to be merged for a control replicate 5.',
+			group: 'input_genomic_data_control',
+			help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep5_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		ctl_fastqs_rep5_R1: {
+			description: 'Read2 FASTQs to be merged for a control replicate 5.',
+			group: 'input_genomic_data_control',
+			help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep5_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		ctl_fastqs_rep6_R1: {
+			description: 'Read1 FASTQs to be merged for a control replicate 6.',
+			group: 'input_genomic_data_control',
+			help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep6_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		ctl_fastqs_rep6_R1: {
+			description: 'Read2 FASTQs to be merged for a control replicate 6.',
+			group: 'input_genomic_data_control',
+			help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep6_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		ctl_fastqs_rep7_R1: {
+			description: 'Read1 FASTQs to be merged for a control replicate 7.',
+			group: 'input_genomic_data_control',
+			help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep7_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		ctl_fastqs_rep7_R2: {
+			description: 'Read2 FASTQs to be merged for a control replicate 7.',
+			group: 'input_genomic_data_control',
+			help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep7_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		ctl_fastqs_rep8_R1: {
+			description: 'Read1 FASTQs to be merged for a control replicate 8.',
+			group: 'input_genomic_data_control',
+			help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep8_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		ctl_fastqs_rep8_R2: {
+			description: 'Read2 FASTQs to be merged for a control replicate 8.',
+			group: 'input_genomic_data_control',
+			help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep8_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		ctl_fastqs_rep9_R1: {
+			description: 'Read1 FASTQs to be merged for a control replicate 9.',
+			group: 'input_genomic_data_control',
+			help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep9_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		ctl_fastqs_rep9_R2: {
+			description: 'Read2 FASTQs to be merged for a control replicate 9.',
+			group: 'input_genomic_data_control',
+			help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep9_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		ctl_fastqs_rep10_R1: {
+			description: 'Read1 FASTQs to be merged for a control replicate 10.',
+			group: 'input_genomic_data_control',
+			help: 'Make sure that they are consistent with read2 FASTQs (chip.ctl_fastqs_rep10_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		ctl_fastqs_rep10_R2: {
+			description: 'Read2 FASTQs to be merged for a control replicate 10.',
+			group: 'input_genomic_data_control',
+			help: 'Make sure that they are consistent with read1 FASTQs (chip.ctl_fastqs_rep10_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		ctl_bams: {
+			description: 'List of unfiltered/raw BAM files for each control replicate.',
+			group: 'input_genomic_data_control',
+			help: 'Define if you want to start pipeline from BAM files. Unfiltered/raw BAM file generated from aligner (e.g. bowtie2). Each entry for each control replicate. e.g. [ctl1.bam, ctl2.bam, ctl3.bam, ...].'
+		}
+		ctl_nodup_bams: {
+			description: 'List of filtered/deduped BAM files for each control replicate',
+			group: 'input_genomic_data_control',
+			help: 'Define if you want to start pipeline from filtered BAM files. Filtered/deduped BAM file. Each entry for each control replicate. e.g. [ctl1.nodup.bam, ctl2.nodup.bam, ctl3.nodup.bam, ...].'
+		}
+		ctl_tas: {
+			description: 'List of TAG-ALIGN files for each biological replicate.',
+			group: 'input_genomic_data_control',
+			help: 'Define if you want to start pipeline from TAG-ALIGN files. TAG-ALIGN is in a 6-col BED format. It is a simplified version of BAM. Each entry for each control replicate. e.g. [ctl1.tagAlign.gz, ctl2.tagAlign.gz, ...].'
+		}
 
-	#### input file definition
-	# pipeline can start from any type of inputs and then leave all other types undefined
-	# supported types: fastq, bam, nodup_bam (filtered bam), ta (tagAlign), peak
-	# define up to 4 replicates
-	# [rep_id] is for each replicate
+		pipeline_type: {
+			description: 'Pipeline type. tf for TF ChIP-Seq or histone for Histone ChIP-Seq.',
+			group: 'pipeline_parameter',
+			help: 'Default peak caller is different for each type. spp For TF ChIP-Seq and macs2 for histone ChIP-Seq. Regardless of pipeline type, spp always requires controls but macs2 doesn\'t.'
+		}
+		align_only: {
+			description: 'Align only mode.',
+			group: 'pipeline_parameter',
+			help: 'Reads will be aligned but there will be no peak-calling on them.'
+		}
+		true_rep_only: {
+			description: 'Disables all analyses related to pseudo-replicates.',
+			group: 'pipeline_parameter',
+			help: 'Pipeline generates 2 pseudo-replicate from one biological replicate. This flag turns off all analyses related to pseudos (with prefix/suffix pr, ppr).'
+		}
+		enable_count_signal_track: {
+			description: 'Enables generation of count signal tracks.',
+			group: 'pipeline_parameter'
+		}
+		enable_jsd: {
+			description: 'Enables Jensen-Shannon Distance (JSD) plot generation.',
+			group: 'pipeline_parameter'
+		}
+		enable_gc_bias: {
+			description: 'Enables GC bias calculation.',
+			group: 'pipeline_parameter'
+		}
 
- 	### fastqs
-	Array[File] fastqs_rep1_R1 = []		# FASTQs to be merged for rep1 R1
-	Array[File] fastqs_rep1_R2 = [] 	# do not define if single-ended
-	Array[File] fastqs_rep2_R1 = [] 	# do not define if unreplicated
-	Array[File] fastqs_rep2_R2 = []		# ...
-	Array[File] fastqs_rep3_R1 = []
-	Array[File] fastqs_rep3_R2 = []
-	Array[File] fastqs_rep4_R1 = []
-	Array[File] fastqs_rep4_R2 = []
-	Array[File] fastqs_rep5_R1 = []
-	Array[File] fastqs_rep5_R2 = []
-	Array[File] fastqs_rep6_R1 = []
-	Array[File] fastqs_rep6_R2 = []
-	Array[File] fastqs_rep7_R1 = []
-	Array[File] fastqs_rep7_R2 = []
-	Array[File] fastqs_rep8_R1 = []
-	Array[File] fastqs_rep8_R2 = []
-	Array[File] fastqs_rep9_R1 = []
-	Array[File] fastqs_rep9_R2 = []
-	Array[File] fastqs_rep10_R1 = []
-	Array[File] fastqs_rep10_R2 = []
+		aligner: {
+			description: 'Aligner. bowtie2 or bwa',
+			group: 'alignment',
+			help: 'It is bowtie2 by default.'
+		}
+		use_bwa_mem_for_pe: {
+			description: 'For paired end dataset with read length >= 70bp, use bwa mem instead of bwa aln.',
+			group: 'alignment',
+			help: 'Use it only for paired end reads >= 70bp.'
+		}
+		crop_length: {
+			description: 'Crop FASTQs\' reads longer than this length.',
+			group: 'alignment',
+			help: 'Also drop all reads shorter than chip.crop_length - chip.crop_length_tol.'
+		}
+		crop_length_tol: {
+			description: 'Tolerance for cropping reads in FASTQs.',
+			group: 'alignment',
+			help: 'Drop all reads shorter than chip.crop_length - chip.crop_length_tol. Activated only when chip.crop_length is defined.'
+		}
+		xcor_trim_bp: {
+			description: 'Trim experiment read1 FASTQ (for both SE and PE) for cross-correlation analysis.',
+			group: 'alignment',
+			help: 'This does not affect alignment of experimental/control replicates. Pipeline additionaly aligns R1 FASTQ only for cross-correlation analysis only. This parameter is used for it.'
+		}
+		use_filt_pe_ta_for_xcor: {
+			description: 'Use filtered PE BAM for cross-correlation analysis.',
+			group: 'alignment',
+			help: 'If not defined, pipeline uses SE BAM generated from trimmed read1 FASTQ for cross-correlation analysis.'
+		}
+		dup_marker: {
+			description: 'Marker for duplicate reads. picard or sambamba.',
+			group: 'alignment',
+			help: 'picard for Picard MarkDuplicates or sambamba for sambamba markdup.'
+		}
+		no_dup_removal: {
+			description: 'Disable removal of duplicate reads during filtering BAM.',
+			group: 'alignment',
+			help: 'Duplicate reads are filtererd out during filtering BAMs to gerenate NODUP_BAM. This flag will keep all duplicate reads in NODUP_BAM. This flag does not affect naming of NODUP_BAM. NODUP_BAM will still have .nodup. suffix in its filename.'
+		}
+		mapq_thresh: {
+			description: 'Threshold for low MAPQ reads removal',
+			group: 'alignment',
+			help: 'Low MAPQ reads are filtered out while filtering BAM.',
+		}
+		filter_chrs: {
+			description: 'List of chromosomes to be filtered out while filtering BAM.',
+			group: 'alignment',
+			help: 'It is empty by default, hence no filtering out of specfic chromosomes. It is case-sensitive. Use exact word for chromosome names.'
+		}
+		subsample_reads: {
+			description: 'Subsample reads. Shuffle and subsample reads.',
+			group: 'alignment',
+			help: 'This affects all downstream analyses after filtering experiment BAM. (e.g. all TAG-ALIGN files, peak-calling). Reads will be shuffled only if actual number of reads in BAM exceeds this number. 0 means disabled.'
+		}
+		ctl_subsample_reads: {
+			description: 'Subsample control reads. Shuffle and subsample control reads.',
+			group: 'alignment',
+			help: 'This affects all downstream analyses after filtering control BAM. (e.g. all TAG-ALIGN files, peak-calling). Reads will be shuffled only if actual number of reads in BAM exceeds this number. 0 means disabled.'
+		}
 
-	Array[File] ctl_fastqs_rep1_R1 = []		# Control FASTQs to be merged for rep1 R1
-	Array[File] ctl_fastqs_rep1_R2 = [] 	# do not define if single-ended
-	Array[File] ctl_fastqs_rep2_R1 = [] 	# do not define if unreplicated
-	Array[File] ctl_fastqs_rep2_R2 = []		# ...
-	Array[File] ctl_fastqs_rep3_R1 = []
-	Array[File] ctl_fastqs_rep3_R2 = []
-	Array[File] ctl_fastqs_rep4_R1 = []
-	Array[File] ctl_fastqs_rep4_R2 = []
-	Array[File] ctl_fastqs_rep5_R1 = []
-	Array[File] ctl_fastqs_rep5_R2 = []
-	Array[File] ctl_fastqs_rep6_R1 = []
-	Array[File] ctl_fastqs_rep6_R2 = []
-	Array[File] ctl_fastqs_rep7_R1 = []
-	Array[File] ctl_fastqs_rep7_R2 = []
-	Array[File] ctl_fastqs_rep8_R1 = []
-	Array[File] ctl_fastqs_rep8_R2 = []
-	Array[File] ctl_fastqs_rep9_R1 = []
-	Array[File] ctl_fastqs_rep9_R2 = []
-	Array[File] ctl_fastqs_rep10_R1 = []
-	Array[File] ctl_fastqs_rep10_R2 = []
+		ctl_depth_limit: {
+			description: 'Hard limit for chosen control\'s depth.',
+			group: 'peak_calling',
+			help: 'If control chosen by chip.always_use_pooled_ctl and chip.ctl_depth_ratio is deeper than this hard limit, then such control is subsampled.'
+		}
+		exp_ctl_depth_ratio_limit: {
+			description: 'Second limit for chosen control\'s' depth.',
+			group: 'peak_calling',
+			help: 'If control chosen by chip.always_use_pooled_ctl and chip.ctl_depth_ratio is deeper than experiment replicate\'s read depth multiplied by this factor then such control is subsampled down to maximum of multiplied value and hard limit chip.ctl_depth_limit.'
+		}
 
-	### other input types (bam, nodup_bam, ta)
-	Array[File?] bams = [] 			# [rep_id]
-	Array[File?] ctl_bams = [] 		# [rep_id]
-	Array[File?] nodup_bams = [] 	# [rep_id]
-	Array[File?] ctl_nodup_bams = [] # [rep_id]
-	Array[File?] tas = []			# [rep_id]
-	Array[File?] ctl_tas = []		# [rep_id]
+		xcor_subsample_reads: {
+			description: 'Subsample reads for cross-corrlelation analysis only.',
+			group: 'alignment',
+			help: 'This does not affect downstream analyses after filtering BAM. It is for cross-correlation analysis only.  0 means disabled.'
+		}
 
-	### other input types (peak)
-	Array[Int?] fraglen = [] 	# [rep_id]. fragment length if inputs are peaks
-	Array[File?] peaks = []		# [PAIR(rep_id1,rep_id2)]. example for 3 reps: [rep1_rep2, rep1_rep3, rep2_rep3]
-	Array[File?] peaks_pr1 = []	# [rep_id]. do not define if true_rep=true
-	Array[File?] peaks_pr2 = []	# [rep_id]. do not define if true_rep=true
-	File? peak_ppr1				# do not define if you have a single replicate or true_rep=true
-	File? peak_ppr2				# do not define if you have a single replicate or true_rep=true
-	File? peak_pooled			# do not define if you have a single replicate or true_rep=true
+		xcor_exclusion_range_min: {
+			description: 'Exclusion minimum for cross-correlation analysis.',
+			group: 'peak_calling',
+			help: 'For run_spp.R -s. Make sure that it is consistent with default strand shift -s=-500:5:1500 in run_spp.R.'
+		}
+		xcor_exclusion_range_max: {
+			description: 'Exclusion maximum for cross-coorrelation analysis.',
+			group: 'peak_calling',
+			help: 'For run_spp.R -s. If not defined default value of `max(read length + 10, 50)` for TF and `max(read_len + 10, 100)` for histone are used'
+		}
+		fraglen: {
+			description: 'Fragment length for each biological replicate.',
+			group: 'peak_calling',
+			help: 'Fragment length is estimated by cross-correlation analysis, which is valid only when pipeline started from FASTQs. If defined, fragment length estimated by cross-correlation analysis is ignored.'
+		}
+		peak_caller: {
+			description: 'Peak caller.',
+			group: 'peak_calling',
+			help: 'It is spp and macs2 by default for TF ChIP-seq and histone ChIP-seq, respectively. e.g. you can use macs2 for TF ChIP-Seq even though spp is by default for TF ChIP-Seq (chip.pipeline_type == tf).'
+		}
+		always_use_pooled_ctl: {
+			description: 'Always choose a pooled control for each experiment replicate.',
+			group: 'peak_calling',
+			help: 'If turned on, ignores chip.ctl_depth_ratio.'
+		}
+		ctl_depth_ratio: {
+			description: 'Maximum depth ratio between control replicates.',
+			group: 'peak_calling',
+			help: 'If ratio of depth between any two controls is higher than this, then always use a pooled control for all experiment replicates.'
+		}
 
-	####################### pipeline starts here #######################
-	# DO NOT DEFINE ANY VARIABLES DECLARED BELOW IN AN INPUT JSON FILE #
-	# THEY ARE TEMPORARY/INTERMEDIATE SYSTEM VARIABLES                 #
-	####################### pipeline starts here #######################
+		cap_num_peak: {
+			description: 'Upper limit on the number of peaks.',
+			group: 'peak_calling',
+			help: 'It is 30000000 and 50000000 by default for spp and macs2, respectively.'
+		}
+		pval_thresh: {
+			description: 'p-value Threshold for MACS2 peak caller.',
+			group: 'peak_calling',
+			help: 'macs2 callpeak -p'
+		}
+		fdr_thresh: {
+			description: 'FDR threshold for spp peak caller (phantompeakqualtools).',
+			group: 'peak_calling',
+			help: 'run_spp.R -fdr='
+		}
+		idr_thresh: {
+			description: 'IDR threshold.',
+			group: 'peak_calling'
+		}
+
+		align_cpu: {
+			description: 'Number of cores for task align.',
+			group: 'resource_parameter',
+			help: 'Task align merges/crops/maps FASTQs.'
+		}
+		align_mem_mb: {
+			description: 'Memory (MB) required for task align.',
+			group: 'resource_parameter',
+			help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+		}
+		align_time_hr: {
+			description: 'Walltime (h) required for task align.',
+			group: 'resource_parameter',
+			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+		}
+		align_disks: {
+			description: 'Persistent disk size to store intermediate files and outputs of task align.',
+			group: 'resource_parameter',
+			help: 'This is for GCP/AWS only.'
+		}
+		filter_cpu: {
+			description: 'Number of cores for task filter.',
+			group: 'resource_parameter',
+			help: 'Task filter filters raw/unfilterd BAM to get filtered/deduped BAM.'
+		}
+		filter_mem_mb: {
+			description: 'Memory (MB) required for task filter.',
+			group: 'resource_parameter',
+			help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+		}
+		filter_time_hr: {
+			description: 'Walltime (h) required for task filter.',
+			group: 'resource_parameter',
+			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+		}
+		filter_disks: {
+			description: 'Persistent disk size to store intermediate files and outputs of task filter.',
+			group: 'resource_parameter',
+			help: 'This is for GCP/AWS only.'
+		}
+		bam2ta_cpu: {
+			description: 'Number of cores for task bam2ta.',
+			group: 'resource_parameter',
+			help: 'Task bam2ta converts filtered/deduped BAM in to TAG-ALIGN (6-col BED) format.'
+		}
+		bam2ta_mem_mb: {
+			description: 'Memory (MB) required for task bam2ta.',
+			group: 'resource_parameter',
+			help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+		}
+		bam2ta_time_hr: {
+			description: 'Walltime (h) required for task bam2ta.',
+			group: 'resource_parameter',
+			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+		}
+		bam2ta_disks: {
+			description: 'Persistent disk size to store intermediate files and outputs of task bam2ta.',
+			group: 'resource_parameter',
+			help: 'This is for GCP/AWS only.'
+		}
+		spr_mem_mb: {
+			description: 'Memory (MB) required for task spr.',
+			group: 'resource_parameter',
+			help: 'Task spr generates two pseudo-replicates from each biological replicate. This task uses Unix shuf/sort, which can take significant amount of memory.'
+		}
+		jsd_cpu: {
+			description: 'Number of cores for task jsd.',
+			group: 'resource_parameter',
+			help: 'Task jsd plots Jensen-Shannon distance and metrics related to it.'
+		}
+		jsd_mem_mb: {
+			description: 'Memory (MB) required for task jsd.',
+			group: 'resource_parameter',
+			help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+		}
+		jsd_time_hr: {
+			description: 'Walltime (h) required for task jsd.',
+			group: 'resource_parameter',
+			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+		}
+		jsd_disks: {
+			description: 'Persistent disk size to store intermediate files and outputs of task jsd.',
+			group: 'resource_parameter',
+			help: 'This is for GCP/AWS only.'
+		}
+		xcor_cpu: {
+			description: 'Number of cores for task xcor.',
+			group: 'resource_parameter',
+			help: 'Task xcor does cross-correlation analysis (including a plot) on subsampled TAG-ALIGNs.'
+		}
+		xcor_mem_mb: {
+			description: 'Memory (MB) required for task xcor.',
+			group: 'resource_parameter',
+			help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+		}
+		xcor_time_hr: {
+			description: 'Walltime (h) required for task xcor.',
+			group: 'resource_parameter',
+			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+		}
+		xcor_disks: {
+			description: 'Persistent disk size to store intermediate files and outputs of task xcor.',
+			group: 'resource_parameter',
+			help: 'This is for GCP/AWS only.'
+		}
+		call_peak_cpu: {
+			description: 'Number of cores for task call_peak.',
+			group: 'resource_parameter',
+			help: 'Task call_peak call peaks on TAG-ALIGNs by using MACS2 peak caller.'
+		}
+		call_peak_mem_mb: {
+			description: 'Memory (MB) required for task call_peak.',
+			group: 'resource_parameter',
+			help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+		}
+		call_peak_time_hr: {
+			description: 'Walltime (h) required for task call_peak.',
+			group: 'resource_parameter',
+			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+		}
+		call_peak_disks: {
+			description: 'Persistent disk size to store intermediate files and outputs of task call_peak.',
+			group: 'resource_parameter',
+			help: 'This is for GCP/AWS only.'
+		}
+		macs2_signal_track_mem_mb: {
+			description: 'Memory (MB) required for task macs2_signal_track.',
+			group: 'resource_parameter',
+			help: 'Task macs2_signal_track_mem_mb uses MACS2 to get signal tracks for p-val (suffixed with .pval.) and fold enrichment (suffixed with .fc.). This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+		}
+		macs2_signal_track_time_hr: {
+			description: 'Walltime (h) required for task macs2_signal_track.',
+			group: 'resource_parameter',
+			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+		}
+		macs2_signal_track_disks: {
+			description: 'Persistent disk size to store intermediate files and outputs of task macs2_signal_track.',
+			group: 'resource_parameter',
+			help: 'This is for GCP/AWS only.'
+		}
+		align_trimmomatic_java_heap: {
+			description: 'Maximum Java heap (java -Xmx) in task align.',
+			group: 'resource_parameter',
+			help: 'Maximum memory for Trimmomatic. If not defined, 90% of align_mem_mb will be used.'
+		}
+		filter_picard_java_heap: {
+			description: 'Maximum Java heap (java -Xmx) in task filter.',
+			group: 'resource_parameter',
+			help: 'Maximum memory for Picard tools MarkDuplicates. If not defined, 90% of filter_mem_mb will be used.'
+		}
+		gc_bias_picard_java_heap: {
+			description: 'Maximum Java heap (java -Xmx) in task gc_bias.',
+			group: 'resource_parameter',
+			help: 'Maximum memory for Picard tools CollectGcBiasMetrics. If not defined, 90% of 10000 MB will be used.'
+		}
+	}
 
 	# read genome data and paths
 	if ( defined(genome_tsv) ) {
 		call read_genome_tsv { input: genome_tsv = genome_tsv }
 	}
-	File? ref_fa_ = if defined(ref_fa) then ref_fa
-		else read_genome_tsv.ref_fa
+	File ref_fa_ = select_first([ref_fa, read_genome_tsv.ref_fa])
 	File? bwa_idx_tar_ = if defined(bwa_idx_tar) then bwa_idx_tar
 		else read_genome_tsv.bwa_idx_tar
-	File? bowtie2_idx_tar_ = if defined(bowtie2_idx_tar) then bowtie2_idx_tar
-		else read_genome_tsv.bowtie2_idx_tar
-	File? custom_aligner_idx_tar_ = if defined(custom_aligner_idx_tar) then custom_aligner_idx_tar
-		else read_genome_tsv.custom_aligner_idx_tar
-	File? chrsz_ = if defined(chrsz) then chrsz
-		else read_genome_tsv.chrsz
-	String? gensz_ = if defined(gensz) then gensz
-		else read_genome_tsv.gensz
+	File bowtie2_idx_tar_ = select_first([bowtie2_idx_tar, read_genome_tsv.bowtie2_idx_tar])
+	File chrsz_ = select_first([chrsz, read_genome_tsv.chrsz])
+	String gensz_ = select_first([gensz, read_genome_tsv.gensz])
 	File? blacklist1_ = if defined(blacklist) then blacklist
 		else read_genome_tsv.blacklist
 	File? blacklist2_ = if defined(blacklist2) then blacklist2
@@ -247,13 +890,9 @@ workflow chip {
 	File? blacklist_ = if length(blacklists) > 1 then pool_blacklist.ta_pooled
 		else if length(blacklists) > 0 then blacklists[0]
 		else blacklist2_
-	String? mito_chr_name_ = if defined(mito_chr_name) then mito_chr_name
-		else read_genome_tsv.mito_chr_name		
-	String? regex_bfilt_peak_chr_name_ = if defined(regex_bfilt_peak_chr_name) then regex_bfilt_peak_chr_name
-		else read_genome_tsv.regex_bfilt_peak_chr_name
-	String? genome_name_ = if defined(genome_name) then genome_name
-		else if defined(read_genome_tsv.genome_name) then read_genome_tsv.genome_name
-		else basename(select_first([genome_tsv, ref_fa_, chrsz_, 'None']))
+	String mito_chr_name_ = select_first([mito_chr_name, read_genome_tsv.mito_chr_name])
+	String regex_bfilt_peak_chr_name_ = select_first([regex_bfilt_peak_chr_name, read_genome_tsv.regex_bfilt_peak_chr_name])
+	String genome_name_ = select_first([genome_name, read_genome_tsv.genome_name, basename(chrsz_)])
 
 	# read additional annotation data
 	File? tss_ = if defined(tss) then tss
@@ -272,21 +911,20 @@ workflow chip {
 		else read_genome_tsv.roadmap_meta
 
 	### temp vars (do not define these)
-	String aligner_ = if defined(custom_align_py) then 'custom' else aligner
-	String peak_caller_ = if defined(custom_call_peak_py) then 'custom'
-						else if pipeline_type=='tf' then select_first([peak_caller, 'spp'])
+	String aligner_ = aligner
+	String peak_caller_ = if pipeline_type=='tf' then select_first([peak_caller, 'spp'])
 						else select_first([peak_caller, 'macs2'])
-	String peak_type_ = if peak_caller_=='spp' then select_first([peak_type, 'regionPeak'])
-						else if peak_caller_=='macs2' then select_first([peak_type, 'narrowPeak'])
-						else select_first([peak_type, 'narrowPeak'])
+	String peak_type_ = if peak_caller_=='spp' then 'regionPeak'
+						else 'narrowPeak'
 	Boolean enable_idr = pipeline_type=='tf' # enable_idr for TF chipseq only
 	String idr_rank_ = if peak_caller_=='spp' then 'signal.value'
 						else if peak_caller_=='macs2' then 'p.value'
 						else 'p.value'
+	Int cap_num_peak_spp = 300000
+	Int cap_num_peak_macs2 = 500000						
 	Int cap_num_peak_ = if peak_caller_ == 'spp' then select_first([cap_num_peak, cap_num_peak_spp])
 		else select_first([cap_num_peak, cap_num_peak_macs2])
-	Int mapq_thresh_ = if aligner=='bowtie2' then select_first([mapq_thresh, mapq_thresh_bowtie2])
-						else select_first([mapq_thresh, mapq_thresh_bwa])
+	Int mapq_thresh_ = mapq_thresh
 
 	# temporary 2-dim fastqs array [rep_id][merge_id]
 	Array[Array[File]] fastqs_R1 = 
@@ -355,7 +993,7 @@ workflow chip {
 		ctl_fastqs_rep6_R2, ctl_fastqs_rep7_R2, ctl_fastqs_rep8_R2, ctl_fastqs_rep9_R2, ctl_fastqs_rep10_R2]
 
 	# temporary variables to get number of replicates
-	# 	WDLic implementation of max(A,B,C,...)
+	#	 WDLic implementation of max(A,B,C,...)
 	Int num_rep_fastq = length(fastqs_R1)
 	Int num_rep_bam = if length(bams)<num_rep_fastq then num_rep_fastq
 		else length(bams)
@@ -383,33 +1021,38 @@ workflow chip {
 			msg = 'No FASTQ/BAM/TAG-ALIGN/PEAK defined in your input JSON. Check if your FASTQs are defined as "chip.fastqs_repX_RY". DO NOT MISS suffix _R1 even for single ended FASTQ.'
 		}
 	}
-	if ( !defined(chrsz_) ) {
-		call raise_exception as error_genome_database { input:
-			msg = 'No genome database found in your input JSON. Did you define "chip.genome_tsv" correctly?'
-		}
-	}
 	if ( !align_only && peak_caller_ == 'spp' && num_ctl == 0 ) {
 		call raise_exception as error_control_required { input:
 			msg = 'SPP requires control inputs. Define control input files ("chip.ctl_*") in an input JSON file.'
 		}
 	}
+	if ( (num_rep_fastq > 0 || num_ctl_fastq > 0) && aligner_ != 'bwa' && aligner_ != 'bowtie2' ) {
+		call raise_exception as error_wrong_aligner { input:
+			msg = 'Choose chip.aligner between bwa and bowtie2.'
+		}
+	}
+	if ( aligner_ != 'bwa' && use_bwa_mem_for_pe ) {
+		call raise_exception as error_use_bwa_mem_for_non_bwa { input:
+			msg = 'To use chip.use_bwa_mem_for_pe, choose bwa for chip.aligner.'
+		}
+	}	
 	if ( ( ctl_depth_limit > 0 || exp_ctl_depth_ratio_limit > 0 ) && num_ctl > 1 && length(ctl_paired_ends) > 1  ) {
 		call raise_exception as error_subsample_pooled_control_with_mixed_endedness { input:
 			msg = 'Cannot use automatic control subsampling ("chip.ctl_depth_limit">0 and "chip.exp_ctl_depth_limit">0) for ' +
-			      'multiple controls with mixed endedness (e.g. SE ctl-rep1 and PE ctl-rep2). ' +
-			      'Automatic control subsampling is enabled by default. ' +
-			      'Disable automatic control subsampling by explicitly defining the above two parameters as 0 in your input JSON file. ' +
-			      'You can still use manual control subsamping ("chip.ctl_subsample_reads">0) since it is done ' +
-			      'for individual control\'s TAG-ALIGN output according to each control\'s endedness. '
+				  'multiple controls with mixed endedness (e.g. SE ctl-rep1 and PE ctl-rep2). ' +
+				  'Automatic control subsampling is enabled by default. ' +
+				  'Disable automatic control subsampling by explicitly defining the above two parameters as 0 in your input JSON file. ' +
+				  'You can still use manual control subsamping ("chip.ctl_subsample_reads">0) since it is done ' +
+				  'for individual control\'s TAG-ALIGN output according to each control\'s endedness. '
 		}
 	}
 
 	# align each replicate
 	scatter(i in range(num_rep)) {
 		# to override endedness definition for individual replicate
-		# 	paired_end will override paired_ends[i]
-		Boolean? paired_end_ = if !defined(paired_end) && i<length(paired_ends) then paired_ends[i]
-			else paired_end
+		#	 paired_end will override paired_ends[i]
+		Boolean paired_end_ = if !defined(paired_end) && i<length(paired_ends) then paired_ends[i]
+			else select_first([paired_end])
 
 		Boolean has_input_of_align = i<length(fastqs_R1) && length(fastqs_R1[i])>0
 		Boolean has_output_of_align = i<length(bams) && defined(bams[i])
@@ -422,10 +1065,8 @@ workflow chip {
 
 				aligner = aligner_,
 				mito_chr_name = mito_chr_name_,
-				custom_align_py = custom_align_py,
 				idx_tar = if aligner=='bwa' then bwa_idx_tar_
-					else if aligner=='bowtie2' then bowtie2_idx_tar_
-					else custom_aligner_idx_tar_,
+					else bowtie2_idx_tar_,
 				paired_end = paired_end_,
 				use_bwa_mem_for_pe = use_bwa_mem_for_pe,
 
@@ -515,10 +1156,8 @@ workflow chip {
 
 				aligner = aligner_,
 				mito_chr_name = mito_chr_name_,
-				custom_align_py = custom_align_py,
 				idx_tar = if aligner=='bwa' then bwa_idx_tar_
-					else if aligner=='bowtie2' then bowtie2_idx_tar_
-					else custom_aligner_idx_tar_,
+					else bowtie2_idx_tar_,
 				paired_end = false,
 				use_bwa_mem_for_pe = use_bwa_mem_for_pe,
 
@@ -590,14 +1229,14 @@ workflow chip {
 			}
 		}
 
-		# use trimmed/unfilitered R1 tagAlign for paired end dataset 		
+		# use trimmed/unfilitered R1 tagAlign for paired end dataset
 		# if not starting from fastqs, keep using old method
 		#  (mapping with both ends for tag-aligns to be used for xcor)
 		# subsample tagalign (non-mito) and cross-correlation analysis
 		File? ta_xcor = if defined(bam2ta_no_dedup_R1.ta) then bam2ta_no_dedup_R1.ta
 			else if defined(bam2ta_no_dedup.ta) then bam2ta_no_dedup.ta
 			else ta_
-		Boolean? paired_end_xcor = if defined(bam2ta_no_dedup_R1.ta) then false
+		Boolean paired_end_xcor = if defined(bam2ta_no_dedup_R1.ta) then false
 			else paired_end_
 
 		Boolean has_input_of_xcor = defined(ta_xcor)
@@ -626,10 +1265,9 @@ workflow chip {
 	# align each control
 	scatter(i in range(num_ctl)) {
 		# to override endedness definition for individual control
-		# 	ctl_paired_end will override ctl_paired_ends[i]
-		Boolean? ctl_paired_end_ = if !defined(ctl_paired_end) && i<length(ctl_paired_ends) then ctl_paired_ends[i]
-			else if defined(ctl_paired_end) then ctl_paired_end
-			else paired_end
+		#	 ctl_paired_end will override ctl_paired_ends[i]
+		Boolean ctl_paired_end_ = if !defined(ctl_paired_end) && i<length(ctl_paired_ends) then ctl_paired_ends[i]
+			else select_first([ctl_paired_end, paired_end])
 
 		Boolean has_input_of_align_ctl = i<length(ctl_fastqs_R1) && length(ctl_fastqs_R1[i])>0
 		Boolean has_output_of_align_ctl = i<length(ctl_bams) && defined(ctl_bams[i])
@@ -642,10 +1280,8 @@ workflow chip {
 
 				aligner = aligner_,
 				mito_chr_name = mito_chr_name_,
-				custom_align_py = custom_align_py,
 				idx_tar = if aligner=='bwa' then bwa_idx_tar_
-					else if aligner=='bowtie2' then bowtie2_idx_tar_
-					else custom_aligner_idx_tar_,
+					else bowtie2_idx_tar_,
 				paired_end = ctl_paired_end_,
 				use_bwa_mem_for_pe = use_bwa_mem_for_pe,
 
@@ -768,7 +1404,7 @@ workflow chip {
 	if ( has_all_input_of_choose_ctl && !align_only ) {
 		# choose appropriate control for each exp IP replicate
 		# outputs:
-		# 	choose_ctl.idx : control replicate index for each exp replicate 
+		#	 choose_ctl.idx : control replicate index for each exp replicate 
 		#					-1 means pooled ctl replicate
 		call choose_ctl { input:
 			tas = ta_,
@@ -785,8 +1421,8 @@ workflow chip {
 	scatter(i in range(num_rep)) {
 		# make control ta array [[1,2,3,4]] -> [[1],[2],[3],[4]]
 		# chosen_ctl_ta_id
-		# 	>=0: control TA index (this means that control TA with this index exists)
-		# 	-1: use pooled control
+		#	 >=0: control TA index (this means that control TA with this index exists)
+		#	 -1: use pooled control
 		#	-2: there is no control
 		Int chosen_ctl_ta_id = if has_all_input_of_choose_ctl && !align_only then
 			select_first([choose_ctl.chosen_ctl_ta_ids])[i] else -2
@@ -797,8 +1433,8 @@ workflow chip {
 		Int chosen_ctl_ta_subsample = if has_all_input_of_choose_ctl && !align_only then
 			select_first([choose_ctl.chosen_ctl_ta_subsample])[i] else 0
 		Boolean chosen_ctl_paired_end = if chosen_ctl_ta_id == -2 then false
-			else if chosen_ctl_ta_id == -1 then select_first(ctl_paired_end_)
-			else select_first([ctl_paired_end_[chosen_ctl_ta_id]])
+			else if chosen_ctl_ta_id == -1 then ctl_paired_end_[0]
+			else ctl_paired_end_[chosen_ctl_ta_id]
 	}
 	Int chosen_ctl_ta_pooled_subsample = if has_all_input_of_choose_ctl && !align_only then
 		select_first([choose_ctl.chosen_ctl_ta_subsample_pooled]) else 0
@@ -814,7 +1450,6 @@ workflow chip {
 			call call_peak { input :
 				peak_caller = peak_caller_,
 				peak_type = peak_type_,
-				custom_call_peak_py = custom_call_peak_py,
 				tas = flatten([[ta_[i]], chosen_ctl_tas[i]]),
 				gensz = gensz_,
 				chrsz = chrsz_,
@@ -860,7 +1495,6 @@ workflow chip {
 			call call_peak as call_peak_pr1 { input :
 				peak_caller = peak_caller_,
 				peak_type = peak_type_,
-				custom_call_peak_py = custom_call_peak_py,
 				tas = flatten([[spr.ta_pr1[i]], chosen_ctl_tas[i]]),
 				gensz = gensz_,
 				chrsz = chrsz_,
@@ -889,7 +1523,6 @@ workflow chip {
 			call call_peak as call_peak_pr2 { input :
 				peak_caller = peak_caller_,
 				peak_type = peak_type_,
-				custom_call_peak_py = custom_call_peak_py,
 				tas = flatten([[spr.ta_pr2[i]], chosen_ctl_tas[i]]),
 				gensz = gensz_,
 				chrsz = chrsz_,
@@ -926,7 +1559,7 @@ workflow chip {
 		else if num_ctl < 2 then [ctl_ta_[0]] # choose first (only) control
 		else select_all([pool_ta_ctl.ta_pooled]) # choose pooled control
 	Boolean chosen_ctl_ta_pooled_paired_end = if !has_all_input_of_choose_ctl || align_only then false
-		else select_first(ctl_paired_end_)
+		else ctl_paired_end_[0]
 
 	Boolean has_input_of_call_peak_pooled = defined(pool_ta.ta_pooled)
 	Boolean has_output_of_call_peak_pooled = defined(peak_pooled)
@@ -936,7 +1569,6 @@ workflow chip {
 		call call_peak as call_peak_pooled { input :
 			peak_caller = peak_caller_,
 			peak_type = peak_type_,
-			custom_call_peak_py = custom_call_peak_py,
 			tas = flatten([select_all([pool_ta.ta_pooled]), chosen_ctl_ta_pooled]),
 			gensz = gensz_,
 			chrsz = chrsz_,
@@ -982,7 +1614,6 @@ workflow chip {
 		call call_peak as call_peak_ppr1 { input :
 			peak_caller = peak_caller_,
 			peak_type = peak_type_,
-			custom_call_peak_py = custom_call_peak_py,
 			tas = flatten([select_all([pool_ta_pr1.ta_pooled]), chosen_ctl_ta_pooled]),
 			gensz = gensz_,
 			chrsz = chrsz_,
@@ -1011,7 +1642,6 @@ workflow chip {
 		call call_peak as call_peak_ppr2 { input :
 			peak_caller = peak_caller_,
 			peak_type = peak_type_,
-			custom_call_peak_py = custom_call_peak_py,
 			tas = flatten([select_all([pool_ta_pr2.ta_pooled]), chosen_ctl_ta_pooled]),
 			gensz = gensz_,
 			chrsz = chrsz_,
@@ -1034,23 +1664,18 @@ workflow chip {
 		else call_peak_ppr2.peak
 
 	# do IDR/overlap on all pairs of two replicates (i,j)
-	# 	where i and j are zero-based indices and 0 <= i < j < num_rep
-	Array[Pair[Int, Int]] pairs_ = cross(range(num_rep),range(num_rep))
-	scatter( pair in pairs_ ) {
-		Pair[Int, Int]? null_pair
-		Pair[Int, Int]? pairs__ = if pair.left<pair.right then pair else null_pair
-	}
-	Array[Pair[Int, Int]] pairs = select_all(pairs__)
-
-	if ( !align_only ) {
-		scatter( pair in pairs ) {
-			# pair.left = 0-based index of 1st replicate
-			# pair.right = 0-based index of 2nd replicate
+	#	 where i and j are zero-based indices and 0 <= i < j < num_rep
+	scatter( pair in cross(range(num_rep),range(num_rep)) ) {
+		# pair.left = 0-based index of 1st replicate
+		# pair.right = 0-based index of 2nd replicate
+		File? peak1_ = peak_[pair.left]
+		File? peak2_ = peak_[pair.right]
+		if ( !align_only && pair.left<pair.right ) {
 			# Naive overlap on every pair of true replicates
 			call overlap { input :
 				prefix = 'rep'+(pair.left+1)+'_vs_rep'+(pair.right+1),
-				peak1 = peak_[pair.left],
-				peak2 = peak_[pair.right],
+				peak1 = peak1_,
+				peak2 = peak2_,
 				peak_pooled = peak_pooled_,
 				fraglen = fraglen_mean.rounded_mean,
 				peak_type = peak_type_,
@@ -1060,17 +1685,12 @@ workflow chip {
 				ta = pool_ta.ta_pooled,
 			}
 		}
-	}
-
-	if ( enable_idr && !align_only ) {
-		scatter( pair in pairs ) {
-			# pair.left = 0-based index of 1st replicate
-			# pair.right = 0-based index of 2nd replicate
+		if ( enable_idr && !align_only && pair.left<pair.right ) {
 			# IDR on every pair of true replicates
 			call idr { input :
 				prefix = 'rep'+(pair.left+1)+'_vs_rep'+(pair.right+1),
-				peak1 = peak_[pair.left],
-				peak2 = peak_[pair.right],
+				peak1 = peak1_,
+				peak2 = peak2_,
 				peak_pooled = peak_pooled_,
 				fraglen = fraglen_mean.rounded_mean,
 				idr_thresh = idr_thresh,
@@ -1161,7 +1781,7 @@ workflow chip {
 		# reproducibility QC for overlapping peaks
 		call reproducibility as reproducibility_overlap { input :
 			prefix = 'overlap',
-			peaks = overlap.bfilt_overlap_peak,
+			peaks = select_all(overlap.bfilt_overlap_peak),
 			peaks_pr = overlap_pr.bfilt_overlap_peak,
 			peak_ppr = overlap_ppr.bfilt_overlap_peak,
 			peak_type = peak_type_,
@@ -1173,7 +1793,7 @@ workflow chip {
 		# reproducibility QC for IDR peaks
 		call reproducibility as reproducibility_idr { input :
 			prefix = 'idr',
-			peaks = idr.bfilt_idr_peak,
+			peaks = select_all(idr.bfilt_idr_peak),
 			peaks_pr = idr_pr.bfilt_idr_peak,
 			peak_ppr = idr_ppr.bfilt_idr_peak,
 			peak_type = peak_type_,
@@ -1198,45 +1818,45 @@ workflow chip {
 		xcor_trim_bp = xcor_trim_bp,
 		xcor_subsample_reads = xcor_subsample_reads,
 
-		samstat_qcs = align.samstat_qc,
-		nodup_samstat_qcs = filter.samstat_qc,
-		dup_qcs = filter.dup_qc,
-		lib_complexity_qcs = filter.lib_complexity_qc,
-		xcor_plots = xcor.plot_png,
-		xcor_scores = xcor.score,
+		samstat_qcs = select_all(align.samstat_qc),
+		nodup_samstat_qcs = select_all(filter.samstat_qc),
+		dup_qcs = select_all(filter.dup_qc),
+		lib_complexity_qcs = select_all(filter.lib_complexity_qc),
+		xcor_plots = select_all(xcor.plot_png),
+		xcor_scores = select_all(xcor.score),
 
-		ctl_samstat_qcs = align_ctl.samstat_qc,
-		ctl_nodup_samstat_qcs = filter_ctl.samstat_qc,
-		ctl_dup_qcs = filter_ctl.dup_qc,
-		ctl_lib_complexity_qcs = filter_ctl.lib_complexity_qc,
+		ctl_samstat_qcs = select_all(align_ctl.samstat_qc),
+		ctl_nodup_samstat_qcs = select_all(filter_ctl.samstat_qc),
+		ctl_dup_qcs = select_all(filter_ctl.dup_qc),
+		ctl_lib_complexity_qcs = select_all(filter_ctl.lib_complexity_qc),
 
 		jsd_plot = jsd.plot,
 		jsd_qcs = jsd.jsd_qcs,
 
-		frip_qcs = call_peak.frip_qc,
-		frip_qcs_pr1 = call_peak_pr1.frip_qc,
-		frip_qcs_pr2 = call_peak_pr2.frip_qc,
+		frip_qcs = select_all(call_peak.frip_qc),
+		frip_qcs_pr1 = select_all(call_peak_pr1.frip_qc),
+		frip_qcs_pr2 = select_all(call_peak_pr2.frip_qc),
 		frip_qc_pooled = call_peak_pooled.frip_qc,
 		frip_qc_ppr1 = call_peak_ppr1.frip_qc,
 		frip_qc_ppr2 = call_peak_ppr2.frip_qc,
 
-		idr_plots = idr.idr_plot,
+		idr_plots = select_all(idr.idr_plot),
 		idr_plots_pr = idr_pr.idr_plot,
 		idr_plot_ppr = idr_ppr.idr_plot,
-		frip_idr_qcs = idr.frip_qc,
+		frip_idr_qcs = select_all(idr.frip_qc),
 		frip_idr_qcs_pr = idr_pr.frip_qc,
 		frip_idr_qc_ppr = idr_ppr.frip_qc,
-		frip_overlap_qcs = overlap.frip_qc,
+		frip_overlap_qcs = select_all(overlap.frip_qc),
 		frip_overlap_qcs_pr = overlap_pr.frip_qc,
 		frip_overlap_qc_ppr = overlap_ppr.frip_qc,
 		idr_reproducibility_qc = reproducibility_idr.reproducibility_qc,
 		overlap_reproducibility_qc = reproducibility_overlap.reproducibility_qc,
 
-		gc_plots = gc_bias.gc_plot,
+		gc_plots = select_all(gc_bias.gc_plot),
 
-		peak_region_size_qcs = call_peak.peak_region_size_qc,
-		peak_region_size_plots = call_peak.peak_region_size_plot,
-		num_peak_qcs = call_peak.num_peak_qc,
+		peak_region_size_qcs = select_all(call_peak.peak_region_size_qc),
+		peak_region_size_plots = select_all(call_peak.peak_region_size_plot),
+		num_peak_qcs = select_all(call_peak.num_peak_qc),
 
 		idr_opt_peak_region_size_qc = reproducibility_idr.peak_region_size_qc,
 		idr_opt_peak_region_size_plot = reproducibility_overlap.peak_region_size_plot,
@@ -1255,26 +1875,27 @@ workflow chip {
 }
 
 task align {
-	Array[File] fastqs_R1 		# [merge_id]
-	Array[File] fastqs_R2
-	Int? trim_bp			# this is for R1 only
-	Int crop_length
-	Int crop_length_tol
-	String aligner
-	String mito_chr_name
-	Int? multimapping
-	File? custom_align_py	
-	File? idx_tar			# reference index tar
-	Boolean paired_end
-	Boolean use_bwa_mem_for_pe
+	input {
+		Array[File] fastqs_R1		 # [merge_id]
+		Array[File] fastqs_R2
+		Int? trim_bp			# this is for R1 only
+		Int crop_length
+		Int crop_length_tol
+		String aligner
+		String mito_chr_name
+		Int? multimapping
+		File? idx_tar			# reference index tar
+		Boolean paired_end
+		Boolean use_bwa_mem_for_pe
+
+		String? trimmomatic_java_heap
+		Int cpu
+		Int mem_mb
+		Int time_hr
+		String disks
+	}
 
 	Float trimmomatic_java_heap_factor = 0.9
-	String? trimmomatic_java_heap
-	Int cpu
-	Int mem_mb
-	Int time_hr
-	String disks
-
 	Array[Array[File]] tmp_fastqs = if paired_end then transpose([fastqs_R1, fastqs_R2])
 				else transpose([fastqs_R1])
 	command {
@@ -1285,7 +1906,7 @@ task align {
 		then
 		  echo -e "\n* Error: pipeline dependencies not found." 1>&2
 		  echo 'Conda users: Did you activate Conda environment (conda activate encode-chip-seq-pipeline)?' 1>&2
-		  echo '    Or did you install Conda and environment correctly (bash scripts/install_conda_env.sh)?' 1>&2
+		  echo '	Or did you install Conda and environment correctly (bash scripts/install_conda_env.sh)?' 1>&2
 		  echo 'GCP/AWS/Docker users: Did you add --docker flag to Caper command line arg?' 1>&2
 		  echo 'Singularity users: Did you add --singularity flag to Caper command line arg?' 1>&2
 		  echo -e "\n" 1>&2
@@ -1329,7 +1950,7 @@ task align {
 		fi
 
 		if [ '${aligner}' == 'bwa' ]; then
-		 	python3 $(which encode_task_bwa.py) \
+			 python3 $(which encode_task_bwa.py) \
 				${idx_tar} \
 				R1$SUFFIX/*.fastq.gz \
 				${if paired_end then 'R2$SUFFIX/*.fastq.gz' else ''} \
@@ -1338,18 +1959,11 @@ task align {
 				${'--nth ' + cpu}
 
 		elif [ '${aligner}' == 'bowtie2' ]; then
-		 	python3 $(which encode_task_bowtie2.py) \
+			 python3 $(which encode_task_bowtie2.py) \
 				${idx_tar} \
 				R1$SUFFIX/*.fastq.gz \
 				${if paired_end then 'R2$SUFFIX/*.fastq.gz' else ''} \
 				${'--multimapping ' + multimapping} \
-				${if paired_end then '--paired-end' else ''} \
-				${'--nth ' + cpu}
-		else
-			python3 ${custom_align_py} \
-				${idx_tar} \
-				R1$SUFFIX/*.fastq.gz \
-				${if paired_end then 'R2$SUFFIX/*.fastq.gz' else ''} \
 				${if paired_end then '--paired-end' else ''} \
 				${'--nth ' + cpu}
 		fi 
@@ -1376,22 +1990,24 @@ task align {
 }
 
 task filter {
-	File bam
-	Boolean paired_end
-	String dup_marker 			# picard.jar MarkDuplicates (picard) or 
-								# sambamba markdup (sambamba)
-	Int mapq_thresh				# threshold for low MAPQ reads removal
-	Array[String] filter_chrs 	# chrs to be removed from final (nodup/filt) BAM
-	File chrsz					# 2-col chromosome sizes file
-	Boolean no_dup_removal 		# no dupe reads removal when filtering BAM
-	String mito_chr_name
+	input {
+		File? bam
+		Boolean paired_end
+		String dup_marker			 # picard.jar MarkDuplicates (picard) or 
+									# sambamba markdup (sambamba)
+		Int mapq_thresh				# threshold for low MAPQ reads removal
+		Array[String] filter_chrs	 # chrs to be removed from final (nodup/filt) BAM
+		File chrsz					# 2-col chromosome sizes file
+		Boolean no_dup_removal		 # no dupe reads removal when filtering BAM
+		String mito_chr_name
 
-	Int cpu
-	Int mem_mb
+		Int cpu
+		Int mem_mb
+		String? picard_java_heap
+		Int time_hr
+		String disks
+	}
 	Float picard_java_heap_factor = 0.9
-	String? picard_java_heap
-	Int time_hr
-	String disks
 
 	command {
 		python3 $(which encode_task_filter.py) \
@@ -1423,15 +2039,17 @@ task filter {
 }
 
 task bam2ta {
-	File bam
-	Boolean paired_end
-	String mito_chr_name 		# mito chromosome name
-	Int subsample 				# number of reads to subsample TAGALIGN
-								# this affects all downstream analysis
-	Int cpu
-	Int mem_mb
-	Int time_hr
-	String disks
+	input {
+		File? bam
+		Boolean paired_end
+		String mito_chr_name		 # mito chromosome name
+		Int subsample				 # number of reads to subsample TAGALIGN
+									# this affects all downstream analysis
+		Int cpu
+		Int mem_mb
+		Int time_hr
+		String disks
+	}
 
 	command {
 		python3 $(which encode_task_bam2ta.py) \
@@ -1453,11 +2071,13 @@ task bam2ta {
 	}
 }
 
-task spr { # make two self pseudo replicates
-	File ta
-	Boolean paired_end
+task spr {
+	input {
+		File? ta
+		Boolean paired_end
 
-	Int mem_mb
+		Int mem_mb
+	}
 
 	command {
 		python3 $(which encode_task_spr.py) \
@@ -1477,13 +2097,15 @@ task spr { # make two self pseudo replicates
 }
 
 task pool_ta {
-	Array[File?] tas
-	Int? col 			# number of columns in pooled TA
-	String? prefix 		# basename prefix
+	input {
+		Array[File?] tas
+		Int? col			 # number of columns in pooled TA
+		String? prefix		 # basename prefix
+	}
 
 	command {
 		python3 $(which encode_task_pool_ta.py) \
-			${sep=' ' tas} \
+			${sep=' ' select_all(tas)} \
 			${'--prefix ' + prefix} \
 			${'--col ' + col}
 	}
@@ -1499,20 +2121,22 @@ task pool_ta {
 }
 
 task xcor {
-	File ta
-	Boolean paired_end
-	String mito_chr_name
-	Int subsample  # number of reads to subsample TAGALIGN
-					# this will be used for xcor only
-					# will not affect any downstream analysis
-	String? chip_seq_type
-	Int? exclusion_range_min
-	Int? exclusion_range_max
+	input {
+		File? ta
+		Boolean paired_end
+		String mito_chr_name
+		Int subsample  # number of reads to subsample TAGALIGN
+						# this will be used for xcor only
+						# will not affect any downstream analysis
+		String? chip_seq_type
+		Int? exclusion_range_min
+		Int? exclusion_range_max
 
-	Int cpu
-	Int mem_mb	
-	Int time_hr
-	String disks
+		Int cpu
+		Int mem_mb	
+		Int time_hr
+		String disks
+	}
 
 	command {
 		python3 $(which encode_task_xcor.py) \
@@ -1530,7 +2154,8 @@ task xcor {
 		File plot_pdf = glob('*.cc.plot.pdf')[0]
 		File plot_png = glob('*.cc.plot.png')[0]
 		File score = glob('*.cc.qc')[0]
-		Int fraglen = read_int(glob('*.cc.fraglen.txt')[0])
+		File fraglen_log = glob('*.cc.fraglen.txt')[0]
+		Int fraglen = read_int(fraglen_log)
 	}
 	runtime {
 		cpu : cpu
@@ -1541,19 +2166,21 @@ task xcor {
 }
 
 task jsd {
-	Array[File?] nodup_bams
-	Array[File?] ctl_bams
-	File blacklist
-	Int mapq_thresh
+	input {
+		Array[File?] nodup_bams
+		Array[File?] ctl_bams
+		File? blacklist
+		Int mapq_thresh
 
-	Int cpu
-	Int mem_mb
-	Int time_hr
-	String disks
+		Int cpu
+		Int mem_mb
+		Int time_hr
+		String disks
+	}
 
 	command {
 		python3 $(which encode_task_jsd.py) \
-			${sep=' ' nodup_bams} \
+			${sep=' ' select_all(nodup_bams)} \
 			${if length(ctl_bams)>0 then '--ctl-bam '+ select_first(ctl_bams) else ''} \
 			${'--mapq-thresh '+ mapq_thresh} \
 			${'--blacklist '+ blacklist} \
@@ -1572,20 +2199,22 @@ task jsd {
 }
 
 task choose_ctl {
-	Array[File?] tas
-	Array[File?] ctl_tas
-	File? ta_pooled
-	File? ctl_ta_pooled
-	Boolean always_use_pooled_ctl # always use pooled control for all exp rep.
-	Float ctl_depth_ratio 		# if ratio between controls is higher than this
-								# then always use pooled control for all exp rep.
-	Int ctl_depth_limit
-	Float exp_ctl_depth_ratio_limit
+	input {
+		Array[File?] tas
+		Array[File?] ctl_tas
+		File? ta_pooled
+		File? ctl_ta_pooled
+		Boolean always_use_pooled_ctl # always use pooled control for all exp rep.
+		Float ctl_depth_ratio		 # if ratio between controls is higher than this
+									# then always use pooled control for all exp rep.
+		Int ctl_depth_limit
+		Float exp_ctl_depth_ratio_limit
+	}
 
 	command {
 		python3 $(which encode_task_choose_ctl.py) \
-			--tas ${sep=' ' tas} \
-			--ctl-tas ${sep=' ' ctl_tas} \
+			--tas ${sep=' ' select_all(tas)} \
+			--ctl-tas ${sep=' ' select_all(ctl_tas)} \
 			${'--ta-pooled ' + ta_pooled} \
 			${'--ctl-ta-pooled ' + ctl_ta_pooled} \
 			${if always_use_pooled_ctl then '--always-use-pooled-ctl' else ''} \
@@ -1594,9 +2223,12 @@ task choose_ctl {
 			${'--exp-ctl-depth-ratio-limit ' + exp_ctl_depth_ratio_limit}
 	}
 	output {
-		Array[Int] chosen_ctl_ta_ids = read_lines(glob('chosen_ctl.tsv')[0])
-		Array[Int] chosen_ctl_ta_subsample = read_lines(glob('chosen_ctl_subsample.tsv')[0])
-		Int chosen_ctl_ta_subsample_pooled = read_int(glob('chosen_ctl_subsample_pooled.txt')[0])
+		File chosen_ctl_id_tsv = glob('chosen_ctl.tsv')[0]
+		File chosen_ctl_subsample_tsv = glob('chosen_ctl_subsample.tsv')[0]
+		File chosen_ctl_subsample_pooled_txt = glob('chosen_ctl_subsample_pooled.txt')[0]
+		Array[Int] chosen_ctl_ta_ids = read_lines(chosen_ctl_id_tsv)
+		Array[Int] chosen_ctl_ta_subsample = read_lines(chosen_ctl_subsample_tsv)
+		Int chosen_ctl_ta_subsample_pooled = read_int(chosen_ctl_subsample_pooled_txt)
 	}
 	runtime {
 		cpu : 1
@@ -1607,8 +2239,10 @@ task choose_ctl {
 }
 
 task count_signal_track {
-	File ta 			# tag-align
-	File chrsz			# 2-col chromosome sizes file
+	input {
+		File? ta			 # tag-align
+		File chrsz			# 2-col chromosome sizes file
+	}
 
 	command {
 		python3 $(which encode_task_count_signal_track.py) \
@@ -1628,34 +2262,35 @@ task count_signal_track {
 }
 
 task call_peak {
-	String peak_caller
-	String peak_type
-	File? custom_call_peak_py
-	Array[File?] tas	# [ta, control_ta]. control_ta is optional
-	Int fraglen 		# fragment length from xcor
-	String gensz		# Genome size (sum of entries in 2nd column of 
-                        # chr. sizes file, or hs for human, ms for mouse)
-	File chrsz			# 2-col chromosome sizes file
-	Int cap_num_peak	# cap number of raw peaks called from MACS2
-	Int ctl_subsample	# subsample control if >0. 0: no subsampling
-	Boolean ctl_paired_end # control is paired end
-	Float pval_thresh 	# p.value threshold for MACS2
-	Float? fdr_thresh 	# FDR threshold for SPP
+	input {
+		String peak_caller
+		String peak_type
+		Array[File?] tas	# [ta, control_ta]. control_ta is optional
+		Int fraglen		 # fragment length from xcor
+		String gensz		# Genome size (sum of entries in 2nd column of 
+							# chr. sizes file, or hs for human, ms for mouse)
+		File chrsz			# 2-col chromosome sizes file
+		Int cap_num_peak	# cap number of raw peaks called from MACS2
+		Int ctl_subsample	# subsample control if >0. 0: no subsampling
+		Boolean ctl_paired_end # control is paired end
+		Float pval_thresh	 # p.value threshold for MACS2
+		Float? fdr_thresh	 # FDR threshold for SPP
 
-	File? blacklist 	# blacklist BED to filter raw peaks
-	String? regex_bfilt_peak_chr_name
+		File? blacklist	 # blacklist BED to filter raw peaks
+		String? regex_bfilt_peak_chr_name
 
-	Int cpu	
-	Int mem_mb
-	Int time_hr
-	String disks
+		Int cpu	
+		Int mem_mb
+		Int time_hr
+		String disks
+	}
 
 	command {
 		set -e
 
 		if [ '${peak_caller}' == 'macs2' ]; then
 			python3 $(which encode_task_macs2_chip.py) \
-				${sep=' ' tas} \
+				${sep=' ' select_all(tas)} \
 				${'--gensz '+ gensz} \
 				${'--chrsz ' + chrsz} \
 				${'--fraglen ' + fraglen} \
@@ -1666,23 +2301,11 @@ task call_peak {
 
 		elif [ '${peak_caller}' == 'spp' ]; then
 			python3 $(which encode_task_spp.py) \
-				${sep=' ' tas} \
+				${sep=' ' select_all(tas)} \
 				${'--fraglen ' + fraglen} \
 				${'--cap-num-peak ' + cap_num_peak} \
 				${'--ctl-subsample ' + ctl_subsample} \
 				${if ctl_paired_end then '--ctl-paired-end' else ''} \
-				${'--fdr-thresh '+ fdr_thresh} \
-				${'--nth ' + cpu}
-		else
-			python3 ${custom_call_peak_py} \
-				${sep=' ' tas} \
-				${'--gensz '+ gensz} \
-				${'--chrsz ' + chrsz} \
-				${'--fraglen ' + fraglen} \
-				${'--cap-num-peak ' + cap_num_peak} \
-				${'--ctl-subsample ' + ctl_subsample}
-				${if ctl_paired_end then '--ctl-paired-end' else ''} \
-				${'--pval-thresh '+ pval_thresh} \
 				${'--fdr-thresh '+ fdr_thresh} \
 				${'--nth ' + cpu}
 		fi
@@ -1697,7 +2320,6 @@ task call_peak {
 			${'--blacklist ' + blacklist}		
 	}
 	output {
-		# generated by custom_call_peak_py
 		File peak = glob('*[!.][!b][!f][!i][!l][!t].'+peak_type+'.gz')[0]
 		# generated by post_call_peak py
 		File bfilt_peak = glob('*.bfilt.'+peak_type+'.gz')[0]
@@ -1719,22 +2341,24 @@ task call_peak {
 }
 
 task macs2_signal_track {
-	Array[File?] tas	# [ta, control_ta]. control_ta is optional
-	Int fraglen 		# fragment length from xcor
-	String gensz		# Genome size (sum of entries in 2nd column of 
-                        # chr. sizes file, or hs for human, ms for mouse)
-	File chrsz			# 2-col chromosome sizes file
-	Int ctl_subsample	# subsample control if >0. 0: no subsampling
-	Boolean ctl_paired_end # control is paired end	
-	Float pval_thresh 	# p.value threshold
+	input {
+		Array[File?] tas	# [ta, control_ta]. control_ta is optional
+		Int fraglen		 # fragment length from xcor
+		String gensz		# Genome size (sum of entries in 2nd column of 
+							# chr. sizes file, or hs for human, ms for mouse)
+		File chrsz			# 2-col chromosome sizes file
+		Int ctl_subsample	# subsample control if >0. 0: no subsampling
+		Boolean ctl_paired_end # control is paired end	
+		Float pval_thresh	 # p.value threshold
 
-	Int mem_mb
-	Int time_hr
-	String disks
+		Int mem_mb
+		Int time_hr
+		String disks
+	}
 
 	command {
 		python3 $(which encode_task_macs2_signal_track_chip.py) \
-			${sep=' ' tas} \
+			${sep=' ' select_all(tas)} \
 			${'--gensz '+ gensz} \
 			${'--chrsz ' + chrsz} \
 			${'--fraglen ' + fraglen} \
@@ -1756,19 +2380,21 @@ task macs2_signal_track {
 }
 
 task idr {
-	String prefix 		# prefix for IDR output file
-	File peak1 			
-	File peak2
-	File peak_pooled
-	Float idr_thresh
-	File? blacklist 	# blacklist BED to filter raw peaks
-	String regex_bfilt_peak_chr_name
-	# parameters to compute FRiP
-	File? ta			# to calculate FRiP
-	Int fraglen 		# fragment length from xcor
-	File chrsz			# 2-col chromosome sizes file
-	String peak_type
-	String rank
+	input {
+		String prefix		 # prefix for IDR output file
+		File? peak1
+		File? peak2
+		File? peak_pooled
+		Float idr_thresh
+		File? blacklist	 # blacklist BED to filter raw peaks
+		String regex_bfilt_peak_chr_name
+		# parameters to compute FRiP
+		File? ta			# to calculate FRiP
+		Int? fraglen		 # fragment length from xcor
+		File chrsz			# 2-col chromosome sizes file
+		String peak_type
+		String rank
+	}
 
 	command {
 		${if defined(ta) then '' else 'touch null.frip.qc'}
@@ -1805,17 +2431,19 @@ task idr {
 }
 
 task overlap {
-	String prefix 	# prefix for IDR output file
-	File peak1
-	File peak2
-	File peak_pooled
-	File? blacklist # blacklist BED to filter raw peaks
-	String regex_bfilt_peak_chr_name
-	# parameters to compute FRiP
-	File? ta		# to calculate FRiP
-	Int fraglen 	# fragment length from xcor (for FRIP)
-	File chrsz		# 2-col chromosome sizes file
-	String peak_type
+	input {
+		String prefix	 # prefix for IDR output file
+		File? peak1
+		File? peak2
+		File? peak_pooled
+		File? blacklist # blacklist BED to filter raw peaks
+		String regex_bfilt_peak_chr_name
+		# parameters to compute FRiP
+		File? ta		# to calculate FRiP
+		Int? fraglen	 # fragment length from xcor (for FRIP)
+		File chrsz		# 2-col chromosome sizes file
+		String peak_type
+	}
 
 	command {
 		${if defined(ta) then '' else 'touch null.frip.qc'}
@@ -1848,15 +2476,17 @@ task overlap {
 }
 
 task reproducibility {
-	String prefix
-	Array[File]? peaks # peak files from pair of true replicates
-						# in a sorted order. for example of 4 replicates,
-						# 1,2 1,3 1,4 2,3 2,4 3,4.
-                        # x,y means peak file from rep-x vs rep-y
-	Array[File?] peaks_pr	# peak files from pseudo replicates
-	File? peak_ppr			# Peak file from pooled pseudo replicate.
-	String peak_type
-	File chrsz			# 2-col chromosome sizes file
+	input {
+		String prefix
+		Array[File] peaks # peak files from pair of true replicates
+							# in a sorted order. for example of 4 replicates,
+							# 1,2 1,3 1,4 2,3 2,4 3,4.
+							# x,y means peak file from rep-x vs rep-y
+		Array[File]? peaks_pr	# peak files from pseudo replicates
+		File? peak_ppr			# Peak file from pooled pseudo replicate.
+		String peak_type
+		File chrsz			# 2-col chromosome sizes file
+	}
 
 	command {
 		python3 $(which encode_task_reproducibility.py) \
@@ -1891,12 +2521,14 @@ task reproducibility {
 }
 
 task gc_bias {
-	File nodup_bam
-	File ref_fa
+	input {
+		File? nodup_bam
+		File ref_fa
 
+		String? picard_java_heap
+	}
 	Int mem_mb = 10000
 	Float picard_java_heap_factor = 0.9
-	String? picard_java_heap
 
 	command {
 		python3 $(which encode_task_gc_bias.py) \
@@ -1916,73 +2548,72 @@ task gc_bias {
 	}
 }
 
-# gather all outputs and generate 
-# - qc.html		: organized final HTML report
-# - qc.json		: all QCs
 task qc_report {
-	# optional metadata
-	String pipeline_ver
- 	String title # name of sample
-	String description # description for sample
-	String? genome
-	#String? encode_accession_id	# ENCODE accession ID of sample
-	# workflow params
-	Array[Boolean?] paired_ends
-	Array[Boolean?] ctl_paired_ends
-	String pipeline_type
-	String aligner
-	String peak_caller
-	Int cap_num_peak
-	Float idr_thresh
-	Float pval_thresh
-	Int xcor_trim_bp
-	Int xcor_subsample_reads
-	# QCs
-	Array[File?] samstat_qcs
-	Array[File?] nodup_samstat_qcs
-	Array[File?] dup_qcs
-	Array[File?] lib_complexity_qcs
-	Array[File?] ctl_samstat_qcs
-	Array[File?] ctl_nodup_samstat_qcs
-	Array[File?] ctl_dup_qcs
-	Array[File?] ctl_lib_complexity_qcs
-	Array[File?] xcor_plots
-	Array[File?] xcor_scores
-	File? jsd_plot
-	Array[File]? jsd_qcs
-	Array[File]? idr_plots
-	Array[File]? idr_plots_pr
-	File? idr_plot_ppr
-	Array[File?] frip_qcs
-	Array[File?] frip_qcs_pr1
-	Array[File?] frip_qcs_pr2
-	File? frip_qc_pooled
-	File? frip_qc_ppr1 
-	File? frip_qc_ppr2 
-	Array[File]? frip_idr_qcs
-	Array[File]? frip_idr_qcs_pr
-	File? frip_idr_qc_ppr 
-	Array[File]? frip_overlap_qcs
-	Array[File]? frip_overlap_qcs_pr
-	File? frip_overlap_qc_ppr
-	File? idr_reproducibility_qc
-	File? overlap_reproducibility_qc
+	input {
+		# optional metadata
+		String pipeline_ver
+		String title # name of sample
+		String description # description for sample
+		String? genome
+		#String? encode_accession_id	# ENCODE accession ID of sample
+		# workflow params
+		Array[Boolean] paired_ends
+		Array[Boolean] ctl_paired_ends
+		String pipeline_type
+		String aligner
+		String peak_caller
+		Int cap_num_peak
+		Float idr_thresh
+		Float pval_thresh
+		Int xcor_trim_bp
+		Int xcor_subsample_reads
+		# QCs
+		Array[File] samstat_qcs
+		Array[File] nodup_samstat_qcs
+		Array[File] dup_qcs
+		Array[File] lib_complexity_qcs
+		Array[File] ctl_samstat_qcs
+		Array[File] ctl_nodup_samstat_qcs
+		Array[File] ctl_dup_qcs
+		Array[File] ctl_lib_complexity_qcs
+		Array[File] xcor_plots
+		Array[File] xcor_scores
+		File? jsd_plot
+		Array[File]? jsd_qcs
+		Array[File] idr_plots
+		Array[File]? idr_plots_pr
+		File? idr_plot_ppr
+		Array[File] frip_qcs
+		Array[File] frip_qcs_pr1
+		Array[File] frip_qcs_pr2
+		File? frip_qc_pooled
+		File? frip_qc_ppr1 
+		File? frip_qc_ppr2 
+		Array[File] frip_idr_qcs
+		Array[File]? frip_idr_qcs_pr
+		File? frip_idr_qc_ppr 
+		Array[File] frip_overlap_qcs
+		Array[File]? frip_overlap_qcs_pr
+		File? frip_overlap_qc_ppr
+		File? idr_reproducibility_qc
+		File? overlap_reproducibility_qc
 
-	Array[File?] gc_plots
+		Array[File] gc_plots
 
-	Array[File?] peak_region_size_qcs
-	Array[File?] peak_region_size_plots
-	Array[File?] num_peak_qcs
+		Array[File] peak_region_size_qcs
+		Array[File] peak_region_size_plots
+		Array[File] num_peak_qcs
 
-	File? idr_opt_peak_region_size_qc
-	File? idr_opt_peak_region_size_plot
-	File? idr_opt_num_peak_qc
+		File? idr_opt_peak_region_size_qc
+		File? idr_opt_peak_region_size_plot
+		File? idr_opt_num_peak_qc
 
-	File? overlap_opt_peak_region_size_qc
-	File? overlap_opt_peak_region_size_plot
-	File? overlap_opt_num_peak_qc
+		File? overlap_opt_peak_region_size_qc
+		File? overlap_opt_peak_region_size_plot
+		File? overlap_opt_num_peak_qc
 
-	File? qc_json_ref
+		File? qc_json_ref
+	}
 
 	command {
 		python3 $(which encode_task_qc_report.py) \
@@ -2059,14 +2690,14 @@ task qc_report {
 
 ### workflow system tasks
 task read_genome_tsv {
-	File genome_tsv
-
-	String? null_s
+	input {
+		File? genome_tsv
+		String? null_s
+	}
 	command <<<
+		echo "$(basename ~{genome_tsv})" > genome_name
 		# create empty files for all entries
-		touch genome_name
 		touch ref_fa bowtie2_idx_tar bwa_idx_tar chrsz gensz blacklist blacklist2
-		touch custom_aligner_idx_tar
 		touch tss tss_enrich # for backward compatibility
 		touch dnase prom enh reg2map reg2map_bed roadmap_meta
 		touch mito_chr_name
@@ -2074,7 +2705,7 @@ task read_genome_tsv {
 
 		python <<CODE
 		import os
-		with open('${genome_tsv}','r') as fp:
+		with open('~{genome_tsv}','r') as fp:
 			for line in fp:
 				arr = line.strip('\n').split('\t')
 				if arr:
@@ -2084,11 +2715,10 @@ task read_genome_tsv {
 		CODE
 	>>>
 	output {
-		String? genome_name = if size('genome_name')==0 then basename(genome_tsv) else read_string('genome_name')
+		String? genome_name = read_string('genome_name')
 		String? ref_fa = if size('ref_fa')==0 then null_s else read_string('ref_fa')
 		String? bwa_idx_tar = if size('bwa_idx_tar')==0 then null_s else read_string('bwa_idx_tar')
 		String? bowtie2_idx_tar = if size('bowtie2_idx_tar')==0 then null_s else read_string('bowtie2_idx_tar')
-		String? custom_aligner_idx_tar = if size('custom_aligner_idx_tar')==0 then null_s else read_string('custom_aligner_idx_tar')
 		String? chrsz = if size('chrsz')==0 then null_s else read_string('chrsz')
 		String? gensz = if size('gensz')==0 then null_s else read_string('gensz')
 		String? blacklist = if size('blacklist')==0 then null_s else read_string('blacklist')
@@ -2096,7 +2726,6 @@ task read_genome_tsv {
 		String? mito_chr_name = if size('mito_chr_name')==0 then null_s else read_string('mito_chr_name')
 		String? regex_bfilt_peak_chr_name = if size('regex_bfilt_peak_chr_name')==0 then 'chr[\\dXY]+'
 			else read_string('regex_bfilt_peak_chr_name')
-		# optional data
 		String? tss = if size('tss')!=0 then read_string('tss')
 			else if size('tss_enrich')!=0 then read_string('tss_enrich') else null_s
 		String? dnase = if size('dnase')==0 then null_s else read_string('dnase')
@@ -2116,17 +2745,19 @@ task read_genome_tsv {
 }
 
 task rounded_mean {
-	Array[Int] ints
+	input {
+		Array[Int] ints
+	}
 	command <<<
 		python <<CODE
-		arr = [${sep=',' ints}]
+		arr = [~{sep=',' ints}]
 		with open('tmp.txt','w') as fp:
 			if len(arr):
-			    sum_ = sum(arr)
-			    mean_ = sum(arr)/float(len(arr))
-			    fp.write('{}'.format(int(round(mean_))))
+				sum_ = sum(arr)
+				mean_ = sum(arr)/float(len(arr))
+				fp.write('{}'.format(int(round(mean_))))
 			else:
-			    fp.write('0')
+				fp.write('0')
 		CODE
 	>>>
 	output {
@@ -2141,8 +2772,10 @@ task rounded_mean {
 }
 
 task raise_exception {
-	String msg
-	Array[String]? vals
+	input {
+		String msg
+		Array[String]? vals
+	}
 	command {
 		echo -e "\n* Error: ${msg}\n" >&2
 		echo -e "* Vals: ${sep=',' vals}\n" >&2

--- a/chip.wdl
+++ b/chip.wdl
@@ -644,7 +644,7 @@ workflow chip {
             help: 'If control chosen by chip.always_use_pooled_ctl and chip.ctl_depth_ratio is deeper than this hard limit, then such control is subsampled.'
         }
         exp_ctl_depth_ratio_limit: {
-            description: 'Second limit for chosen control\'s' depth.',
+            description: 'Second limit for chosen control\'s depth.',
             group: 'peak_calling',
             help: 'If control chosen by chip.always_use_pooled_ctl and chip.ctl_depth_ratio is deeper than experiment replicate\'s read depth multiplied by this factor then such control is subsampled down to maximum of multiplied value and hard limit chip.ctl_depth_limit.'
         }

--- a/dev/build_on_dx_dockerhub.sh
+++ b/dev/build_on_dx_dockerhub.sh
@@ -8,89 +8,102 @@ DXWDL=~/dxWDL-v1.46.4.jar
 # check if docker image exists on dockerhub
 docker pull $DOCKER
 
+# make a copy of WDL
+# workflows generated from original WDL cannot start from inputs other than FASTQs
+# make all vars non-optional (without ?)
+cp chip.wdl chip.dx.wdl
+sed -i 's/Array\[File?\] bams = \[\]/Array\[File\] bams = \[\]/g' chip.dx.wdl
+sed -i 's/Array\[File?\] nodup_bams = \[\]/Array\[File\] nodup_bams = \[\]/g' chip.dx.wdl
+sed -i 's/Array\[File?\] tas = \[\]/Array\[File\] tas = \[\]/g' chip.dx.wdl
+sed -i 's/Array\[File?\] ctl_bams = \[\]/Array\[File\] ctl_bams = \[\]/g' chip.dx.wdl
+sed -i 's/Array\[File?\] ctl_nodup_bams = \[\]/Array\[File\] ctl_nodup_bams = \[\]/g' chip.dx.wdl
+sed -i 's/Array\[File?\] ctl_tas = \[\]/Array\[File\] ctl_tas = \[\]/g' chip.dx.wdl
+
 # general
-java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+java -jar ${DXWDL} compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ChIP-seq2/workflows/$VER/general -defaults example_input_json/dx/template_general.json
 
 # hg38
-java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+java -jar ${DXWDL} compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ChIP-seq2/workflows/$VER/hg38 -defaults example_input_json/dx/template_hg38.json
 
 # hg19
-java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+java -jar ${DXWDL} compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ChIP-seq2/workflows/$VER/hg19 -defaults example_input_json/dx/template_hg19.json
 
 # mm10
-java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+java -jar ${DXWDL} compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ChIP-seq2/workflows/$VER/mm10 -defaults example_input_json/dx/template_mm10.json
 
 # mm9
-java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+java -jar ${DXWDL} compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ChIP-seq2/workflows/$VER/mm9 -defaults example_input_json/dx/template_mm9.json
 
 # test sample PE ENCSR936XTK (full)
-java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+java -jar ${DXWDL} compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ChIP-seq2/workflows/$VER/test_ENCSR936XTK -defaults example_input_json/dx/ENCSR936XTK_dx.json
 
 # test sample SE ENCSR000DYI (full)
-java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+java -jar ${DXWDL} compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ChIP-seq2/workflows/$VER/test_ENCSR000DYI -defaults example_input_json/dx/ENCSR000DYI_dx.json
 
 # test sample SE ENCSR000DYI (subsampled, chr19/chrM only)
-java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+java -jar ${DXWDL} compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ChIP-seq2/workflows/$VER/test_ENCSR000DYI_subsampled_chr19_only -defaults example_input_json/dx/ENCSR000DYI_subsampled_chr19_only_dx.json
 
 # test sample SE ENCSR000DYI (subsampled, chr19/chrM only, rep1)
-java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+java -jar ${DXWDL} compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ChIP-seq2/workflows/$VER/test_ENCSR000DYI_subsampled_chr19_only_rep1 -defaults example_input_json/dx/ENCSR000DYI_subsampled_chr19_only_rep1_dx.json
 
 ## DX Azure
 
 # general
-java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+java -jar ${DXWDL} compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ChIP-seq2/workflows/$VER/general -defaults example_input_json/dx_azure/template_general.json
 
 # hg38
-java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+java -jar ${DXWDL} compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ChIP-seq2/workflows/$VER/hg38 -defaults example_input_json/dx_azure/template_hg38.json
 
 # hg19
-java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+java -jar ${DXWDL} compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ChIP-seq2/workflows/$VER/hg19 -defaults example_input_json/dx_azure/template_hg19.json
 
 # mm10
-java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+java -jar ${DXWDL} compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ChIP-seq2/workflows/$VER/mm10 -defaults example_input_json/dx_azure/template_mm10.json
 
 # mm9
-java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+java -jar ${DXWDL} compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ChIP-seq2/workflows/$VER/mm9 -defaults example_input_json/dx_azure/template_mm9.json
 
 # test sample PE ENCSR936XTK (full)
-java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+java -jar ${DXWDL} compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ChIP-seq2/workflows/$VER/test_ENCSR936XTK -defaults example_input_json/dx_azure/ENCSR936XTK_dx_azure.json
 
 # test sample SE ENCSR000DYI (full)
-java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+java -jar ${DXWDL} compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ChIP-seq2/workflows/$VER/test_ENCSR000DYI -defaults example_input_json/dx_azure/ENCSR000DYI_dx_azure.json
 
 # test sample SE ENCSR000DYI (subsampled, chr19/chrM only)
-java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+java -jar ${DXWDL} compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ChIP-seq2/workflows/$VER/test_ENCSR000DYI_subsampled_chr19_only -defaults example_input_json/dx_azure/ENCSR000DYI_subsampled_chr19_only_dx_azure.json
+
+rm -f chip.dx.wdl

--- a/dev/build_on_dx_dockerhub.sh
+++ b/dev/build_on_dx_dockerhub.sh
@@ -1,74 +1,96 @@
 #!/bin/bash
 set -e
 
-VER=$(cat chip.wdl | grep "#CAPER docker" | awk 'BEGIN{FS=":"} {print $2}')
+VER=$(cat chip.wdl | grep "String pipeline_ver = " | awk '{gsub("'"'"'",""); print $4}')
 DOCKER=encodedcc/chip-seq-pipeline:$VER
+DXWDL=~/dxWDL-v1.46.4.jar
 
 # check if docker image exists on dockerhub
 docker pull $DOCKER
 
-# make a copy of WDL
-# workflows generated from original WDL cannot start from inputs other than FASTQs
-# make all vars non-optional (without ?)
-cp chip.wdl chip.dx.wdl
-sed -i 's/Array\[File?\] bams = \[\]/Array\[File\] bams = \[\]/g' chip.dx.wdl
-sed -i 's/Array\[File?\] nodup_bams = \[\]/Array\[File\] nodup_bams = \[\]/g' chip.dx.wdl
-sed -i 's/Array\[File?\] tas = \[\]/Array\[File\] tas = \[\]/g' chip.dx.wdl
-sed -i 's/Array\[File?\] ctl_bams = \[\]/Array\[File\] ctl_bams = \[\]/g' chip.dx.wdl
-sed -i 's/Array\[File?\] ctl_nodup_bams = \[\]/Array\[File\] ctl_nodup_bams = \[\]/g' chip.dx.wdl
-sed -i 's/Array\[File?\] ctl_tas = \[\]/Array\[File\] ctl_tas = \[\]/g' chip.dx.wdl
-
 # general
-java -jar ~/dxWDL-0.81.6.jar compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER/general -defaults example_input_json/dx/template_general.json
+java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ChIP-seq2/workflows/$VER/general -defaults example_input_json/dx/template_general.json
 
 # hg38
-java -jar ~/dxWDL-0.81.6.jar compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER/hg38 -defaults example_input_json/dx/template_hg38.json
+java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ChIP-seq2/workflows/$VER/hg38 -defaults example_input_json/dx/template_hg38.json
 
 # hg19
-java -jar ~/dxWDL-0.81.6.jar compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER/hg19 -defaults example_input_json/dx/template_hg19.json
+java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ChIP-seq2/workflows/$VER/hg19 -defaults example_input_json/dx/template_hg19.json
 
 # mm10
-java -jar ~/dxWDL-0.81.6.jar compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER/mm10 -defaults example_input_json/dx/template_mm10.json
+java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ChIP-seq2/workflows/$VER/mm10 -defaults example_input_json/dx/template_mm10.json
 
 # mm9
-java -jar ~/dxWDL-0.81.6.jar compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER/mm9 -defaults example_input_json/dx/template_mm9.json
+java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ChIP-seq2/workflows/$VER/mm9 -defaults example_input_json/dx/template_mm9.json
 
 # test sample PE ENCSR936XTK (full)
-java -jar ~/dxWDL-0.81.6.jar compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER/test_ENCSR936XTK -defaults example_input_json/dx/ENCSR936XTK_dx.json
+java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ChIP-seq2/workflows/$VER/test_ENCSR936XTK -defaults example_input_json/dx/ENCSR936XTK_dx.json
 
 # test sample SE ENCSR000DYI (full)
-java -jar ~/dxWDL-0.81.6.jar compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER/test_ENCSR000DYI -defaults example_input_json/dx/ENCSR000DYI_dx.json
+java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ChIP-seq2/workflows/$VER/test_ENCSR000DYI -defaults example_input_json/dx/ENCSR000DYI_dx.json
 
 # test sample SE ENCSR000DYI (subsampled, chr19/chrM only)
-java -jar ~/dxWDL-0.81.6.jar compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER/test_ENCSR000DYI_subsampled_chr19_only -defaults example_input_json/dx/ENCSR000DYI_subsampled_chr19_only_dx.json
+java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ChIP-seq2/workflows/$VER/test_ENCSR000DYI_subsampled_chr19_only -defaults example_input_json/dx/ENCSR000DYI_subsampled_chr19_only_dx.json
 
 # test sample SE ENCSR000DYI (subsampled, chr19/chrM only, rep1)
-java -jar ~/dxWDL-0.81.6.jar compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER/test_ENCSR000DYI_subsampled_chr19_only_rep1 -defaults example_input_json/dx/ENCSR000DYI_subsampled_chr19_only_rep1_dx.json
+java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ChIP-seq2/workflows/$VER/test_ENCSR000DYI_subsampled_chr19_only_rep1 -defaults example_input_json/dx/ENCSR000DYI_subsampled_chr19_only_rep1_dx.json
 
 ## DX Azure
 
 # general
-java -jar ~/dxWDL-0.81.6.jar compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER/general -defaults example_input_json/dx_azure/template_general.json
+java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ChIP-seq2/workflows/$VER/general -defaults example_input_json/dx_azure/template_general.json
 
 # hg38
-java -jar ~/dxWDL-0.81.6.jar compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER/hg38 -defaults example_input_json/dx_azure/template_hg38.json
+java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ChIP-seq2/workflows/$VER/hg38 -defaults example_input_json/dx_azure/template_hg38.json
 
 # hg19
-java -jar ~/dxWDL-0.81.6.jar compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER/hg19 -defaults example_input_json/dx_azure/template_hg19.json
+java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ChIP-seq2/workflows/$VER/hg19 -defaults example_input_json/dx_azure/template_hg19.json
 
 # mm10
-java -jar ~/dxWDL-0.81.6.jar compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER/mm10 -defaults example_input_json/dx_azure/template_mm10.json
+java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ChIP-seq2/workflows/$VER/mm10 -defaults example_input_json/dx_azure/template_mm10.json
 
 # mm9
-java -jar ~/dxWDL-0.81.6.jar compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER/mm9 -defaults example_input_json/dx_azure/template_mm9.json
+java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ChIP-seq2/workflows/$VER/mm9 -defaults example_input_json/dx_azure/template_mm9.json
 
 # test sample PE ENCSR936XTK (full)
-java -jar ~/dxWDL-0.81.6.jar compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER/test_ENCSR936XTK -defaults example_input_json/dx_azure/ENCSR936XTK_dx_azure.json
+java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ChIP-seq2/workflows/$VER/test_ENCSR936XTK -defaults example_input_json/dx_azure/ENCSR936XTK_dx_azure.json
 
 # test sample SE ENCSR000DYI (full)
-java -jar ~/dxWDL-0.81.6.jar compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER/test_ENCSR000DYI -defaults example_input_json/dx_azure/ENCSR000DYI_dx_azure.json
+java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ChIP-seq2/workflows/$VER/test_ENCSR000DYI -defaults example_input_json/dx_azure/ENCSR000DYI_dx_azure.json
 
 # test sample SE ENCSR000DYI (subsampled, chr19/chrM only)
-java -jar ~/dxWDL-0.81.6.jar compile chip.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ChIP-seq2/workflows/$VER/test_ENCSR000DYI_subsampled_chr19_only -defaults example_input_json/dx_azure/ENCSR000DYI_subsampled_chr19_only_dx_azure.json
-
-rm -f chip.dx.wdl
+java -jar ${DXWDL} compile chip.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ChIP-seq2/workflows/$VER/test_ENCSR000DYI_subsampled_chr19_only -defaults example_input_json/dx_azure/ENCSR000DYI_subsampled_chr19_only_dx_azure.json

--- a/dev/test/test_task/compare_md5sum.wdl
+++ b/dev/test/test_task/compare_md5sum.wdl
@@ -1,92 +1,95 @@
+version 1.0
 task compare_md5sum {
-	Array[String] labels
-	Array[File] files
-	Array[File] ref_files
-
-	command <<<
-		python <<CODE	
-		from collections import OrderedDict
-		import os
-		import json
-		import hashlib
-
-		def md5sum(filename, blocksize=65536):
-		    hash = hashlib.md5()
-		    with open(filename, 'rb') as f:
-		        for block in iter(lambda: f.read(blocksize), b''):
-		            hash.update(block)
-		    return hash.hexdigest()
-
-		with open('${write_lines(labels)}','r') as fp:
-			labels = fp.read().splitlines()
-		with open('${write_lines(files)}','r') as fp:
-			files = fp.read().splitlines()
-		with open('${write_lines(ref_files)}','r') as fp:
-			ref_files = fp.read().splitlines()
-
-		result = OrderedDict()
-		match = OrderedDict()
-		match_overall = True
-
-		result['tasks'] = []
-		result['failed_task_labels'] = []
-		result['succeeded_task_labels'] = []
-		for i, label in enumerate(labels):
-			f = files[i]
-			ref_f = ref_files[i]
-			md5 = md5sum(f)
-			ref_md5 = md5sum(ref_f)
-			# if text file, read in contents
-			if f.endswith('.qc') or f.endswith('.txt') or \
-				f.endswith('.log') or f.endswith('.out'):
-				with open(f,'r') as fp:
-					contents = fp.read()
-				with open(ref_f,'r') as fp:
-					ref_contents = fp.read()
-			else:
-				contents = ''
-				ref_contents = ''
-			matched = md5==ref_md5
-			result['tasks'].append(OrderedDict([
-				('label', label),
-				('match', matched),
-				('md5sum', md5),
-				('ref_md5sum', ref_md5),
-				('basename', os.path.basename(f)),
-				('ref_basename', os.path.basename(ref_f)),
-				('contents', contents),
-				('ref_contents', ref_contents),
-				]))
-			match[label] = matched
-			match_overall &= matched
-			if matched:
-				result['succeeded_task_labels'].append(label)
-			else:
-				result['failed_task_labels'].append(label)		
-		result['match_overall'] = match_overall
-
-		with open('result.json','w') as fp:
-			fp.write(json.dumps(result, indent=4))
-		match_tmp = []
-		for key in match:
-			val = match[key]
-			match_tmp.append('{}\t{}'.format(key, val))
-		with open('match.tsv','w') as fp:
-			fp.writelines('\n'.join(match_tmp))
-		with open('match_overall.txt','w') as fp:
-			fp.write(str(match_overall))
-		CODE
-	>>>
-	output {
-		Map[String,String] match = read_map('match.tsv') # key:label, val:match
-		Boolean match_overall = read_boolean('match_overall.txt')
-		File json = glob('result.json')[0] # details (json file)
-		String json_str = read_string('result.json') # details (string)
+	input {
+	    Array[String] labels
+	    Array[File] files
+	    Array[File] ref_files
 	}
-	runtime {
-		cpu : 1
-		memory : '4000 MB'
-		time : 1
-		disks : 'local-disk 50 HDD'
-	}
+
+    command <<<
+        python <<CODE    
+        from collections import OrderedDict
+        import os
+        import json
+        import hashlib
+
+        def md5sum(filename, blocksize=65536):
+            hash = hashlib.md5()
+            with open(filename, 'rb') as f:
+                for block in iter(lambda: f.read(blocksize), b''):
+                    hash.update(block)
+            return hash.hexdigest()
+
+        with open('~{write_lines(labels)}','r') as fp:
+            labels = fp.read().splitlines()
+        with open('~{write_lines(files)}','r') as fp:
+            files = fp.read().splitlines()
+        with open('~{write_lines(ref_files)}','r') as fp:
+            ref_files = fp.read().splitlines()
+
+        result = OrderedDict()
+        match = OrderedDict()
+        match_overall = True
+
+        result['tasks'] = []
+        result['failed_task_labels'] = []
+        result['succeeded_task_labels'] = []
+        for i, label in enumerate(labels):
+            f = files[i]
+            ref_f = ref_files[i]
+            md5 = md5sum(f)
+            ref_md5 = md5sum(ref_f)
+            # if text file, read in contents
+            if f.endswith('.qc') or f.endswith('.txt') or \
+                f.endswith('.log') or f.endswith('.out'):
+                with open(f,'r') as fp:
+                    contents = fp.read()
+                with open(ref_f,'r') as fp:
+                    ref_contents = fp.read()
+            else:
+                contents = ''
+                ref_contents = ''
+            matched = md5==ref_md5
+            result['tasks'].append(OrderedDict([
+                ('label', label),
+                ('match', matched),
+                ('md5sum', md5),
+                ('ref_md5sum', ref_md5),
+                ('basename', os.path.basename(f)),
+                ('ref_basename', os.path.basename(ref_f)),
+                ('contents', contents),
+                ('ref_contents', ref_contents),
+                ]))
+            match[label] = matched
+            match_overall &= matched
+            if matched:
+                result['succeeded_task_labels'].append(label)
+            else:
+                result['failed_task_labels'].append(label)        
+        result['match_overall'] = match_overall
+
+        with open('result.json','w') as fp:
+            fp.write(json.dumps(result, indent=4))
+        match_tmp = []
+        for key in match:
+            val = match[key]
+            match_tmp.append('{}\t{}'.format(key, val))
+        with open('match.tsv','w') as fp:
+            fp.writelines('\n'.join(match_tmp))
+        with open('match_overall.txt','w') as fp:
+            fp.write(str(match_overall))
+        CODE
+    >>>
+    output {
+        Map[String,String] match = read_map('match.tsv') # key:label, val:match
+        Boolean match_overall = read_boolean('match_overall.txt')
+        File json = glob('result.json')[0] # details (json file)
+        String json_str = read_string('result.json') # details (string)
+    }
+    runtime {
+        cpu : 1
+        memory : '4000 MB'
+        time : 1
+        disks : 'local-disk 50 HDD'
+    }
 }

--- a/dev/test/test_task/test_bam2ta.wdl
+++ b/dev/test/test_task/test_bam2ta.wdl
@@ -1,88 +1,89 @@
-# ENCODE DCC ChIP-Seq pipeline tester for task bam2ta
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../chip.wdl' as chip
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_bam2ta {
-	Int bam2ta_subsample
+    input {
+        Int bam2ta_subsample
 
-	String pe_nodup_bam
-	String se_nodup_bam
+        String pe_nodup_bam
+        String se_nodup_bam
 
-	String ref_pe_ta
-	String ref_pe_ta_subsample
-	String ref_se_ta
-	String ref_se_ta_subsample
-	String mito_chr_name = 'chrM'
+        String ref_pe_ta
+        String ref_pe_ta_subsample
+        String ref_se_ta
+        String ref_se_ta_subsample
+    }
+    String mito_chr_name = 'chrM'
 
-	Int bam2ta_cpu = 1
-	Int bam2ta_mem_mb = 10000
-	Int bam2ta_time_hr = 6
-	String bam2ta_disks = 'local-disk 100 HDD'
+    Int bam2ta_cpu = 1
+    Int bam2ta_mem_mb = 10000
+    Int bam2ta_time_hr = 6
+    String bam2ta_disks = 'local-disk 100 HDD'
 
-	call chip.bam2ta as pe_bam2ta { input :
-		bam = pe_nodup_bam,
-		subsample = 0,
-		paired_end = true,
-		mito_chr_name = mito_chr_name,
+    call chip.bam2ta as pe_bam2ta { input :
+        bam = pe_nodup_bam,
+        subsample = 0,
+        paired_end = true,
+        mito_chr_name = mito_chr_name,
 
-		cpu = bam2ta_cpu,
-		mem_mb = bam2ta_mem_mb,
-		time_hr = bam2ta_time_hr,
-		disks = bam2ta_disks,
-	}
-	call chip.bam2ta as pe_bam2ta_subsample { input :
-		bam = pe_nodup_bam,
-		subsample = bam2ta_subsample,
-		paired_end = true,
-		mito_chr_name = mito_chr_name,
+        cpu = bam2ta_cpu,
+        mem_mb = bam2ta_mem_mb,
+        time_hr = bam2ta_time_hr,
+        disks = bam2ta_disks,
+    }
+    call chip.bam2ta as pe_bam2ta_subsample { input :
+        bam = pe_nodup_bam,
+        subsample = bam2ta_subsample,
+        paired_end = true,
+        mito_chr_name = mito_chr_name,
 
-		cpu = bam2ta_cpu,
-		mem_mb = bam2ta_mem_mb,
-		time_hr = bam2ta_time_hr,
-		disks = bam2ta_disks,
-	}
-	call chip.bam2ta as se_bam2ta { input :
-		bam = se_nodup_bam,
-		subsample = 0,
-		paired_end = false,
-		mito_chr_name = mito_chr_name,
+        cpu = bam2ta_cpu,
+        mem_mb = bam2ta_mem_mb,
+        time_hr = bam2ta_time_hr,
+        disks = bam2ta_disks,
+    }
+    call chip.bam2ta as se_bam2ta { input :
+        bam = se_nodup_bam,
+        subsample = 0,
+        paired_end = false,
+        mito_chr_name = mito_chr_name,
 
-		cpu = bam2ta_cpu,
-		mem_mb = bam2ta_mem_mb,
-		time_hr = bam2ta_time_hr,
-		disks = bam2ta_disks,
-	}
-	call chip.bam2ta as se_bam2ta_subsample { input :
-		bam = se_nodup_bam,
-		subsample = bam2ta_subsample,
-		paired_end = false,
-		mito_chr_name = mito_chr_name,
+        cpu = bam2ta_cpu,
+        mem_mb = bam2ta_mem_mb,
+        time_hr = bam2ta_time_hr,
+        disks = bam2ta_disks,
+    }
+    call chip.bam2ta as se_bam2ta_subsample { input :
+        bam = se_nodup_bam,
+        subsample = bam2ta_subsample,
+        paired_end = false,
+        mito_chr_name = mito_chr_name,
 
-		cpu = bam2ta_cpu,
-		mem_mb = bam2ta_mem_mb,
-		time_hr = bam2ta_time_hr,
-		disks = bam2ta_disks,
-	}
+        cpu = bam2ta_cpu,
+        mem_mb = bam2ta_mem_mb,
+        time_hr = bam2ta_time_hr,
+        disks = bam2ta_disks,
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'pe_bam2ta',
-			'pe_bam2ta_subsample',
-			'se_bam2ta',
-			'se_bam2ta_subsample',
-		],
-		files = [
-			pe_bam2ta.ta,
-			pe_bam2ta_subsample.ta,
-			se_bam2ta.ta,
-			se_bam2ta_subsample.ta,
-		],
-		ref_files = [
-			ref_pe_ta,
-			ref_pe_ta_subsample,
-			ref_se_ta,
-			ref_se_ta_subsample,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'pe_bam2ta',
+            'pe_bam2ta_subsample',
+            'se_bam2ta',
+            'se_bam2ta_subsample',
+        ],
+        files = [
+            pe_bam2ta.ta,
+            pe_bam2ta_subsample.ta,
+            se_bam2ta.ta,
+            se_bam2ta_subsample.ta,
+        ],
+        ref_files = [
+            ref_pe_ta,
+            ref_pe_ta_subsample,
+            ref_se_ta,
+            ref_se_ta_subsample,
+        ],
+    }
 }

--- a/dev/test/test_task/test_bowtie2.wdl
+++ b/dev/test/test_task/test_bowtie2.wdl
@@ -1,118 +1,118 @@
-# ENCODE DCC ChIP-Seq pipeline tester for task bwa
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../chip.wdl' as chip
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_bowtie2 {
-	Array[File] pe_fastqs_R1
-	Array[File] pe_fastqs_R2
-	Array[File] se_fastqs
+    input {
+        Array[File] pe_fastqs_R1
+        Array[File] pe_fastqs_R2
+        Array[File] se_fastqs
 
-	Int pe_crop_length
-	Int se_crop_length
-	Int pe_crop_length_tol = 2
-	Int se_crop_length_tol = 2
+        Int pe_crop_length
+        Int se_crop_length
+        Int pe_crop_length_tol = 2
+        Int se_crop_length_tol = 2
+        # we don't compare BAM because BAM's header includes date
+        # hence md5sums don't match all the time
+        String ref_pe_flagstat
+        String ref_se_flagstat
 
-	# we don't compare BAM because BAM's header includes date
-	# hence md5sums don't match all the time
-	String ref_pe_flagstat
-	String ref_se_flagstat
+        String ref_pe_cropped_flagstat
+        String ref_se_cropped_flagstat
 
-	String ref_pe_cropped_flagstat
-	String ref_se_cropped_flagstat
+        String pe_bowtie2_idx_tar
+        String se_bowtie2_idx_tar
+    }
 
-	String pe_bowtie2_idx_tar
-	String se_bowtie2_idx_tar
+    Int bowtie2_cpu = 1
+    Int bowtie2_mem_mb = 20000
+    Int bowtie2_time_hr = 48
+    String bowtie2_disks = 'local-disk 100 HDD'
 
-	Int bowtie2_cpu = 1
-	Int bowtie2_mem_mb = 20000
-	Int bowtie2_time_hr = 48
-	String bowtie2_disks = 'local-disk 100 HDD'
+    call chip.align as pe_bowtie2 { input :
+        aligner = 'bowtie2',
+        idx_tar = pe_bowtie2_idx_tar,
+        mito_chr_name = 'chrM',
+        fastqs_R1 = pe_fastqs_R1,
+        fastqs_R2 = pe_fastqs_R2,
+        paired_end = true,
+        use_bwa_mem_for_pe = false,
+        crop_length = 0,
+        crop_length_tol = 0,
 
-	call chip.align as pe_bowtie2 { input :
-		aligner = 'bowtie2',
-		idx_tar = pe_bowtie2_idx_tar,
-		mito_chr_name = 'chrM',
-		fastqs_R1 = pe_fastqs_R1,
-		fastqs_R2 = pe_fastqs_R2,
-		paired_end = true,
-		use_bwa_mem_for_pe = false,
-		crop_length = 0,
-		crop_length_tol = 0,
+        cpu = bowtie2_cpu,
+        mem_mb = bowtie2_mem_mb,
+        time_hr = bowtie2_time_hr,
+        disks = bowtie2_disks,
+    }
+    call chip.align as se_bowtie2 { input :
+        aligner = 'bowtie2',
+        idx_tar = se_bowtie2_idx_tar,
+        mito_chr_name = 'chrM',
+        fastqs_R1 = se_fastqs,
+        fastqs_R2 = [],
+        paired_end = false,
+        use_bwa_mem_for_pe = false,
+        crop_length = 0,
+        crop_length_tol = 0,
 
-		cpu = bowtie2_cpu,
-		mem_mb = bowtie2_mem_mb,
-		time_hr = bowtie2_time_hr,
-		disks = bowtie2_disks,
-	}
-	call chip.align as se_bowtie2 { input :
-		aligner = 'bowtie2',
-		idx_tar = se_bowtie2_idx_tar,
-		mito_chr_name = 'chrM',
-		fastqs_R1 = se_fastqs,
-		fastqs_R2 = [],
-		paired_end = false,
-		use_bwa_mem_for_pe = false,
-		crop_length = 0,
-		crop_length_tol = 0,
+        cpu = bowtie2_cpu,
+        mem_mb = bowtie2_mem_mb,
+        time_hr = bowtie2_time_hr,
+        disks = bowtie2_disks,
+    }
 
-		cpu = bowtie2_cpu,
-		mem_mb = bowtie2_mem_mb,
-		time_hr = bowtie2_time_hr,
-		disks = bowtie2_disks,
-	}
+    call chip.align as pe_cropped_bowtie2 { input :
+        aligner = 'bowtie2',
+        idx_tar = pe_bowtie2_idx_tar,
+        mito_chr_name = 'chrM',
+        fastqs_R1 = pe_fastqs_R1,
+        fastqs_R2 = pe_fastqs_R2,
+        paired_end = true,
+        use_bwa_mem_for_pe = false,
+        crop_length = pe_crop_length,
+        crop_length_tol = pe_crop_length_tol,
 
-	call chip.align as pe_cropped_bowtie2 { input :
-		aligner = 'bowtie2',
-		idx_tar = pe_bowtie2_idx_tar,
-		mito_chr_name = 'chrM',
-		fastqs_R1 = pe_fastqs_R1,
-		fastqs_R2 = pe_fastqs_R2,
-		paired_end = true,
-		use_bwa_mem_for_pe = false,
-		crop_length = pe_crop_length,
-		crop_length_tol = pe_crop_length_tol,
+        cpu = bowtie2_cpu,
+        mem_mb = bowtie2_mem_mb,
+        time_hr = bowtie2_time_hr,
+        disks = bowtie2_disks,
+    }
+    call chip.align as se_cropped_bowtie2 { input :
+        aligner = 'bowtie2',
+        idx_tar = se_bowtie2_idx_tar,
+        mito_chr_name = 'chrM',
+        fastqs_R1 = se_fastqs,
+        fastqs_R2 = [],
+        paired_end = false,
+        use_bwa_mem_for_pe = false,
+        crop_length = se_crop_length,
+        crop_length_tol = se_crop_length_tol,
 
-		cpu = bowtie2_cpu,
-		mem_mb = bowtie2_mem_mb,
-		time_hr = bowtie2_time_hr,
-		disks = bowtie2_disks,
-	}
-	call chip.align as se_cropped_bowtie2 { input :
-		aligner = 'bowtie2',
-		idx_tar = se_bowtie2_idx_tar,
-		mito_chr_name = 'chrM',
-		fastqs_R1 = se_fastqs,
-		fastqs_R2 = [],
-		paired_end = false,
-		use_bwa_mem_for_pe = false,
-		crop_length = se_crop_length,
-		crop_length_tol = se_crop_length_tol,
+        cpu = bowtie2_cpu,
+        mem_mb = bowtie2_mem_mb,
+        time_hr = bowtie2_time_hr,
+        disks = bowtie2_disks,
+    }
 
-		cpu = bowtie2_cpu,
-		mem_mb = bowtie2_mem_mb,
-		time_hr = bowtie2_time_hr,
-		disks = bowtie2_disks,
-	}
-
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'pe_bowtie2',
-			'se_bowtie2',
-			'pe_cropped_bowtie2',
-			'se_cropped_bowtie2',
-		],
-		files = [
-			pe_bowtie2.samstat_qc,
-			se_bowtie2.samstat_qc,
-			pe_cropped_bowtie2.samstat_qc,
-			se_cropped_bowtie2.samstat_qc,
-		],
-		ref_files = [
-			ref_pe_flagstat,
-			ref_se_flagstat,
-			ref_pe_cropped_flagstat,
-			ref_se_cropped_flagstat,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'pe_bowtie2',
+            'se_bowtie2',
+            'pe_cropped_bowtie2',
+            'se_cropped_bowtie2',
+        ],
+        files = [
+            pe_bowtie2.samstat_qc,
+            se_bowtie2.samstat_qc,
+            pe_cropped_bowtie2.samstat_qc,
+            se_cropped_bowtie2.samstat_qc,
+        ],
+        ref_files = [
+            ref_pe_flagstat,
+            ref_se_flagstat,
+            ref_pe_cropped_flagstat,
+            ref_se_cropped_flagstat,
+        ],
+    }
 }

--- a/dev/test/test_task/test_bwa.wdl
+++ b/dev/test/test_task/test_bwa.wdl
@@ -1,71 +1,72 @@
-# ENCODE DCC ChIP-Seq pipeline tester for task bwa
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../chip.wdl' as chip
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_bwa {
-	Array[File] pe_fastqs_R1
-	Array[File] pe_fastqs_R2
-	Array[File] se_fastqs
+    input {
+        Array[File] pe_fastqs_R1
+        Array[File] pe_fastqs_R2
+        Array[File] se_fastqs
 
-	# we don't compare BAM because BAM's header includes date
-	# hence md5sums don't match all the time
-	String ref_pe_flagstat
-	String ref_se_flagstat
+        # we don't compare BAM because BAM's header includes date
+        # hence md5sums don't match all the time
+        String ref_pe_flagstat
+        String ref_se_flagstat
 
-	String pe_bwa_idx_tar
-	String se_bwa_idx_tar
+        String pe_bwa_idx_tar
+        String se_bwa_idx_tar
+    }
 
-	Int bwa_cpu = 1
-	Int bwa_mem_mb = 20000
-	Int bwa_time_hr = 48
-	String bwa_disks = 'local-disk 100 HDD'
+    Int bwa_cpu = 1
+    Int bwa_mem_mb = 20000
+    Int bwa_time_hr = 48
+    String bwa_disks = 'local-disk 100 HDD'
 
-	call chip.align as pe_bwa { input :
-		aligner = 'bwa',
-		idx_tar = pe_bwa_idx_tar,
-		mito_chr_name = 'chrM',
-		fastqs_R1 = pe_fastqs_R1,
-		fastqs_R2 = pe_fastqs_R2,
-		paired_end = true,
-		use_bwa_mem_for_pe = false,
-		crop_length = 0,
-		crop_length_tol = 0,
+    call chip.align as pe_bwa { input :
+        aligner = 'bwa',
+        idx_tar = pe_bwa_idx_tar,
+        mito_chr_name = 'chrM',
+        fastqs_R1 = pe_fastqs_R1,
+        fastqs_R2 = pe_fastqs_R2,
+        paired_end = true,
+        use_bwa_mem_for_pe = false,
+        crop_length = 0,
+        crop_length_tol = 0,
 
-		cpu = bwa_cpu,
-		mem_mb = bwa_mem_mb,
-		time_hr = bwa_time_hr,
-		disks = bwa_disks,
-	}
-	call chip.align as se_bwa { input :
-		aligner = 'bwa',
-		idx_tar = se_bwa_idx_tar,
-		mito_chr_name = 'chrM',
-		fastqs_R1 = se_fastqs,
-		fastqs_R2 = [],
-		paired_end = false,
-		use_bwa_mem_for_pe = false,
-		crop_length = 0,
-		crop_length_tol = 0,
+        cpu = bwa_cpu,
+        mem_mb = bwa_mem_mb,
+        time_hr = bwa_time_hr,
+        disks = bwa_disks,
+    }
+    call chip.align as se_bwa { input :
+        aligner = 'bwa',
+        idx_tar = se_bwa_idx_tar,
+        mito_chr_name = 'chrM',
+        fastqs_R1 = se_fastqs,
+        fastqs_R2 = [],
+        paired_end = false,
+        use_bwa_mem_for_pe = false,
+        crop_length = 0,
+        crop_length_tol = 0,
 
-		cpu = bwa_cpu,
-		mem_mb = bwa_mem_mb,
-		time_hr = bwa_time_hr,
-		disks = bwa_disks,
-	}
+        cpu = bwa_cpu,
+        mem_mb = bwa_mem_mb,
+        time_hr = bwa_time_hr,
+        disks = bwa_disks,
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'pe_bwa',
-			'se_bwa',
-		],
-		files = [
-			pe_bwa.samstat_qc,
-			se_bwa.samstat_qc,
-		],
-		ref_files = [
-			ref_pe_flagstat,
-			ref_se_flagstat,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'pe_bwa',
+            'se_bwa',
+        ],
+        files = [
+            pe_bwa.samstat_qc,
+            se_bwa.samstat_qc,
+        ],
+        ref_files = [
+            ref_pe_flagstat,
+            ref_se_flagstat,
+        ],
+    }
 }

--- a/dev/test/test_task/test_choose_ctl.wdl
+++ b/dev/test/test_task/test_choose_ctl.wdl
@@ -133,47 +133,47 @@ workflow test_choose_ctl {
         exp_ctl_depth_ratio_limit = exp_ctl_depth_ratio_limit,
     }
 
-    Map[String, Pair[Int, Int]] tests = {
-        'se_choose_ctl_idx1': (se_choose_ctl.chosen_ctl_ta_ids[0], ref_se_choose_ctl_idx1),
-        'se_choose_ctl_idx2': (se_choose_ctl.chosen_ctl_ta_ids[1], ref_se_choose_ctl_idx2),
-        'se_choose_ctl_sub1': (se_choose_ctl.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_sub1),
-        'se_choose_ctl_sub2': (se_choose_ctl.chosen_ctl_ta_subsample[1], ref_se_choose_ctl_sub2),
-        'se_choose_ctl_sub_pooled': (se_choose_ctl.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_sub_pooled),
+    Array[Pair[String, Pair[Int, Int]]] tests = [
+        ('se_choose_ctl_idx1', (se_choose_ctl.chosen_ctl_ta_ids[0], ref_se_choose_ctl_idx1)),
+        ('se_choose_ctl_idx2', (se_choose_ctl.chosen_ctl_ta_ids[1], ref_se_choose_ctl_idx2)),
+        ('se_choose_ctl_sub1', (se_choose_ctl.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_sub1)),
+        ('se_choose_ctl_sub2', (se_choose_ctl.chosen_ctl_ta_subsample[1], ref_se_choose_ctl_sub2)),
+        ('se_choose_ctl_sub_pooled', (se_choose_ctl.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_sub_pooled)),
 
-        'se_choose_ctl_always_use_pooled_ctl_idx1': (se_choose_ctl_always_use_pooled_ctl.chosen_ctl_ta_ids[0], ref_se_choose_ctl_always_use_pooled_ctl_idx1),
-        'se_choose_ctl_always_use_pooled_ctl_idx2': (se_choose_ctl_always_use_pooled_ctl.chosen_ctl_ta_ids[1], ref_se_choose_ctl_always_use_pooled_ctl_idx2),
-        'se_choose_ctl_always_use_pooled_ctl_sub1': (se_choose_ctl_always_use_pooled_ctl.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_always_use_pooled_ctl_sub1),
-        'se_choose_ctl_always_use_pooled_ctl_sub2': (se_choose_ctl_always_use_pooled_ctl.chosen_ctl_ta_subsample[1], ref_se_choose_ctl_always_use_pooled_ctl_sub2),
-        'se_choose_ctl_always_use_pooled_ctl_sub_pooled': (se_choose_ctl_always_use_pooled_ctl.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_always_use_pooled_ctl_sub_pooled),
+        ('se_choose_ctl_always_use_pooled_ctl_idx1', (se_choose_ctl_always_use_pooled_ctl.chosen_ctl_ta_ids[0], ref_se_choose_ctl_always_use_pooled_ctl_idx1)),
+        ('se_choose_ctl_always_use_pooled_ctl_idx2', (se_choose_ctl_always_use_pooled_ctl.chosen_ctl_ta_ids[1], ref_se_choose_ctl_always_use_pooled_ctl_idx2)),
+        ('se_choose_ctl_always_use_pooled_ctl_sub1', (se_choose_ctl_always_use_pooled_ctl.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_always_use_pooled_ctl_sub1)),
+        ('se_choose_ctl_always_use_pooled_ctl_sub2', (se_choose_ctl_always_use_pooled_ctl.chosen_ctl_ta_subsample[1], ref_se_choose_ctl_always_use_pooled_ctl_sub2)),
+        ('se_choose_ctl_always_use_pooled_ctl_sub_pooled', (se_choose_ctl_always_use_pooled_ctl.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_always_use_pooled_ctl_sub_pooled)),
 
-        'se_choose_ctl_single_rep_idx1': (se_choose_ctl_single_rep.chosen_ctl_ta_ids[0], ref_se_choose_ctl_single_rep_idx1),
-        'se_choose_ctl_single_rep_sub1': (se_choose_ctl_single_rep.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_single_rep_sub1),
-        'se_choose_ctl_single_rep_sub_pooled': (se_choose_ctl_single_rep.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_single_rep_sub_pooled),
+        ('se_choose_ctl_single_rep_idx1', (se_choose_ctl_single_rep.chosen_ctl_ta_ids[0], ref_se_choose_ctl_single_rep_idx1)),
+        ('se_choose_ctl_single_rep_sub1', (se_choose_ctl_single_rep.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_single_rep_sub1)),
+        ('se_choose_ctl_single_rep_sub_pooled', (se_choose_ctl_single_rep.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_single_rep_sub_pooled)),
 
-        'se_choose_ctl_single_ctl_idx1': (se_choose_ctl_single_ctl.chosen_ctl_ta_ids[0], ref_se_choose_ctl_single_ctl_idx1),
-        'se_choose_ctl_single_ctl_idx2': (se_choose_ctl_single_ctl.chosen_ctl_ta_ids[1], ref_se_choose_ctl_single_ctl_idx2),
-        'se_choose_ctl_single_ctl_sub1': (se_choose_ctl_single_ctl.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_single_ctl_sub1),
-        'se_choose_ctl_single_ctl_sub2': (se_choose_ctl_single_ctl.chosen_ctl_ta_subsample[1], ref_se_choose_ctl_single_ctl_sub2),
-        'se_choose_ctl_single_ctl_sub_pooled': (se_choose_ctl_single_ctl.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_single_ctl_sub_pooled),
+        ('se_choose_ctl_single_ctl_idx1', (se_choose_ctl_single_ctl.chosen_ctl_ta_ids[0], ref_se_choose_ctl_single_ctl_idx1)),
+        ('se_choose_ctl_single_ctl_idx2', (se_choose_ctl_single_ctl.chosen_ctl_ta_ids[1], ref_se_choose_ctl_single_ctl_idx2)),
+        ('se_choose_ctl_single_ctl_sub1', (se_choose_ctl_single_ctl.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_single_ctl_sub1)),
+        ('se_choose_ctl_single_ctl_sub2', (se_choose_ctl_single_ctl.chosen_ctl_ta_subsample[1], ref_se_choose_ctl_single_ctl_sub2)),
+        ('se_choose_ctl_single_ctl_sub_pooled', (se_choose_ctl_single_ctl.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_single_ctl_sub_pooled)),
 
-        'se_choose_ctl_disabled_idx1': (se_choose_ctl_disabled.chosen_ctl_ta_ids[0], ref_se_choose_ctl_disabled_idx1),
-        'se_choose_ctl_disabled_idx2': (se_choose_ctl_disabled.chosen_ctl_ta_ids[1], ref_se_choose_ctl_disabled_idx2),
-        'se_choose_ctl_disabled_sub1': (se_choose_ctl_disabled.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_disabled_sub1),
-        'se_choose_ctl_disabled_sub2': (se_choose_ctl_disabled.chosen_ctl_ta_subsample[1], ref_se_choose_ctl_disabled_sub2),
-        'se_choose_ctl_disabled_sub_pooled': (se_choose_ctl_disabled.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_disabled_sub_pooled),
+        ('se_choose_ctl_disabled_idx1', (se_choose_ctl_disabled.chosen_ctl_ta_ids[0], ref_se_choose_ctl_disabled_idx1)),
+        ('se_choose_ctl_disabled_idx2', (se_choose_ctl_disabled.chosen_ctl_ta_ids[1], ref_se_choose_ctl_disabled_idx2)),
+        ('se_choose_ctl_disabled_sub1', (se_choose_ctl_disabled.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_disabled_sub1)),
+        ('se_choose_ctl_disabled_sub2', (se_choose_ctl_disabled.chosen_ctl_ta_subsample[1], ref_se_choose_ctl_disabled_sub2)),
+        ('se_choose_ctl_disabled_sub_pooled', (se_choose_ctl_disabled.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_disabled_sub_pooled)),
 
-        'se_choose_ctl_ctl_depth_limit_only_idx1': (se_choose_ctl_ctl_depth_limit_only.chosen_ctl_ta_ids[0], ref_se_choose_ctl_ctl_depth_limit_only_idx1),
-        'se_choose_ctl_ctl_depth_limit_only_idx2': (se_choose_ctl_ctl_depth_limit_only.chosen_ctl_ta_ids[1], ref_se_choose_ctl_ctl_depth_limit_only_idx2),
-        'se_choose_ctl_ctl_depth_limit_only_sub1': (se_choose_ctl_ctl_depth_limit_only.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_ctl_depth_limit_only_sub1),
-        'se_choose_ctl_ctl_depth_limit_only_sub2': (se_choose_ctl_ctl_depth_limit_only.chosen_ctl_ta_subsample[1], ref_se_choose_ctl_ctl_depth_limit_only_sub2),
-        'se_choose_ctl_ctl_depth_limit_only_sub_pooled': (se_choose_ctl_ctl_depth_limit_only.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_ctl_depth_limit_only_sub_pooled),
+        ('se_choose_ctl_ctl_depth_limit_only_idx1', (se_choose_ctl_ctl_depth_limit_only.chosen_ctl_ta_ids[0], ref_se_choose_ctl_ctl_depth_limit_only_idx1)),
+        ('se_choose_ctl_ctl_depth_limit_only_idx2', (se_choose_ctl_ctl_depth_limit_only.chosen_ctl_ta_ids[1], ref_se_choose_ctl_ctl_depth_limit_only_idx2)),
+        ('se_choose_ctl_ctl_depth_limit_only_sub1', (se_choose_ctl_ctl_depth_limit_only.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_ctl_depth_limit_only_sub1)),
+        ('se_choose_ctl_ctl_depth_limit_only_sub2', (se_choose_ctl_ctl_depth_limit_only.chosen_ctl_ta_subsample[1], ref_se_choose_ctl_ctl_depth_limit_only_sub2)),
+        ('se_choose_ctl_ctl_depth_limit_only_sub_pooled', (se_choose_ctl_ctl_depth_limit_only.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_ctl_depth_limit_only_sub_pooled)),
 
-        'se_choose_ctl_exp_ctl_depth_ratio_limit_only_idx1': (se_choose_ctl_exp_ctl_depth_ratio_limit_only.chosen_ctl_ta_ids[0], ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_idx1),
-        'se_choose_ctl_exp_ctl_depth_ratio_limit_only_idx2': (se_choose_ctl_exp_ctl_depth_ratio_limit_only.chosen_ctl_ta_ids[1], ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_idx2),
-        'se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub1': (se_choose_ctl_exp_ctl_depth_ratio_limit_only.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub1),
-        'se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub2': (se_choose_ctl_exp_ctl_depth_ratio_limit_only.chosen_ctl_ta_subsample[1], ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub2),
-        'se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub_pooled': (se_choose_ctl_exp_ctl_depth_ratio_limit_only.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub_pooled),
-    }
+        ('se_choose_ctl_exp_ctl_depth_ratio_limit_only_idx1', (se_choose_ctl_exp_ctl_depth_ratio_limit_only.chosen_ctl_ta_ids[0], ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_idx1)),
+        ('se_choose_ctl_exp_ctl_depth_ratio_limit_only_idx2', (se_choose_ctl_exp_ctl_depth_ratio_limit_only.chosen_ctl_ta_ids[1], ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_idx2)),
+        ('se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub1', (se_choose_ctl_exp_ctl_depth_ratio_limit_only.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub1)),
+        ('se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub2', (se_choose_ctl_exp_ctl_depth_ratio_limit_only.chosen_ctl_ta_subsample[1], ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub2)),
+        ('se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub_pooled', (se_choose_ctl_exp_ctl_depth_ratio_limit_only.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub_pooled)),
+    ]
     scatter( test in tests ) {
         String k = test.left
         Pair[Int, Int] v = test.right

--- a/dev/test/test_task/test_choose_ctl.wdl
+++ b/dev/test/test_task/test_choose_ctl.wdl
@@ -1,190 +1,187 @@
-# ENCODE DCC ChIP-Seq pipeline tester
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../chip.wdl' as chip
 import 'compare_md5sum.wdl' as compare_md5sum
 
-workflow test_choose_ctl {	
-	# See ./test_choose_ctl.aux.xlsx for details
-	String se_ta_rep1
-	String se_ta_rep2
-	String se_ta_pooled
-	String se_ctl_ta_rep1
-	String se_ctl_ta_rep2
-	String se_ctl_ta_pooled
+workflow test_choose_ctl {    
+    input {
+        # See ./test_choose_ctl.aux.xlsx for details
+        String se_ta_rep1
+        String se_ta_rep2
+        String se_ta_pooled
+        String se_ctl_ta_rep1
+        String se_ctl_ta_rep2
+        String se_ctl_ta_pooled
 
-	Int ref_se_choose_ctl_idx1
-	Int ref_se_choose_ctl_idx2
-	Int ref_se_choose_ctl_sub1
-	Int ref_se_choose_ctl_sub2
-	Int ref_se_choose_ctl_sub_pooled
+        Int ref_se_choose_ctl_idx1
+        Int ref_se_choose_ctl_idx2
+        Int ref_se_choose_ctl_sub1
+        Int ref_se_choose_ctl_sub2
+        Int ref_se_choose_ctl_sub_pooled
 
-	Int ref_se_choose_ctl_always_use_pooled_ctl_idx1
-	Int ref_se_choose_ctl_always_use_pooled_ctl_idx2
-	Int ref_se_choose_ctl_always_use_pooled_ctl_sub1
-	Int ref_se_choose_ctl_always_use_pooled_ctl_sub2
-	Int ref_se_choose_ctl_always_use_pooled_ctl_sub_pooled
+        Int ref_se_choose_ctl_always_use_pooled_ctl_idx1
+        Int ref_se_choose_ctl_always_use_pooled_ctl_idx2
+        Int ref_se_choose_ctl_always_use_pooled_ctl_sub1
+        Int ref_se_choose_ctl_always_use_pooled_ctl_sub2
+        Int ref_se_choose_ctl_always_use_pooled_ctl_sub_pooled
 
-	Int ref_se_choose_ctl_single_rep_idx1
-	Int ref_se_choose_ctl_single_rep_sub1
-	Int ref_se_choose_ctl_single_rep_sub_pooled
+        Int ref_se_choose_ctl_single_rep_idx1
+        Int ref_se_choose_ctl_single_rep_sub1
+        Int ref_se_choose_ctl_single_rep_sub_pooled
 
-	Int ref_se_choose_ctl_single_ctl_idx1
-	Int ref_se_choose_ctl_single_ctl_idx2
-	Int ref_se_choose_ctl_single_ctl_sub1
-	Int ref_se_choose_ctl_single_ctl_sub2
-	Int ref_se_choose_ctl_single_ctl_sub_pooled
+        Int ref_se_choose_ctl_single_ctl_idx1
+        Int ref_se_choose_ctl_single_ctl_idx2
+        Int ref_se_choose_ctl_single_ctl_sub1
+        Int ref_se_choose_ctl_single_ctl_sub2
+        Int ref_se_choose_ctl_single_ctl_sub_pooled
 
-	Int ref_se_choose_ctl_disabled_idx1
-	Int ref_se_choose_ctl_disabled_idx2
-	Int ref_se_choose_ctl_disabled_sub1
-	Int ref_se_choose_ctl_disabled_sub2
-	Int ref_se_choose_ctl_disabled_sub_pooled
+        Int ref_se_choose_ctl_disabled_idx1
+        Int ref_se_choose_ctl_disabled_idx2
+        Int ref_se_choose_ctl_disabled_sub1
+        Int ref_se_choose_ctl_disabled_sub2
+        Int ref_se_choose_ctl_disabled_sub_pooled
 
-	Int ref_se_choose_ctl_ctl_depth_limit_only_idx1
-	Int ref_se_choose_ctl_ctl_depth_limit_only_idx2
-	Int ref_se_choose_ctl_ctl_depth_limit_only_sub1
-	Int ref_se_choose_ctl_ctl_depth_limit_only_sub2
-	Int ref_se_choose_ctl_ctl_depth_limit_only_sub_pooled
+        Int ref_se_choose_ctl_ctl_depth_limit_only_idx1
+        Int ref_se_choose_ctl_ctl_depth_limit_only_idx2
+        Int ref_se_choose_ctl_ctl_depth_limit_only_sub1
+        Int ref_se_choose_ctl_ctl_depth_limit_only_sub2
+        Int ref_se_choose_ctl_ctl_depth_limit_only_sub_pooled
 
-	Int ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_idx1
-	Int ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_idx2
-	Int ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub1
-	Int ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub2
-	Int ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub_pooled
+        Int ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_idx1
+        Int ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_idx2
+        Int ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub1
+        Int ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub2
+        Int ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub_pooled
 
-	String? null
+        Float ctl_depth_ratio
+        Int ctl_depth_limit
+        Float exp_ctl_depth_ratio_limit
+    }
 
-	Float ctl_depth_ratio
-	Int ctl_depth_limit
-	Float exp_ctl_depth_ratio_limit
+    call chip.choose_ctl as se_choose_ctl { input :
+        tas = [se_ta_rep1, se_ta_rep2],
+        ctl_tas = [se_ctl_ta_rep1, se_ctl_ta_rep2],
+        ta_pooled = se_ta_pooled,
+        always_use_pooled_ctl = false,
+        ctl_ta_pooled = se_ctl_ta_pooled,
+        ctl_depth_ratio = ctl_depth_ratio,
+        ctl_depth_limit = ctl_depth_limit,
+        exp_ctl_depth_ratio_limit = exp_ctl_depth_ratio_limit,
+    }
 
-	call chip.choose_ctl as se_choose_ctl { input :
-		tas = [se_ta_rep1, se_ta_rep2],
-		ctl_tas = [se_ctl_ta_rep1, se_ctl_ta_rep2],
-		ta_pooled = se_ta_pooled,
-		always_use_pooled_ctl = false,
-		ctl_ta_pooled = se_ctl_ta_pooled,
-		ctl_depth_ratio = ctl_depth_ratio,
-		ctl_depth_limit = ctl_depth_limit,
-		exp_ctl_depth_ratio_limit = exp_ctl_depth_ratio_limit,
-	}
+    call chip.choose_ctl as se_choose_ctl_always_use_pooled_ctl { input :
+        tas = [se_ta_rep1, se_ta_rep2],
+        ctl_tas = [se_ctl_ta_rep1, se_ctl_ta_rep2],
+        ta_pooled = se_ta_pooled,
+        always_use_pooled_ctl = true,
+        ctl_ta_pooled = se_ctl_ta_pooled,
+        ctl_depth_ratio = ctl_depth_ratio,
+        ctl_depth_limit = ctl_depth_limit,
+        exp_ctl_depth_ratio_limit = exp_ctl_depth_ratio_limit,
+    }
 
-	call chip.choose_ctl as se_choose_ctl_always_use_pooled_ctl { input :
-		tas = [se_ta_rep1, se_ta_rep2],
-		ctl_tas = [se_ctl_ta_rep1, se_ctl_ta_rep2],
-		ta_pooled = se_ta_pooled,
-		always_use_pooled_ctl = true,
-		ctl_ta_pooled = se_ctl_ta_pooled,
-		ctl_depth_ratio = ctl_depth_ratio,
-		ctl_depth_limit = ctl_depth_limit,
-		exp_ctl_depth_ratio_limit = exp_ctl_depth_ratio_limit,
-	}
+    # INTENTIONALLY swapped ctl_tas 
+    call chip.choose_ctl as se_choose_ctl_single_rep { input :
+        tas = [se_ta_rep1],
+        ctl_tas = [se_ctl_ta_rep2, se_ctl_ta_rep1],
+        always_use_pooled_ctl = false,
+        ctl_ta_pooled = se_ctl_ta_pooled,
+        ctl_depth_ratio = ctl_depth_ratio,
+        ctl_depth_limit = ctl_depth_limit,
+        exp_ctl_depth_ratio_limit = exp_ctl_depth_ratio_limit,
+    }
 
-	# INTENTIONALLY swapped ctl_tas 
-	call chip.choose_ctl as se_choose_ctl_single_rep { input :
-		tas = [se_ta_rep1],
-		ctl_tas = [se_ctl_ta_rep2, se_ctl_ta_rep1],
-		ta_pooled = null,
-		always_use_pooled_ctl = false,
-		ctl_ta_pooled = se_ctl_ta_pooled,
-		ctl_depth_ratio = ctl_depth_ratio,
-		ctl_depth_limit = ctl_depth_limit,
-		exp_ctl_depth_ratio_limit = exp_ctl_depth_ratio_limit,
-	}
+    call chip.choose_ctl as se_choose_ctl_single_ctl { input :
+        tas = [se_ta_rep1, se_ta_rep2],
+        ctl_tas = [se_ctl_ta_rep1],
+        ta_pooled = se_ctl_ta_rep1,
+        always_use_pooled_ctl = false,
+        ctl_depth_ratio = ctl_depth_ratio,
+        ctl_depth_limit = ctl_depth_limit,
+        exp_ctl_depth_ratio_limit = exp_ctl_depth_ratio_limit,
+    }
 
-	call chip.choose_ctl as se_choose_ctl_single_ctl { input :
-		tas = [se_ta_rep1, se_ta_rep2],
-		ctl_tas = [se_ctl_ta_rep1],
-		ta_pooled = se_ctl_ta_rep1,
-		always_use_pooled_ctl = false,
-		ctl_ta_pooled = null,
-		ctl_depth_ratio = ctl_depth_ratio,
-		ctl_depth_limit = ctl_depth_limit,
-		exp_ctl_depth_ratio_limit = exp_ctl_depth_ratio_limit,
-	}
+    call chip.choose_ctl as se_choose_ctl_disabled { input :
+        tas = [se_ta_rep1, se_ta_rep2],
+        ctl_tas = [se_ctl_ta_rep1, se_ctl_ta_rep2],
+        ta_pooled = se_ta_pooled,
+        always_use_pooled_ctl = false,
+        ctl_ta_pooled = se_ctl_ta_pooled,
+        ctl_depth_ratio = ctl_depth_ratio,
+        ctl_depth_limit = 0,
+        exp_ctl_depth_ratio_limit = 0.0,
+    }
 
-	call chip.choose_ctl as se_choose_ctl_disabled { input :
-		tas = [se_ta_rep1, se_ta_rep2],
-		ctl_tas = [se_ctl_ta_rep1, se_ctl_ta_rep2],
-		ta_pooled = se_ta_pooled,
-		always_use_pooled_ctl = false,
-		ctl_ta_pooled = se_ctl_ta_pooled,
-		ctl_depth_ratio = ctl_depth_ratio,
-		ctl_depth_limit = 0,
-		exp_ctl_depth_ratio_limit = 0.0,
-	}
+    call chip.choose_ctl as se_choose_ctl_ctl_depth_limit_only { input :
+        tas = [se_ta_rep1, se_ta_rep2],
+        ctl_tas = [se_ctl_ta_rep1, se_ctl_ta_rep2],
+        ta_pooled = se_ta_pooled,
+        always_use_pooled_ctl = false,
+        ctl_ta_pooled = se_ctl_ta_pooled,
+        ctl_depth_ratio = ctl_depth_ratio,
+        ctl_depth_limit = ctl_depth_limit,
+        exp_ctl_depth_ratio_limit = 0,
+    }
 
-	call chip.choose_ctl as se_choose_ctl_ctl_depth_limit_only { input :
-		tas = [se_ta_rep1, se_ta_rep2],
-		ctl_tas = [se_ctl_ta_rep1, se_ctl_ta_rep2],
-		ta_pooled = se_ta_pooled,
-		always_use_pooled_ctl = false,
-		ctl_ta_pooled = se_ctl_ta_pooled,
-		ctl_depth_ratio = ctl_depth_ratio,
-		ctl_depth_limit = ctl_depth_limit,
-		exp_ctl_depth_ratio_limit = 0,
-	}
+    call chip.choose_ctl as se_choose_ctl_exp_ctl_depth_ratio_limit_only { input :
+        tas = [se_ta_rep1, se_ta_rep2],
+        ctl_tas = [se_ctl_ta_rep1, se_ctl_ta_rep2],
+        ta_pooled = se_ta_pooled,
+        always_use_pooled_ctl = false,
+        ctl_ta_pooled = se_ctl_ta_pooled,
+        ctl_depth_ratio = ctl_depth_ratio,
+        ctl_depth_limit = 0,
+        exp_ctl_depth_ratio_limit = exp_ctl_depth_ratio_limit,
+    }
 
-	call chip.choose_ctl as se_choose_ctl_exp_ctl_depth_ratio_limit_only { input :
-		tas = [se_ta_rep1, se_ta_rep2],
-		ctl_tas = [se_ctl_ta_rep1, se_ctl_ta_rep2],
-		ta_pooled = se_ta_pooled,
-		always_use_pooled_ctl = false,
-		ctl_ta_pooled = se_ctl_ta_pooled,
-		ctl_depth_ratio = ctl_depth_ratio,
-		ctl_depth_limit = 0,
-		exp_ctl_depth_ratio_limit = exp_ctl_depth_ratio_limit,
-	}
+    Map[String, Pair[Int, Int]] tests = {
+        'se_choose_ctl_idx1': (se_choose_ctl.chosen_ctl_ta_ids[0], ref_se_choose_ctl_idx1),
+        'se_choose_ctl_idx2': (se_choose_ctl.chosen_ctl_ta_ids[1], ref_se_choose_ctl_idx2),
+        'se_choose_ctl_sub1': (se_choose_ctl.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_sub1),
+        'se_choose_ctl_sub2': (se_choose_ctl.chosen_ctl_ta_subsample[1], ref_se_choose_ctl_sub2),
+        'se_choose_ctl_sub_pooled': (se_choose_ctl.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_sub_pooled),
 
-	Map[String, Pair[Int, Int]] tests = {
-		'se_choose_ctl_idx1': (se_choose_ctl.chosen_ctl_ta_ids[0], ref_se_choose_ctl_idx1),
-		'se_choose_ctl_idx2': (se_choose_ctl.chosen_ctl_ta_ids[1], ref_se_choose_ctl_idx2),
-		'se_choose_ctl_sub1': (se_choose_ctl.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_sub1),
-		'se_choose_ctl_sub2': (se_choose_ctl.chosen_ctl_ta_subsample[1], ref_se_choose_ctl_sub2),
-		'se_choose_ctl_sub_pooled': (se_choose_ctl.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_sub_pooled),
+        'se_choose_ctl_always_use_pooled_ctl_idx1': (se_choose_ctl_always_use_pooled_ctl.chosen_ctl_ta_ids[0], ref_se_choose_ctl_always_use_pooled_ctl_idx1),
+        'se_choose_ctl_always_use_pooled_ctl_idx2': (se_choose_ctl_always_use_pooled_ctl.chosen_ctl_ta_ids[1], ref_se_choose_ctl_always_use_pooled_ctl_idx2),
+        'se_choose_ctl_always_use_pooled_ctl_sub1': (se_choose_ctl_always_use_pooled_ctl.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_always_use_pooled_ctl_sub1),
+        'se_choose_ctl_always_use_pooled_ctl_sub2': (se_choose_ctl_always_use_pooled_ctl.chosen_ctl_ta_subsample[1], ref_se_choose_ctl_always_use_pooled_ctl_sub2),
+        'se_choose_ctl_always_use_pooled_ctl_sub_pooled': (se_choose_ctl_always_use_pooled_ctl.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_always_use_pooled_ctl_sub_pooled),
 
-		'se_choose_ctl_always_use_pooled_ctl_idx1': (se_choose_ctl_always_use_pooled_ctl.chosen_ctl_ta_ids[0], ref_se_choose_ctl_always_use_pooled_ctl_idx1),
-		'se_choose_ctl_always_use_pooled_ctl_idx2': (se_choose_ctl_always_use_pooled_ctl.chosen_ctl_ta_ids[1], ref_se_choose_ctl_always_use_pooled_ctl_idx2),
-		'se_choose_ctl_always_use_pooled_ctl_sub1': (se_choose_ctl_always_use_pooled_ctl.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_always_use_pooled_ctl_sub1),
-		'se_choose_ctl_always_use_pooled_ctl_sub2': (se_choose_ctl_always_use_pooled_ctl.chosen_ctl_ta_subsample[1], ref_se_choose_ctl_always_use_pooled_ctl_sub2),
-		'se_choose_ctl_always_use_pooled_ctl_sub_pooled': (se_choose_ctl_always_use_pooled_ctl.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_always_use_pooled_ctl_sub_pooled),
+        'se_choose_ctl_single_rep_idx1': (se_choose_ctl_single_rep.chosen_ctl_ta_ids[0], ref_se_choose_ctl_single_rep_idx1),
+        'se_choose_ctl_single_rep_sub1': (se_choose_ctl_single_rep.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_single_rep_sub1),
+        'se_choose_ctl_single_rep_sub_pooled': (se_choose_ctl_single_rep.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_single_rep_sub_pooled),
 
-		'se_choose_ctl_single_rep_idx1': (se_choose_ctl_single_rep.chosen_ctl_ta_ids[0], ref_se_choose_ctl_single_rep_idx1),
-		'se_choose_ctl_single_rep_sub1': (se_choose_ctl_single_rep.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_single_rep_sub1),
-		'se_choose_ctl_single_rep_sub_pooled': (se_choose_ctl_single_rep.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_single_rep_sub_pooled),
+        'se_choose_ctl_single_ctl_idx1': (se_choose_ctl_single_ctl.chosen_ctl_ta_ids[0], ref_se_choose_ctl_single_ctl_idx1),
+        'se_choose_ctl_single_ctl_idx2': (se_choose_ctl_single_ctl.chosen_ctl_ta_ids[1], ref_se_choose_ctl_single_ctl_idx2),
+        'se_choose_ctl_single_ctl_sub1': (se_choose_ctl_single_ctl.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_single_ctl_sub1),
+        'se_choose_ctl_single_ctl_sub2': (se_choose_ctl_single_ctl.chosen_ctl_ta_subsample[1], ref_se_choose_ctl_single_ctl_sub2),
+        'se_choose_ctl_single_ctl_sub_pooled': (se_choose_ctl_single_ctl.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_single_ctl_sub_pooled),
 
-		'se_choose_ctl_single_ctl_idx1': (se_choose_ctl_single_ctl.chosen_ctl_ta_ids[0], ref_se_choose_ctl_single_ctl_idx1),
-		'se_choose_ctl_single_ctl_idx2': (se_choose_ctl_single_ctl.chosen_ctl_ta_ids[1], ref_se_choose_ctl_single_ctl_idx2),
-		'se_choose_ctl_single_ctl_sub1': (se_choose_ctl_single_ctl.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_single_ctl_sub1),
-		'se_choose_ctl_single_ctl_sub2': (se_choose_ctl_single_ctl.chosen_ctl_ta_subsample[1], ref_se_choose_ctl_single_ctl_sub2),
-		'se_choose_ctl_single_ctl_sub_pooled': (se_choose_ctl_single_ctl.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_single_ctl_sub_pooled),
+        'se_choose_ctl_disabled_idx1': (se_choose_ctl_disabled.chosen_ctl_ta_ids[0], ref_se_choose_ctl_disabled_idx1),
+        'se_choose_ctl_disabled_idx2': (se_choose_ctl_disabled.chosen_ctl_ta_ids[1], ref_se_choose_ctl_disabled_idx2),
+        'se_choose_ctl_disabled_sub1': (se_choose_ctl_disabled.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_disabled_sub1),
+        'se_choose_ctl_disabled_sub2': (se_choose_ctl_disabled.chosen_ctl_ta_subsample[1], ref_se_choose_ctl_disabled_sub2),
+        'se_choose_ctl_disabled_sub_pooled': (se_choose_ctl_disabled.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_disabled_sub_pooled),
 
-		'se_choose_ctl_disabled_idx1': (se_choose_ctl_disabled.chosen_ctl_ta_ids[0], ref_se_choose_ctl_disabled_idx1),
-		'se_choose_ctl_disabled_idx2': (se_choose_ctl_disabled.chosen_ctl_ta_ids[1], ref_se_choose_ctl_disabled_idx2),
-		'se_choose_ctl_disabled_sub1': (se_choose_ctl_disabled.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_disabled_sub1),
-		'se_choose_ctl_disabled_sub2': (se_choose_ctl_disabled.chosen_ctl_ta_subsample[1], ref_se_choose_ctl_disabled_sub2),
-		'se_choose_ctl_disabled_sub_pooled': (se_choose_ctl_disabled.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_disabled_sub_pooled),
+        'se_choose_ctl_ctl_depth_limit_only_idx1': (se_choose_ctl_ctl_depth_limit_only.chosen_ctl_ta_ids[0], ref_se_choose_ctl_ctl_depth_limit_only_idx1),
+        'se_choose_ctl_ctl_depth_limit_only_idx2': (se_choose_ctl_ctl_depth_limit_only.chosen_ctl_ta_ids[1], ref_se_choose_ctl_ctl_depth_limit_only_idx2),
+        'se_choose_ctl_ctl_depth_limit_only_sub1': (se_choose_ctl_ctl_depth_limit_only.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_ctl_depth_limit_only_sub1),
+        'se_choose_ctl_ctl_depth_limit_only_sub2': (se_choose_ctl_ctl_depth_limit_only.chosen_ctl_ta_subsample[1], ref_se_choose_ctl_ctl_depth_limit_only_sub2),
+        'se_choose_ctl_ctl_depth_limit_only_sub_pooled': (se_choose_ctl_ctl_depth_limit_only.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_ctl_depth_limit_only_sub_pooled),
 
-		'se_choose_ctl_ctl_depth_limit_only_idx1': (se_choose_ctl_ctl_depth_limit_only.chosen_ctl_ta_ids[0], ref_se_choose_ctl_ctl_depth_limit_only_idx1),
-		'se_choose_ctl_ctl_depth_limit_only_idx2': (se_choose_ctl_ctl_depth_limit_only.chosen_ctl_ta_ids[1], ref_se_choose_ctl_ctl_depth_limit_only_idx2),
-		'se_choose_ctl_ctl_depth_limit_only_sub1': (se_choose_ctl_ctl_depth_limit_only.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_ctl_depth_limit_only_sub1),
-		'se_choose_ctl_ctl_depth_limit_only_sub2': (se_choose_ctl_ctl_depth_limit_only.chosen_ctl_ta_subsample[1], ref_se_choose_ctl_ctl_depth_limit_only_sub2),
-		'se_choose_ctl_ctl_depth_limit_only_sub_pooled': (se_choose_ctl_ctl_depth_limit_only.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_ctl_depth_limit_only_sub_pooled),
-
-		'se_choose_ctl_exp_ctl_depth_ratio_limit_only_idx1': (se_choose_ctl_exp_ctl_depth_ratio_limit_only.chosen_ctl_ta_ids[0], ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_idx1),
-		'se_choose_ctl_exp_ctl_depth_ratio_limit_only_idx2': (se_choose_ctl_exp_ctl_depth_ratio_limit_only.chosen_ctl_ta_ids[1], ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_idx2),
-		'se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub1': (se_choose_ctl_exp_ctl_depth_ratio_limit_only.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub1),
-		'se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub2': (se_choose_ctl_exp_ctl_depth_ratio_limit_only.chosen_ctl_ta_subsample[1], ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub2),
-		'se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub_pooled': (se_choose_ctl_exp_ctl_depth_ratio_limit_only.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub_pooled),
-	}
-	scatter( test in tests ) {
-		String k = test.left
-		Pair[Int, Int] v = test.right
-		if ( v.left != v.right ) {
-			call chip.raise_exception { input:
-				msg = k,
-				vals = [v.left, v.right]
-			}
-		}
-	}
+        'se_choose_ctl_exp_ctl_depth_ratio_limit_only_idx1': (se_choose_ctl_exp_ctl_depth_ratio_limit_only.chosen_ctl_ta_ids[0], ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_idx1),
+        'se_choose_ctl_exp_ctl_depth_ratio_limit_only_idx2': (se_choose_ctl_exp_ctl_depth_ratio_limit_only.chosen_ctl_ta_ids[1], ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_idx2),
+        'se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub1': (se_choose_ctl_exp_ctl_depth_ratio_limit_only.chosen_ctl_ta_subsample[0], ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub1),
+        'se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub2': (se_choose_ctl_exp_ctl_depth_ratio_limit_only.chosen_ctl_ta_subsample[1], ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub2),
+        'se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub_pooled': (se_choose_ctl_exp_ctl_depth_ratio_limit_only.chosen_ctl_ta_subsample_pooled, ref_se_choose_ctl_exp_ctl_depth_ratio_limit_only_sub_pooled),
+    }
+    scatter( test in tests ) {
+        String k = test.left
+        Pair[Int, Int] v = test.right
+        if ( v.left != v.right ) {
+            call chip.raise_exception { input:
+                msg = k,
+                vals = [v.left, v.right]
+            }
+        }
+    }
 }

--- a/dev/test/test_task/test_count_signal_track.wdl
+++ b/dev/test/test_task/test_count_signal_track.wdl
@@ -1,33 +1,34 @@
-# ENCODE DCC ChIP-Seq pipeline tester for task count_signal_track
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../chip.wdl' as chip
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_count_signal_track {
-	String se_ta
+    input {
+        String se_ta
 
-	String ref_se_count_signal_track_pos_bw
-	String ref_se_count_signal_track_neg_bw
+        String ref_se_count_signal_track_pos_bw
+        String ref_se_count_signal_track_neg_bw
 
-	String se_chrsz
+        String se_chrsz
+    }
 
-	call chip.count_signal_track as se_count_signal_track { input :
-		ta = se_ta,
-		chrsz = se_chrsz,
-	}
+    call chip.count_signal_track as se_count_signal_track { input :
+        ta = se_ta,
+        chrsz = se_chrsz,
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'se_count_signal_track_pos_bw',
-			'se_count_signal_track_neg_bw',
-		],
-		files = [
-			se_count_signal_track.pos_bw,
-			se_count_signal_track.neg_bw,
-		],
-		ref_files = [
-			ref_se_count_signal_track_pos_bw,
-			ref_se_count_signal_track_neg_bw,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'se_count_signal_track_pos_bw',
+            'se_count_signal_track_neg_bw',
+        ],
+        files = [
+            se_count_signal_track.pos_bw,
+            se_count_signal_track.neg_bw,
+        ],
+        ref_files = [
+            ref_se_count_signal_track_pos_bw,
+            ref_se_count_signal_track_neg_bw,
+        ],
+    }
 }

--- a/dev/test/test_task/test_filter.wdl
+++ b/dev/test/test_task/test_filter.wdl
@@ -1,115 +1,112 @@
-# ENCODE DCC ChIP-Seq pipeline tester for task filter
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../chip.wdl' as chip
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_filter {
-	String dup_marker = 'picard'	# picard.jar MarkDuplicates (picard) or 
-									# sambamba markdup (sambamba)
-	Int mapq_thresh = 30			# threshold for low MAPQ reads removal
-	Boolean no_dup_removal = false	# no dupe reads removal when filtering BAM
-									# dup.qc and pbc.qc will be empty files
-									# and nodup_bam in the output is 
-									# filtered bam with dupes	
-	String pe_bam
-	String se_bam
+    input {
+        String dup_marker = 'picard'
+        Int mapq_thresh = 30
+        Boolean no_dup_removal = false
+        String pe_bam
+        String se_bam
 
-	String chrsz
+        String chrsz
 
-	String ref_pe_nodup_samstat_qc
-	String ref_pe_filt_samstat_qc
-	String ref_se_nodup_samstat_qc
-	String ref_se_filt_samstat_qc
-	String mito_chr_name = 'chrM'
+        String ref_pe_nodup_samstat_qc
+        String ref_pe_filt_samstat_qc
+        String ref_se_nodup_samstat_qc
+        String ref_se_filt_samstat_qc
+    }
+    String mito_chr_name = 'chrM'
 
-	Int filter_cpu = 1
-	Int filter_mem_mb = 20000
-	Int filter_time_hr = 24
-	String filter_disks = 'local-disk 100 HDD'
+    Int filter_cpu = 1
+    Int filter_mem_mb = 20000
+    Int filter_time_hr = 24
+    String filter_disks = 'local-disk 100 HDD'
 
-	call chip.filter as pe_filter { input :
-		bam = pe_bam,
-		no_dup_removal = false,
-		paired_end = true,
-		dup_marker = dup_marker,
-		mapq_thresh = mapq_thresh,
-		mito_chr_name = mito_chr_name,
-		filter_chrs = [],
-		chrsz = chrsz,
+    call chip.filter as pe_filter { input :
+        bam = pe_bam,
+        no_dup_removal = false,
+        paired_end = true,
+        dup_marker = dup_marker,
+        mapq_thresh = mapq_thresh,
+        mito_chr_name = mito_chr_name,
+        filter_chrs = [],
+        chrsz = chrsz,
 
-		cpu = filter_cpu,
-		mem_mb = filter_mem_mb,
-		picard_java_heap = '4G',
-		time_hr = filter_time_hr,
-		disks = filter_disks,
-	}
-	call chip.filter as pe_filter_no_dup_removal { input :
-		bam = pe_bam,
-		no_dup_removal = true,
-		paired_end = true,
-		dup_marker = dup_marker,
-		mapq_thresh = mapq_thresh,
-		mito_chr_name = mito_chr_name,
-		filter_chrs = [],
-		chrsz = chrsz,
+        cpu = filter_cpu,
+        mem_mb = filter_mem_mb,
+        picard_java_heap = '4G',
+        time_hr = filter_time_hr,
+        disks = filter_disks,
+    }
+    call chip.filter as pe_filter_no_dup_removal { input :
+        bam = pe_bam,
+        no_dup_removal = true,
+        paired_end = true,
+        dup_marker = dup_marker,
+        mapq_thresh = mapq_thresh,
+        mito_chr_name = mito_chr_name,
+        filter_chrs = [],
+        chrsz = chrsz,
 
-		cpu = filter_cpu,
-		mem_mb = filter_mem_mb,
-		picard_java_heap = '4G',
-		time_hr = filter_time_hr,
-		disks = filter_disks,
-	}
-	call chip.filter as se_filter { input :
-		bam = se_bam,
-		no_dup_removal = false,
-		paired_end = false,
-		dup_marker = dup_marker,
-		mapq_thresh = mapq_thresh,
-		mito_chr_name = mito_chr_name,
-		filter_chrs = [],
-		chrsz = chrsz,
+        cpu = filter_cpu,
+        mem_mb = filter_mem_mb,
+        picard_java_heap = '4G',
+        time_hr = filter_time_hr,
+        disks = filter_disks,
+    }
+    call chip.filter as se_filter { input :
+        bam = se_bam,
+        no_dup_removal = false,
+        paired_end = false,
+        dup_marker = dup_marker,
+        mapq_thresh = mapq_thresh,
+        mito_chr_name = mito_chr_name,
+        filter_chrs = [],
+        chrsz = chrsz,
 
-		cpu = filter_cpu,
-		mem_mb = filter_mem_mb,
-		picard_java_heap = '4G',
-		time_hr = filter_time_hr,
-		disks = filter_disks,
-	}
-	call chip.filter as se_filter_no_dup_removal { input :
-		bam = se_bam,
-		no_dup_removal = true,
-		paired_end = false,
-		dup_marker = dup_marker,
-		mapq_thresh = mapq_thresh,
-		mito_chr_name = mito_chr_name,
-		filter_chrs = [],
-		chrsz = chrsz,
+        cpu = filter_cpu,
+        mem_mb = filter_mem_mb,
+        picard_java_heap = '4G',
+        time_hr = filter_time_hr,
+        disks = filter_disks,
+    }
+    call chip.filter as se_filter_no_dup_removal { input :
+        bam = se_bam,
+        no_dup_removal = true,
+        paired_end = false,
+        dup_marker = dup_marker,
+        mapq_thresh = mapq_thresh,
+        mito_chr_name = mito_chr_name,
+        filter_chrs = [],
+        chrsz = chrsz,
 
-		cpu = filter_cpu,
-		mem_mb = filter_mem_mb,
-		picard_java_heap = '4G',
-		time_hr = filter_time_hr,
-		disks = filter_disks,
-	}
+        cpu = filter_cpu,
+        mem_mb = filter_mem_mb,
+        picard_java_heap = '4G',
+        time_hr = filter_time_hr,
+        disks = filter_disks,
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'pe_filter',
-			'pe_filter_no_dup_removal',
-			'se_filter',
-			'se_filter_no_dup_removal',
-		],
-		files = [
-			pe_filter.samstat_qc,
-			pe_filter_no_dup_removal.samstat_qc,
-			se_filter.samstat_qc,
-			se_filter_no_dup_removal.samstat_qc,
-		],
-		ref_files = [
-			ref_pe_nodup_samstat_qc,
-			ref_pe_filt_samstat_qc,
-			ref_se_nodup_samstat_qc,
-			ref_se_filt_samstat_qc,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'pe_filter',
+            'pe_filter_no_dup_removal',
+            'se_filter',
+            'se_filter_no_dup_removal',
+        ],
+        files = [
+            pe_filter.samstat_qc,
+            pe_filter_no_dup_removal.samstat_qc,
+            se_filter.samstat_qc,
+            se_filter_no_dup_removal.samstat_qc,
+        ],
+        ref_files = [
+            ref_pe_nodup_samstat_qc,
+            ref_pe_filt_samstat_qc,
+            ref_se_nodup_samstat_qc,
+            ref_se_filt_samstat_qc,
+        ],
+    }
 }

--- a/dev/test/test_task/test_gc_bias.json
+++ b/dev/test/test_task/test_gc_bias.json
@@ -1,5 +1,4 @@
 {
-    "test_gc_bias.paired_end" : true,
     "test_gc_bias.ref_fa" : "chip-seq-pipeline-test-data/genome_data/hg38_chr19_chrM/GRCh38_no_alt_analysis_set_GCA_000001405.15.chr19_chrM.fasta.gz",
     "test_gc_bias.nodup_bam" : "chip-seq-pipeline-test-data/input/pe/gc_bias/rep1-R1.subsampled.67.merged.nodup.bam",
 

--- a/dev/test/test_task/test_gc_bias.wdl
+++ b/dev/test/test_task/test_gc_bias.wdl
@@ -1,49 +1,50 @@
-# ENCODE DCC ChIP-Seq pipeline tester
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../chip.wdl' as chip
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_gc_bias {
-	File nodup_bam
+    input {
+        File nodup_bam
+        File ref_fa
+        File ref_gc_log
+    }
 
-	File ref_fa
+    call chip.gc_bias { input : 
+        nodup_bam = nodup_bam,
+        ref_fa = ref_fa,
+        picard_java_heap = '4G',
+    }
 
-	File ref_gc_log
+    call remove_comments_from_gc_log { input :
+        gc_log = gc_bias.gc_log
+    }
 
-	call chip.gc_bias { input : 
-		nodup_bam = nodup_bam,
-		ref_fa = ref_fa,
-		picard_java_heap = '4G',
-	}
+    call remove_comments_from_gc_log as remove_comments_from_gc_log_ref { input :
+        gc_log = ref_gc_log
+    }
 
-	call remove_comments_from_gc_log { input :
-		gc_log = gc_bias.gc_log
-	}
-
-	call remove_comments_from_gc_log as remove_comments_from_gc_log_ref { input :
-		gc_log = ref_gc_log
-	}
-
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'test_gc_log',
-		],
-		files = [
-			remove_comments_from_gc_log.filt_gc_log,
-		],
-		ref_files = [
-			remove_comments_from_gc_log_ref.filt_gc_log,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'test_gc_log',
+        ],
+        files = [
+            remove_comments_from_gc_log.filt_gc_log,
+        ],
+        ref_files = [
+            remove_comments_from_gc_log_ref.filt_gc_log,
+        ],
+    }
 }
 
 task remove_comments_from_gc_log {
-	File gc_log
-	command {
-		zcat -f ${gc_log} | grep -v '# ' \
-			> ${basename(gc_log) + '.date_filt_out'}
-	}
-	output {
-		File filt_gc_log = glob('*.date_filt_out')[0]
-	}
+    input {
+        File gc_log
+    }
+    command {
+        zcat -f ${gc_log} | grep -v '# ' \
+            > ${basename(gc_log) + '.date_filt_out'}
+    }
+    output {
+        File filt_gc_log = glob('*.date_filt_out')[0]
+    }
 }

--- a/dev/test/test_task/test_idr.wdl
+++ b/dev/test/test_task/test_idr.wdl
@@ -1,58 +1,58 @@
-# ENCODE DCC ChIP-Seq pipeline tester
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../chip.wdl' as chip
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_idr {
-	Float idr_thresh
+    input {
+        Float idr_thresh
 
-	String se_peak_rep1
-	String se_peak_rep2
-	String se_peak_pooled
-	String se_ta_pooled
+        String se_peak_rep1
+        String se_peak_rep2
+        String se_peak_pooled
+        String se_ta_pooled
 
-	String ref_se_idr_peak
-	String ref_se_idr_bfilt_peak
-	String ref_se_idr_frip_qc
+        String ref_se_idr_peak
+        String ref_se_idr_bfilt_peak
+        String ref_se_idr_frip_qc
 
-	String se_blacklist
-	String se_chrsz
+        String se_blacklist
+        String se_chrsz
+        Int fraglen
+    }
 
-	String regex_bfilt_peak_chr_name = 'chr[\\dXY]+'
+    String regex_bfilt_peak_chr_name = 'chr[\\dXY]+'
 
-	Int fraglen
+    call chip.idr as se_idr { input : 
+        prefix = 'rep1-rep2',
+        peak1 = se_peak_rep1,
+        peak2 = se_peak_rep2,
+        peak_pooled = se_peak_pooled,
+        idr_thresh = idr_thresh,
+        peak_type = 'regionPeak', # using SPP regionPeaks
+        rank = 'signal.value', # need to use signal.value for regionPeaks instead of p.value
+        chrsz = se_chrsz,
+        fraglen = fraglen,
+        blacklist = se_blacklist,
+        regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name,
 
-	call chip.idr as se_idr { input : 
-		prefix = 'rep1-rep2',
-		peak1 = se_peak_rep1,
-		peak2 = se_peak_rep2,
-		peak_pooled = se_peak_pooled,
-		idr_thresh = idr_thresh,
-		peak_type = 'regionPeak', # using SPP regionPeaks
-		rank = 'signal.value', # need to use signal.value for regionPeaks instead of p.value
-		chrsz = se_chrsz,
-		fraglen = fraglen,
-		blacklist = se_blacklist,
-		regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name,
+        ta = se_ta_pooled,
+    }
 
-		ta = se_ta_pooled,
-	}
-
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'se_idr_peak',
-			'se_idr_bfilt_peak',
-			'se_idr_frip_qc',
-		],
-		files = [
-			se_idr.idr_peak,
-			se_idr.bfilt_idr_peak,
-			se_idr.frip_qc,
-		],
-		ref_files = [
-			ref_se_idr_peak,
-			ref_se_idr_bfilt_peak,
-			ref_se_idr_frip_qc,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'se_idr_peak',
+            'se_idr_bfilt_peak',
+            'se_idr_frip_qc',
+        ],
+        files = [
+            se_idr.idr_peak,
+            se_idr.bfilt_idr_peak,
+            se_idr.frip_qc,
+        ],
+        ref_files = [
+            ref_se_idr_peak,
+            ref_se_idr_bfilt_peak,
+            ref_se_idr_frip_qc,
+        ],
+    }
 }

--- a/dev/test/test_task/test_jsd.wdl
+++ b/dev/test/test_task/test_jsd.wdl
@@ -1,70 +1,73 @@
-# ENCODE DCC ChIP-Seq pipeline tester for task jsd
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../chip.wdl' as chip
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_jsd {
-	Array[File] se_nodup_bams
-	File se_ctl_nodup_bam
-	File se_blacklist
-	Array[File] ref_se_jsd_logs
-	# task level test data (BAM) is generated from BWA
-	# so we keep using 30 here, this should be 255 for bowtie2 BAMs
-	Int mapq_thresh = 30
+    input {
+        Array[File] se_nodup_bams
+        File se_ctl_nodup_bam
+        File se_blacklist
+        Array[File] ref_se_jsd_logs
+    }
+    # task level test data (BAM) is generated from BWA
+    # so we keep using 30 here, this should be 255 for bowtie2 BAMs
+    Int mapq_thresh = 30
 
-	Int jsd_cpu = 1
-	Int jsd_mem_mb = 12000
-	Int jsd_time_hr = 6
-	String jsd_disks = 'local-disk 100 HDD'
+    Int jsd_cpu = 1
+    Int jsd_mem_mb = 12000
+    Int jsd_time_hr = 6
+    String jsd_disks = 'local-disk 100 HDD'
 
-	call chip.jsd as se_jsd { input :
-		nodup_bams = se_nodup_bams,
-		ctl_bams = [se_ctl_nodup_bam], # use first control only
-		blacklist = se_blacklist,
-		mapq_thresh = mapq_thresh,
+    call chip.jsd as se_jsd { input :
+        nodup_bams = se_nodup_bams,
+        ctl_bams = [se_ctl_nodup_bam], # use first control only
+        blacklist = se_blacklist,
+        mapq_thresh = mapq_thresh,
 
-		cpu = jsd_cpu,
-		mem_mb = jsd_mem_mb,
-		time_hr = jsd_time_hr,
-		disks = jsd_disks,
-	}
+        cpu = jsd_cpu,
+        mem_mb = jsd_mem_mb,
+        time_hr = jsd_time_hr,
+        disks = jsd_disks,
+    }
 
-	# take first 8 columns (vaule in other columns are random)
-	scatter(i in range(2)){
-		call take_8_cols { input :
-			f = se_jsd.jsd_qcs[i],
-		}
-		call take_8_cols as ref_take_8_cols { input :
-			f = ref_se_jsd_logs[i],
-		}
-	}
+    # take first 8 columns (vaule in other columns are random)
+    scatter(i in range(2)){
+        call take_8_cols { input :
+            f = se_jsd.jsd_qcs[i],
+        }
+        call take_8_cols as ref_take_8_cols { input :
+            f = ref_se_jsd_logs[i],
+        }
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'se_jsd_rep1',
-			'se_jsd_rep2',
-		],
-		files = [
-			take_8_cols.out[0],
-			take_8_cols.out[1],
-			#se_jsd.jsd_qcs[0],
-			#se_jsd.jsd_qcs[1],
-		],
-		ref_files = [
-			ref_take_8_cols.out[0],
-			ref_take_8_cols.out[1],
-			#ref_se_jsd_logs[0],
-			#ref_se_jsd_logs[1],
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'se_jsd_rep1',
+            'se_jsd_rep2',
+        ],
+        files = [
+            take_8_cols.out[0],
+            take_8_cols.out[1],
+            #se_jsd.jsd_qcs[0],
+            #se_jsd.jsd_qcs[1],
+        ],
+        ref_files = [
+            ref_take_8_cols.out[0],
+            ref_take_8_cols.out[1],
+            #ref_se_jsd_logs[0],
+            #ref_se_jsd_logs[1],
+        ],
+    }
 }
 
 task take_8_cols {
-	File f
-	command {
-		cut -f 1-8 ${f} > out.txt
-	}
-	output {
-		File out = 'out.txt'
-	}
+    input {
+        File f
+    }
+    command {
+        cut -f 1-8 ${f} > out.txt
+    }
+    output {
+        File out = 'out.txt'
+    }
 }

--- a/dev/test/test_task/test_macs2.wdl
+++ b/dev/test/test_task/test_macs2.wdl
@@ -1,100 +1,101 @@
-# ENCODE DCC ChIP-Seq pipeline tester for task macs2
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../chip.wdl' as chip
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_macs2 {
-	Int cap_num_peak
-	Float pval_thresh
+    input {
+        Int cap_num_peak
+        Float pval_thresh
 
-	Int fraglen
-	Int ctl_subsample
-	Boolean ctl_paired_end
-	# test macs2 for SE set only
-	String se_ta
-	String se_ctl_ta
+        Int fraglen
+        Int ctl_subsample
+        Boolean ctl_paired_end
+        # test macs2 for SE set only
+        String se_ta
+        String se_ctl_ta
 
-	String ref_se_macs2_npeak # raw narrow-peak
-	String ref_se_macs2_bfilt_npeak # blacklist filtered narrow-peak
-	String ref_se_macs2_frip_qc 
-	String ref_se_macs2_subsample_npeak # raw narrow-peak
-	String ref_se_macs2_subsample_bfilt_npeak # blacklist filtered narrow-peak
-	String ref_se_macs2_subsample_frip_qc 
+        String ref_se_macs2_npeak # raw narrow-peak
+        String ref_se_macs2_bfilt_npeak # blacklist filtered narrow-peak
+        String ref_se_macs2_frip_qc 
+        String ref_se_macs2_subsample_npeak # raw narrow-peak
+        String ref_se_macs2_subsample_bfilt_npeak # blacklist filtered narrow-peak
+        String ref_se_macs2_subsample_frip_qc 
 
-	String se_blacklist
-	String se_chrsz
-	String se_gensz
+        String se_blacklist
+        String se_chrsz
+        String se_gensz
+    }
 
-	String regex_bfilt_peak_chr_name = 'chr[\\dXY]+'
+    String regex_bfilt_peak_chr_name = 'chr[\\dXY]+'
 
-	Int macs2_mem_mb = 16000
-	Int macs2_time_hr = 24
-	String macs2_disks = 'local-disk 100 HDD'	
+    Int macs2_mem_mb = 16000
+    Int macs2_time_hr = 24
+    String macs2_disks = 'local-disk 100 HDD'    
 
-	call chip.call_peak as se_macs2 { input :
-		peak_caller = 'macs2',
-		peak_type = 'narrowPeak',
-		tas = [se_ta, se_ctl_ta],
-		ctl_subsample = 0,
-		ctl_paired_end = ctl_paired_end,
-		gensz = se_gensz,
-		chrsz = se_chrsz,
-		fraglen = fraglen,
-		cap_num_peak = cap_num_peak,
-		pval_thresh = pval_thresh,
-		blacklist = se_blacklist,
-		regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name,
+    call chip.call_peak as se_macs2 { input :
+        peak_caller = 'macs2',
+        peak_type = 'narrowPeak',
+        tas = [se_ta, se_ctl_ta],
+        ctl_subsample = 0,
+        ctl_paired_end = ctl_paired_end,
+        gensz = se_gensz,
+        chrsz = se_chrsz,
+        fraglen = fraglen,
+        cap_num_peak = cap_num_peak,
+        pval_thresh = pval_thresh,
+        blacklist = se_blacklist,
+        regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name,
 
-		cpu = 1,
-		mem_mb = macs2_mem_mb,
-		time_hr = macs2_time_hr,
-		disks = macs2_disks,		
-	}
+        cpu = 1,
+        mem_mb = macs2_mem_mb,
+        time_hr = macs2_time_hr,
+        disks = macs2_disks,        
+    }
 
-	call chip.call_peak as se_macs2_subsample { input :
-		peak_caller = 'macs2',
-		peak_type = 'narrowPeak',
-		tas = [se_ta, se_ctl_ta],
-		ctl_subsample = ctl_subsample,
-		ctl_paired_end = ctl_paired_end,
-		gensz = se_gensz,
-		chrsz = se_chrsz,
-		fraglen = fraglen,
-		cap_num_peak = cap_num_peak,
-		pval_thresh = pval_thresh,
-		blacklist = se_blacklist,
-		regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name,
+    call chip.call_peak as se_macs2_subsample { input :
+        peak_caller = 'macs2',
+        peak_type = 'narrowPeak',
+        tas = [se_ta, se_ctl_ta],
+        ctl_subsample = ctl_subsample,
+        ctl_paired_end = ctl_paired_end,
+        gensz = se_gensz,
+        chrsz = se_chrsz,
+        fraglen = fraglen,
+        cap_num_peak = cap_num_peak,
+        pval_thresh = pval_thresh,
+        blacklist = se_blacklist,
+        regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name,
 
-		cpu = 1,
-		mem_mb = macs2_mem_mb,
-		time_hr = macs2_time_hr,
-		disks = macs2_disks,		
-	}
+        cpu = 1,
+        mem_mb = macs2_mem_mb,
+        time_hr = macs2_time_hr,
+        disks = macs2_disks,        
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'se_macs2_npeak',
-			'se_macs2_bfilt_npeak',
-			'se_macs2_frip_qc',
-			'se_macs2_subsample_npeak',
-			'se_macs2_subsample_bfilt_npeak',
-			'se_macs2_subsample_frip_qc',
-		],
-		files = [
-			se_macs2.peak,
-			se_macs2.bfilt_peak,
-			se_macs2.frip_qc,
-			se_macs2_subsample.peak,
-			se_macs2_subsample.bfilt_peak,
-			se_macs2_subsample.frip_qc,
-		],
-		ref_files = [
-			ref_se_macs2_npeak,
-			ref_se_macs2_bfilt_npeak,
-			ref_se_macs2_frip_qc,
-			ref_se_macs2_subsample_npeak,
-			ref_se_macs2_subsample_bfilt_npeak,
-			ref_se_macs2_subsample_frip_qc,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'se_macs2_npeak',
+            'se_macs2_bfilt_npeak',
+            'se_macs2_frip_qc',
+            'se_macs2_subsample_npeak',
+            'se_macs2_subsample_bfilt_npeak',
+            'se_macs2_subsample_frip_qc',
+        ],
+        files = [
+            se_macs2.peak,
+            se_macs2.bfilt_peak,
+            se_macs2.frip_qc,
+            se_macs2_subsample.peak,
+            se_macs2_subsample.bfilt_peak,
+            se_macs2_subsample.frip_qc,
+        ],
+        ref_files = [
+            ref_se_macs2_npeak,
+            ref_se_macs2_bfilt_npeak,
+            ref_se_macs2_frip_qc,
+            ref_se_macs2_subsample_npeak,
+            ref_se_macs2_subsample_bfilt_npeak,
+            ref_se_macs2_subsample_frip_qc,
+        ],
+    }
 }

--- a/dev/test/test_task/test_macs2_signal_track.wdl
+++ b/dev/test/test_task/test_macs2_signal_track.wdl
@@ -1,67 +1,68 @@
-# ENCODE DCC ChIP-Seq pipeline tester for task macs2
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../chip.wdl' as chip
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_macs2_signal_track {
-	Float pval_thresh
+    input {
+        Float pval_thresh
 
-	Int fraglen
-	Int ctl_subsample
-	Boolean ctl_paired_end
-	# test macs2 for SE set only
-	String se_ta
-	String se_ctl_ta
+        Int fraglen
+        Int ctl_subsample
+        Boolean ctl_paired_end
+        # test macs2 for SE set only
+        String se_ta
+        String se_ctl_ta
 
-	String ref_se_macs2_pval_bw # p-val signal
-	String ref_se_macs2_subsample_pval_bw # p-val signal
-	String se_chrsz
-	String se_gensz
+        String ref_se_macs2_pval_bw # p-val signal
+        String ref_se_macs2_subsample_pval_bw # p-val signal
+        String se_chrsz
+        String se_gensz
+    }
 
-	Int macs2_mem_mb = 16000
-	Int macs2_time_hr = 24
-	String macs2_disks = 'local-disk 100 HDD'	
+    Int macs2_mem_mb = 16000
+    Int macs2_time_hr = 24
+    String macs2_disks = 'local-disk 100 HDD'    
 
-	call chip.macs2_signal_track as se_macs2_signal_track { input :
-		tas = [se_ta, se_ctl_ta],
-		ctl_subsample = 0,
-		ctl_paired_end = ctl_paired_end,
-		gensz = se_gensz,
-		chrsz = se_chrsz,
-		fraglen = fraglen,
-		pval_thresh = pval_thresh,
+    call chip.macs2_signal_track as se_macs2_signal_track { input :
+        tas = [se_ta, se_ctl_ta],
+        ctl_subsample = 0,
+        ctl_paired_end = ctl_paired_end,
+        gensz = se_gensz,
+        chrsz = se_chrsz,
+        fraglen = fraglen,
+        pval_thresh = pval_thresh,
 
-		mem_mb = macs2_mem_mb,
-		time_hr = macs2_time_hr,
-		disks = macs2_disks,		
-	}
+        mem_mb = macs2_mem_mb,
+        time_hr = macs2_time_hr,
+        disks = macs2_disks,        
+    }
 
-	call chip.macs2_signal_track as se_macs2_signal_track_subsample { input :
-		tas = [se_ta, se_ctl_ta],
-		ctl_subsample = ctl_subsample,
-		ctl_paired_end = ctl_paired_end,
-		gensz = se_gensz,
-		chrsz = se_chrsz,
-		fraglen = fraglen,
-		pval_thresh = pval_thresh,
+    call chip.macs2_signal_track as se_macs2_signal_track_subsample { input :
+        tas = [se_ta, se_ctl_ta],
+        ctl_subsample = ctl_subsample,
+        ctl_paired_end = ctl_paired_end,
+        gensz = se_gensz,
+        chrsz = se_chrsz,
+        fraglen = fraglen,
+        pval_thresh = pval_thresh,
 
-		mem_mb = macs2_mem_mb,
-		time_hr = macs2_time_hr,
-		disks = macs2_disks,
-	}
+        mem_mb = macs2_mem_mb,
+        time_hr = macs2_time_hr,
+        disks = macs2_disks,
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'se_macs2_pval_bw',
-			'se_macs2_subsample_pval_bw',
-		],
-		files = [
-			se_macs2_signal_track.pval_bw,
-			se_macs2_signal_track_subsample.pval_bw,
-		],
-		ref_files = [
-			ref_se_macs2_pval_bw,
-			ref_se_macs2_subsample_pval_bw,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'se_macs2_pval_bw',
+            'se_macs2_subsample_pval_bw',
+        ],
+        files = [
+            se_macs2_signal_track.pval_bw,
+            se_macs2_signal_track_subsample.pval_bw,
+        ],
+        ref_files = [
+            ref_se_macs2_pval_bw,
+            ref_se_macs2_subsample_pval_bw,
+        ],
+    }
 }

--- a/dev/test/test_task/test_overlap.wdl
+++ b/dev/test/test_task/test_overlap.wdl
@@ -1,54 +1,55 @@
-# ENCODE DCC ChIP-Seq pipeline tester
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../chip.wdl' as chip
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_overlap {
-	String se_peak_rep1 # test overlap,idr for SE set only
-	String se_peak_rep2
-	String se_peak_pooled
-	String se_ta_pooled
+    input {
+        String se_peak_rep1 # test overlap,idr for SE set only
+        String se_peak_rep2
+        String se_peak_pooled
+        String se_ta_pooled
 
-	String ref_se_overlap_peak
-	String ref_se_overlap_bfilt_peak
-	String ref_se_overlap_frip_qc
+        String ref_se_overlap_peak
+        String ref_se_overlap_bfilt_peak
+        String ref_se_overlap_frip_qc
 
-	String se_blacklist
-	String se_chrsz
+        String se_blacklist
+        String se_chrsz
+        Int fraglen
+    }
 
-	String regex_bfilt_peak_chr_name = 'chr[\\dXY]+'
+    String regex_bfilt_peak_chr_name = 'chr[\\dXY]+'
 
-	Int fraglen
 
-	call chip.overlap as se_overlap { input :
-		prefix = 'rep1-rep2',
-		peak1 = se_peak_rep1,
-		peak2 = se_peak_rep2,
-		peak_pooled = se_peak_pooled,
-		peak_type = 'regionPeak',
-		blacklist = se_blacklist,
-		regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name,
+    call chip.overlap as se_overlap { input :
+        prefix = 'rep1-rep2',
+        peak1 = se_peak_rep1,
+        peak2 = se_peak_rep2,
+        peak_pooled = se_peak_pooled,
+        peak_type = 'regionPeak',
+        blacklist = se_blacklist,
+        regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name,
 
-		chrsz = se_chrsz,
-		fraglen = fraglen,
-		ta = se_ta_pooled,
-	}
+        chrsz = se_chrsz,
+        fraglen = fraglen,
+        ta = se_ta_pooled,
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'se_overlap_peak',
-			'se_overlap_bfilt_peak',
-			'se_overlap_frip_qc',
-		],
-		files = [
-			se_overlap.overlap_peak,
-			se_overlap.bfilt_overlap_peak,
-			se_overlap.frip_qc,
-		],
-		ref_files = [
-			ref_se_overlap_peak,
-			ref_se_overlap_bfilt_peak,
-			ref_se_overlap_frip_qc,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'se_overlap_peak',
+            'se_overlap_bfilt_peak',
+            'se_overlap_frip_qc',
+        ],
+        files = [
+            se_overlap.overlap_peak,
+            se_overlap.bfilt_overlap_peak,
+            se_overlap.frip_qc,
+        ],
+        ref_files = [
+            ref_se_overlap_peak,
+            ref_se_overlap_bfilt_peak,
+            ref_se_overlap_frip_qc,
+        ],
+    }
 }

--- a/dev/test/test_task/test_pool_ta.wdl
+++ b/dev/test/test_task/test_pool_ta.wdl
@@ -1,27 +1,28 @@
-# ENCODE DCC ChIP-Seq pipeline tester
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../chip.wdl' as chip
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_pool_ta {
-	String se_ta_rep1
-	String se_ta_rep2
+    input {
+        String se_ta_rep1
+        String se_ta_rep2
 
-	String ref_se_pooled_ta
+        String ref_se_pooled_ta
+    }
 
-	call chip.pool_ta as se_pool_ta { input :
-		tas = [se_ta_rep1, se_ta_rep2],
-	}
+    call chip.pool_ta as se_pool_ta { input :
+        tas = [se_ta_rep1, se_ta_rep2],
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'se_pool_ta',
-		],
-		files = [
-			se_pool_ta.ta_pooled,
-		],
-		ref_files = [
-			ref_se_pooled_ta,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'se_pool_ta',
+        ],
+        files = [
+            se_pool_ta.ta_pooled,
+        ],
+        ref_files = [
+            ref_se_pooled_ta,
+        ],
+    }
 }

--- a/dev/test/test_task/test_reproducibility.wdl
+++ b/dev/test/test_task/test_reproducibility.wdl
@@ -1,35 +1,36 @@
-# ENCODE DCC ChIP-Seq pipeline tester
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../chip.wdl' as chip
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_reproducibility {
-	String se_overlap_peak_rep1_vs_rep2
-	String se_overlap_peak_rep1_pr
-	String se_overlap_peak_rep2_pr
-	String se_overlap_peak_ppr
-	String se_chrsz
+    input {
+        String se_overlap_peak_rep1_vs_rep2
+        String se_overlap_peak_rep1_pr
+        String se_overlap_peak_rep2_pr
+        String se_overlap_peak_ppr
+        String se_chrsz
 
-	String ref_se_reproducibility_qc
+        String ref_se_reproducibility_qc
+    }
 
-	call chip.reproducibility as se_reproducibility { input :
-		prefix = 'overlap',
-		peaks = [se_overlap_peak_rep1_vs_rep2],
-		peaks_pr = [se_overlap_peak_rep1_pr, se_overlap_peak_rep2_pr],
-		peak_ppr = se_overlap_peak_ppr,
-		peak_type = 'regionPeak',		
-		chrsz = se_chrsz,		
-	}
+    call chip.reproducibility as se_reproducibility { input :
+        prefix = 'overlap',
+        peaks = [se_overlap_peak_rep1_vs_rep2],
+        peaks_pr = [se_overlap_peak_rep1_pr, se_overlap_peak_rep2_pr],
+        peak_ppr = se_overlap_peak_ppr,
+        peak_type = 'regionPeak',        
+        chrsz = se_chrsz,        
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'se_reproducibility',
-		],
-		files = [
-			se_reproducibility.reproducibility_qc,
-		],
-		ref_files = [
-			ref_se_reproducibility_qc,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'se_reproducibility',
+        ],
+        files = [
+            se_reproducibility.reproducibility_qc,
+        ],
+        ref_files = [
+            ref_se_reproducibility_qc,
+        ],
+    }
 }

--- a/dev/test/test_task/test_spp.wdl
+++ b/dev/test/test_task/test_spp.wdl
@@ -1,99 +1,100 @@
-# ENCODE DCC ChIP-Seq pipeline tester for task spp
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../chip.wdl' as chip
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_spp {
-	Int cap_num_peak
+    input {
+        Int cap_num_peak
 
-	Int fraglen
-	Int ctl_subsample
-	Boolean ctl_paired_end
-	# test spp for SE set only
-	String se_ta
-	String se_ctl_ta
+        Int fraglen
+        Int ctl_subsample
+        Boolean ctl_paired_end
+        # test spp for SE set only
+        String se_ta
+        String se_ctl_ta
 
-	String ref_se_spp_rpeak # raw narrow-peak
-	String ref_se_spp_bfilt_rpeak # blacklist filtered narrow-peak
-	String ref_se_spp_frip_qc
-	String ref_se_spp_subsample_rpeak # raw narrow-peak
-	String ref_se_spp_subsample_bfilt_rpeak # blacklist filtered narrow-peak
-	String ref_se_spp_subsample_frip_qc
+        String ref_se_spp_rpeak # raw narrow-peak
+        String ref_se_spp_bfilt_rpeak # blacklist filtered narrow-peak
+        String ref_se_spp_frip_qc
+        String ref_se_spp_subsample_rpeak # raw narrow-peak
+        String ref_se_spp_subsample_bfilt_rpeak # blacklist filtered narrow-peak
+        String ref_se_spp_subsample_frip_qc
 
-	String se_blacklist
-	String se_chrsz
+        String se_blacklist
+        String se_chrsz
+    }
 
-	String regex_bfilt_peak_chr_name = 'chr[\\dXY]+'
+    String regex_bfilt_peak_chr_name = 'chr[\\dXY]+'
 
-	Int spp_cpu = 1
-	Int spp_mem_mb = 16000
-	Int spp_time_hr = 72
-	String spp_disks = 'local-disk 100 HDD'
+    Int spp_cpu = 1
+    Int spp_mem_mb = 16000
+    Int spp_time_hr = 72
+    String spp_disks = 'local-disk 100 HDD'
 
-	call chip.call_peak as se_spp { input :
-		peak_caller = 'spp',
-		peak_type = 'regionPeak',
-		gensz = se_chrsz,
-		pval_thresh = 0.0,
-		tas = [se_ta, se_ctl_ta],
-		ctl_subsample = 0,
-		ctl_paired_end = ctl_paired_end,
-		chrsz = se_chrsz,
-		fraglen = fraglen,
-		cap_num_peak = cap_num_peak,
-		blacklist = se_blacklist,
-		regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name,
+    call chip.call_peak as se_spp { input :
+        peak_caller = 'spp',
+        peak_type = 'regionPeak',
+        gensz = se_chrsz,
+        pval_thresh = 0.0,
+        tas = [se_ta, se_ctl_ta],
+        ctl_subsample = 0,
+        ctl_paired_end = ctl_paired_end,
+        chrsz = se_chrsz,
+        fraglen = fraglen,
+        cap_num_peak = cap_num_peak,
+        blacklist = se_blacklist,
+        regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name,
 
-		cpu = spp_cpu,
-		mem_mb = spp_mem_mb,
-		time_hr = spp_time_hr,
-		disks = spp_disks,
-	}
+        cpu = spp_cpu,
+        mem_mb = spp_mem_mb,
+        time_hr = spp_time_hr,
+        disks = spp_disks,
+    }
 
-	call chip.call_peak as se_spp_subsample { input :
-		peak_caller = 'spp',
-		peak_type = 'regionPeak',
-		gensz = se_chrsz,
-		pval_thresh = 0.0,
-		tas = [se_ta, se_ctl_ta],
-		ctl_subsample = ctl_subsample,
-		ctl_paired_end = ctl_paired_end,
-		chrsz = se_chrsz,
-		fraglen = fraglen,
-		cap_num_peak = cap_num_peak,
-		blacklist = se_blacklist,
-		regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name,
+    call chip.call_peak as se_spp_subsample { input :
+        peak_caller = 'spp',
+        peak_type = 'regionPeak',
+        gensz = se_chrsz,
+        pval_thresh = 0.0,
+        tas = [se_ta, se_ctl_ta],
+        ctl_subsample = ctl_subsample,
+        ctl_paired_end = ctl_paired_end,
+        chrsz = se_chrsz,
+        fraglen = fraglen,
+        cap_num_peak = cap_num_peak,
+        blacklist = se_blacklist,
+        regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name,
 
-		cpu = spp_cpu,
-		mem_mb = spp_mem_mb,
-		time_hr = spp_time_hr,
-		disks = spp_disks,
-	}
+        cpu = spp_cpu,
+        mem_mb = spp_mem_mb,
+        time_hr = spp_time_hr,
+        disks = spp_disks,
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'se_spp_rpeak',
-			'se_spp_bfilt_rpeak',
-			'se_spp_frip_qc',
-			'se_spp_subsample_rpeak',
-			'se_spp_subsample_bfilt_rpeak',
-			'se_spp_subsample_frip_qc',
-		],
-		files = [
-			se_spp.peak,
-			se_spp.bfilt_peak,
-			se_spp.frip_qc,
-			se_spp_subsample.peak,
-			se_spp_subsample.bfilt_peak,
-			se_spp_subsample.frip_qc,
-		],
-		ref_files = [
-			ref_se_spp_rpeak,
-			ref_se_spp_bfilt_rpeak,
-			ref_se_spp_frip_qc,
-			ref_se_spp_subsample_rpeak,
-			ref_se_spp_subsample_bfilt_rpeak,
-			ref_se_spp_subsample_frip_qc,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'se_spp_rpeak',
+            'se_spp_bfilt_rpeak',
+            'se_spp_frip_qc',
+            'se_spp_subsample_rpeak',
+            'se_spp_subsample_bfilt_rpeak',
+            'se_spp_subsample_frip_qc',
+        ],
+        files = [
+            se_spp.peak,
+            se_spp.bfilt_peak,
+            se_spp.frip_qc,
+            se_spp_subsample.peak,
+            se_spp_subsample.bfilt_peak,
+            se_spp_subsample.frip_qc,
+        ],
+        ref_files = [
+            ref_se_spp_rpeak,
+            ref_se_spp_bfilt_rpeak,
+            ref_se_spp_frip_qc,
+            ref_se_spp_subsample_rpeak,
+            ref_se_spp_subsample_bfilt_rpeak,
+            ref_se_spp_subsample_frip_qc,
+        ],
+    }
 }

--- a/dev/test/test_task/test_spr.wdl
+++ b/dev/test/test_task/test_spr.wdl
@@ -1,50 +1,50 @@
-# ENCODE DCC ChIP-Seq pipeline tester
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../chip.wdl' as chip
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_spr {
-	String pe_ta
-	String se_ta
+    input {
+        String pe_ta
+        String se_ta
 
-	String ref_pe_ta_pr1
-	String ref_pe_ta_pr2
-	String ref_se_ta_pr1
-	String ref_se_ta_pr2
+        String ref_pe_ta_pr1
+        String ref_pe_ta_pr2
+        String ref_se_ta_pr1
+        String ref_se_ta_pr2
+    }
+    Int spr_mem_mb = 16000
 
-	Int spr_mem_mb = 16000
+    call chip.spr as pe_spr { input :
+        ta = pe_ta,
+        paired_end = true,
 
-	call chip.spr as pe_spr { input :
-		ta = pe_ta,
-		paired_end = true,
+        mem_mb = spr_mem_mb,
+    }    
+    call chip.spr as se_spr { input :
+        ta = se_ta,
+        paired_end = false,
 
-		mem_mb = spr_mem_mb,
-	}	
-	call chip.spr as se_spr { input :
-		ta = se_ta,
-		paired_end = false,
+        mem_mb = spr_mem_mb,
+    }
 
-		mem_mb = spr_mem_mb,
-	}
-
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'pe_spr_pr1',
-			'pe_spr_pr2',
-			'se_spr_pr1',
-			'se_spr_pr2',
-		],
-		files = [
-			pe_spr.ta_pr1,
-			pe_spr.ta_pr2,
-			se_spr.ta_pr1,
-			se_spr.ta_pr2,
-		],
-		ref_files = [
-			ref_pe_ta_pr1,
-			ref_pe_ta_pr2,
-			ref_se_ta_pr1,
-			ref_se_ta_pr2,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'pe_spr_pr1',
+            'pe_spr_pr2',
+            'se_spr_pr1',
+            'se_spr_pr2',
+        ],
+        files = [
+            pe_spr.ta_pr1,
+            pe_spr.ta_pr2,
+            se_spr.ta_pr1,
+            se_spr.ta_pr2,
+        ],
+        ref_files = [
+            ref_pe_ta_pr1,
+            ref_pe_ta_pr2,
+            ref_se_ta_pr1,
+            ref_se_ta_pr2,
+        ],
+    }
 }

--- a/dev/test/test_task/test_xcor.wdl
+++ b/dev/test/test_task/test_xcor.wdl
@@ -1,89 +1,90 @@
-# ENCODE DCC ChIP-Seq pipeline tester
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../chip.wdl' as chip
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_xcor {
-	Int xcor_subsample
-	Int xcor_subsample_default = 15000000
+    input {
+        Int xcor_subsample
+        Int xcor_subsample_default = 15000000
 
-	String pe_ta
-	String se_ta
+        String pe_ta
+        String se_ta
 
-	String ref_pe_xcor_log
-	String ref_pe_xcor_log_subsample
-	String ref_se_xcor_log
-	String ref_se_xcor_log_subsample
-	String mito_chr_name = 'chrM'
+        String ref_pe_xcor_log
+        String ref_pe_xcor_log_subsample
+        String ref_se_xcor_log
+        String ref_se_xcor_log_subsample
+        String mito_chr_name = 'chrM'
 
-	Int xcor_cpu = 1
-	Int xcor_mem_mb = 16000	
-	Int xcor_time_hr = 24
-	String xcor_disks = 'local-disk 100 HDD'
+        Int xcor_cpu = 1
+        Int xcor_mem_mb = 16000    
+        Int xcor_time_hr = 24
+        String xcor_disks = 'local-disk 100 HDD'
+    }
 
-	call chip.xcor as pe_xcor { input :
-		ta = pe_ta,
-		subsample = xcor_subsample_default,
-		paired_end = true,
-		mito_chr_name = mito_chr_name,
+    call chip.xcor as pe_xcor { input :
+        ta = pe_ta,
+        subsample = xcor_subsample_default,
+        paired_end = true,
+        mito_chr_name = mito_chr_name,
 
-		cpu = xcor_cpu,
-		mem_mb = xcor_mem_mb,
-		time_hr = xcor_time_hr,
-		disks = xcor_disks,
-	}
-	call chip.xcor as pe_xcor_subsample { input :
-		ta = pe_ta,
-		subsample = xcor_subsample,
-		paired_end = true,
-		mito_chr_name = mito_chr_name,
+        cpu = xcor_cpu,
+        mem_mb = xcor_mem_mb,
+        time_hr = xcor_time_hr,
+        disks = xcor_disks,
+    }
+    call chip.xcor as pe_xcor_subsample { input :
+        ta = pe_ta,
+        subsample = xcor_subsample,
+        paired_end = true,
+        mito_chr_name = mito_chr_name,
 
-		cpu = xcor_cpu,
-		mem_mb = xcor_mem_mb,
-		time_hr = xcor_time_hr,
-		disks = xcor_disks,
-	}
-	call chip.xcor as se_xcor { input :
-		ta = se_ta,
-		subsample = xcor_subsample_default,
-		paired_end = false,
-		mito_chr_name = mito_chr_name,
+        cpu = xcor_cpu,
+        mem_mb = xcor_mem_mb,
+        time_hr = xcor_time_hr,
+        disks = xcor_disks,
+    }
+    call chip.xcor as se_xcor { input :
+        ta = se_ta,
+        subsample = xcor_subsample_default,
+        paired_end = false,
+        mito_chr_name = mito_chr_name,
 
-		cpu = xcor_cpu,
-		mem_mb = xcor_mem_mb,
-		time_hr = xcor_time_hr,
-		disks = xcor_disks,
-	}
-	call chip.xcor as se_xcor_subsample { input :
-		ta = se_ta,
-		subsample = xcor_subsample,
-		paired_end = false,
-		mito_chr_name = mito_chr_name,
+        cpu = xcor_cpu,
+        mem_mb = xcor_mem_mb,
+        time_hr = xcor_time_hr,
+        disks = xcor_disks,
+    }
+    call chip.xcor as se_xcor_subsample { input :
+        ta = se_ta,
+        subsample = xcor_subsample,
+        paired_end = false,
+        mito_chr_name = mito_chr_name,
 
-		cpu = xcor_cpu,
-		mem_mb = xcor_mem_mb,
-		time_hr = xcor_time_hr,
-		disks = xcor_disks,
-	}
+        cpu = xcor_cpu,
+        mem_mb = xcor_mem_mb,
+        time_hr = xcor_time_hr,
+        disks = xcor_disks,
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'pe_xcor',
-			'pe_xcor_subsample',
-			'se_xcor',
-			'se_xcor_subsample',
-		],
-		files = [
-			pe_xcor.score,
-			pe_xcor_subsample.score,
-			se_xcor.score,
-			se_xcor_subsample.score,
-		],
-		ref_files = [
-			ref_pe_xcor_log,
-			ref_pe_xcor_log_subsample,
-			ref_se_xcor_log,
-			ref_se_xcor_log_subsample,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'pe_xcor',
+            'pe_xcor_subsample',
+            'se_xcor',
+            'se_xcor_subsample',
+        ],
+        files = [
+            pe_xcor.score,
+            pe_xcor_subsample.score,
+            se_xcor.score,
+            se_xcor_subsample.score,
+        ],
+        ref_files = [
+            ref_pe_xcor_log,
+            ref_pe_xcor_log_subsample,
+            ref_se_xcor_log,
+            ref_se_xcor_log_subsample,
+        ],
+    }
 }

--- a/docs/input_short.md
+++ b/docs/input_short.md
@@ -259,7 +259,7 @@ Parameter|Default
 
 > **IMPORTANT**: If you see Java memory errors, check the following resource parameters.
 
-There are special parameters to control maximum Java heap memory (e.g. `java -Xmx4G`) for Picard tools. They are strings including size units. Such string will be directly appended to Java's parameter `-Xmx`.
+There are special parameters to control maximum Java heap memory (e.g. `java -Xmx4G`) for Picard tools. They are strings including size units. Such string will be directly appended to Java's parameter `-Xmx`. If these parameters are not defined then pipeline uses 90% of each task's memory (e.g. `chip.filter_mem_mb`).
 
 Parameter|Default
 ---------|-------

--- a/example_input_json/dx/ENCSR000DYI_dx.json
+++ b/example_input_json/dx/ENCSR000DYI_dx.json
@@ -1,13 +1,13 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg38_dx.tsv",
-    "chip.fastqs_rep1_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep1.fastq.gz"
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-genome-data/genome_tsv/v1/hg38_dx.tsv",
+    "chip.fastqs_rep1_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep1.fastq.gz"
     ],
-    "chip.fastqs_rep2_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep2.fastq.gz"
+    "chip.fastqs_rep2_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep2.fastq.gz"
     ],
-    "chip.ctl_fastqs_rep1_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/ctl1.fastq.gz"
+    "chip.ctl_fastqs_rep1_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/ctl1.fastq.gz"
     ],
-    "chip.ctl_fastqs_rep2_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/ctl2.fastq.gz"
+    "chip.ctl_fastqs_rep2_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/ctl2.fastq.gz"
     ],
 
     "chip.paired_end" : false,

--- a/example_input_json/dx/ENCSR000DYI_subsampled_chr19_only_dx.json
+++ b/example_input_json/dx/ENCSR000DYI_subsampled_chr19_only_dx.json
@@ -1,13 +1,13 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_dx.tsv",
-    "chip.fastqs_rep1_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep1.subsampled.25.fastq.gz"
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_dx.tsv",
+    "chip.fastqs_rep1_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep1.subsampled.25.fastq.gz"
     ],
-    "chip.fastqs_rep2_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep2.subsampled.20.fastq.gz"
+    "chip.fastqs_rep2_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep2.subsampled.20.fastq.gz"
     ],
-    "chip.ctl_fastqs_rep1_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/ctl1.subsampled.25.fastq.gz"
+    "chip.ctl_fastqs_rep1_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/ctl1.subsampled.25.fastq.gz"
     ],
-    "chip.ctl_fastqs_rep2_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/ctl2.subsampled.25.fastq.gz"
+    "chip.ctl_fastqs_rep2_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/ctl2.subsampled.25.fastq.gz"
     ],
 
     "chip.paired_end" : false,

--- a/example_input_json/dx/ENCSR000DYI_subsampled_chr19_only_rep1_dx.json
+++ b/example_input_json/dx/ENCSR000DYI_subsampled_chr19_only_rep1_dx.json
@@ -1,9 +1,9 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_dx.tsv",
-    "chip.fastqs_rep1_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep1.subsampled.25.fastq.gz"
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_dx.tsv",
+    "chip.fastqs_rep1_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep1.subsampled.25.fastq.gz"
     ],
-    "chip.ctl_fastqs_rep1_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/ctl1.subsampled.25.fastq.gz"
+    "chip.ctl_fastqs_rep1_R1" : ["dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/ctl1.subsampled.25.fastq.gz"
     ],
 
     "chip.paired_end" : false,

--- a/example_input_json/dx/ENCSR936XTK_dx.json
+++ b/example_input_json/dx/ENCSR936XTK_dx.json
@@ -1,30 +1,30 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg38_dx.tsv",
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-genome-data/genome_tsv/v1/hg38_dx.tsv",
 
     "chip.fastqs_rep1_R1" : [
-      "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.fastq.gz"
+      "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : [
-      "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R2.fastq.gz"
+      "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R2.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : [
-      "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep2-R1.fastq.gz"
+      "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep2-R1.fastq.gz"
     ],
     "chip.fastqs_rep2_R2" : [
-      "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep2-R2.fastq.gz"
+      "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep2-R2.fastq.gz"
     ],
     "chip.ctl_fastqs_rep1_R1" : [
-      "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/ctl1-R1.fastq.gz"
+      "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/ctl1-R1.fastq.gz"
     ],
     "chip.ctl_fastqs_rep1_R2" : [
-      "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/ctl1-R2.fastq.gz"
+      "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/ctl1-R2.fastq.gz"
     ],
     "chip.ctl_fastqs_rep2_R1" : [
-      "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/ctl2-R1.fastq.gz"
+      "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/ctl2-R1.fastq.gz"
     ],
     "chip.ctl_fastqs_rep2_R2" : [
-      "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/ctl2-R2.fastq.gz"
+      "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/ctl2-R2.fastq.gz"
     ],
 
     "chip.paired_end" : true,

--- a/example_input_json/dx/template_hg19.json
+++ b/example_input_json/dx/template_hg19.json
@@ -1,4 +1,4 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg19_dx.tsv"
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-genome-data/genome_tsv/v1/hg19_dx.tsv"
 }

--- a/example_input_json/dx/template_hg38.json
+++ b/example_input_json/dx/template_hg38.json
@@ -1,4 +1,4 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg38_dx.tsv"
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-genome-data/genome_tsv/v1/hg38_dx.tsv"
 }

--- a/example_input_json/dx/template_mm10.json
+++ b/example_input_json/dx/template_mm10.json
@@ -1,4 +1,4 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/mm10_dx.tsv"
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-genome-data/genome_tsv/v1/mm10_dx.tsv"
 }

--- a/example_input_json/dx/template_mm9.json
+++ b/example_input_json/dx/template_mm9.json
@@ -1,4 +1,4 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/mm9_dx.tsv"
+    "chip.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-genome-data/genome_tsv/v1/mm9_dx.tsv"
 }

--- a/example_input_json/dx_azure/ENCSR000DYI_dx_azure.json
+++ b/example_input_json/dx_azure/ENCSR000DYI_dx_azure.json
@@ -1,13 +1,13 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/hg38_dx_azure.tsv",
-    "chip.fastqs_rep1_R1" : ["dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep1.fastq.gz"
+    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-genome-data/genome_tsv/v1/hg38_dx_azure.tsv",
+    "chip.fastqs_rep1_R1" : ["dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep1.fastq.gz"
     ],
-    "chip.fastqs_rep2_R1" : ["dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep2.fastq.gz"
+    "chip.fastqs_rep2_R1" : ["dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/rep2.fastq.gz"
     ],
-    "chip.ctl_fastqs_rep1_R1" : ["dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/ctl1.fastq.gz"
+    "chip.ctl_fastqs_rep1_R1" : ["dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/ctl1.fastq.gz"
     ],
-    "chip.ctl_fastqs_rep2_R1" : ["dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/ctl2.fastq.gz"
+    "chip.ctl_fastqs_rep2_R1" : ["dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq/ctl2.fastq.gz"
     ],
 
     "chip.paired_end" : false,

--- a/example_input_json/dx_azure/ENCSR000DYI_subsampled_chr19_only_dx_azure.json
+++ b/example_input_json/dx_azure/ENCSR000DYI_subsampled_chr19_only_dx_azure.json
@@ -1,13 +1,13 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_dx_azure.tsv",
-    "chip.fastqs_rep1_R1" : ["dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep1.subsampled.25.fastq.gz"
+    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-genome-data/genome_tsv/v1/hg38_chr19_chrM_dx_azure.tsv",
+    "chip.fastqs_rep1_R1" : ["dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep1.subsampled.25.fastq.gz"
     ],
-    "chip.fastqs_rep2_R1" : ["dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep2.subsampled.15.fastq.gz"
+    "chip.fastqs_rep2_R1" : ["dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/rep2.subsampled.15.fastq.gz"
     ],
-    "chip.ctl_fastqs_rep1_R1" : ["dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/ctl1.subsampled.25.fastq.gz"
+    "chip.ctl_fastqs_rep1_R1" : ["dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/ctl1.subsampled.25.fastq.gz"
     ],
-    "chip.ctl_fastqs_rep2_R1" : ["dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/ctl2.subsampled.25.fastq.gz"
+    "chip.ctl_fastqs_rep2_R1" : ["dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR000DYI/fastq_subsampled/ctl2.subsampled.25.fastq.gz"
     ],
 
     "chip.paired_end" : false,

--- a/example_input_json/dx_azure/ENCSR936XTK_dx_azure.json
+++ b/example_input_json/dx_azure/ENCSR936XTK_dx_azure.json
@@ -1,30 +1,30 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/hg38_dx_azure.tsv",
+    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-genome-data/genome_tsv/v1/hg38_dx_azure.tsv",
 
     "chip.fastqs_rep1_R1" : [
-      "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.fastq.gz"
+      "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R1.fastq.gz"
     ],
     "chip.fastqs_rep1_R2" : [
-      "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R2.fastq.gz"
+      "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep1-R2.fastq.gz"
     ],
     "chip.fastqs_rep2_R1" : [
-      "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep2-R1.fastq.gz"
+      "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep2-R1.fastq.gz"
     ],
     "chip.fastqs_rep2_R2" : [
-      "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep2-R2.fastq.gz"
+      "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/rep2-R2.fastq.gz"
     ],
     "chip.ctl_fastqs_rep1_R1" : [
-      "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/ctl1-R1.fastq.gz"
+      "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/ctl1-R1.fastq.gz"
     ],
     "chip.ctl_fastqs_rep1_R2" : [
-      "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/ctl1-R2.fastq.gz"
+      "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/ctl1-R2.fastq.gz"
     ],
     "chip.ctl_fastqs_rep2_R1" : [
-      "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/ctl2-R1.fastq.gz"
+      "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/ctl2-R1.fastq.gz"
     ],
     "chip.ctl_fastqs_rep2_R2" : [
-      "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/ctl2-R2.fastq.gz"
+      "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-chip-seq-pipeline/ENCSR936XTK/fastq/ctl2-R2.fastq.gz"
     ],
 
     "chip.paired_end" : true,

--- a/example_input_json/dx_azure/template_hg19.json
+++ b/example_input_json/dx_azure/template_hg19.json
@@ -1,4 +1,4 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/hg19_dx_azure.tsv"
+    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-genome-data/genome_tsv/v1/hg19_dx_azure.tsv"
 }

--- a/example_input_json/dx_azure/template_hg38.json
+++ b/example_input_json/dx_azure/template_hg38.json
@@ -1,4 +1,4 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/hg38_dx_azure.tsv"
+    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-genome-data/genome_tsv/v1/hg38_dx_azure.tsv"
 }

--- a/example_input_json/dx_azure/template_mm10.json
+++ b/example_input_json/dx_azure/template_mm10.json
@@ -1,4 +1,4 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/mm10_dx_azure.tsv"
+    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-genome-data/genome_tsv/v1/mm10_dx_azure.tsv"
 }

--- a/example_input_json/dx_azure/template_mm9.json
+++ b/example_input_json/dx_azure/template_mm9.json
@@ -1,4 +1,4 @@
 {
     "chip.pipeline_type" : "tf",
-    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/mm9_dx_azure.tsv"
+    "chip.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-genome-data/genome_tsv/v1/mm9_dx_azure.tsv"
 }


### PR DESCRIPTION
Updated `chip.wdl` to WDL 1.0.
Updated DX workflow builder dXWDL to the latest (v1.46.4).
Made tasks fail on any error (`set -e`).

Linted `chip.wdl` to have whitepaces instead of TAB. So look at [this commit](https://github.com/ENCODE-DCC/chip-seq-pipeline2/pull/151/commits/42a5cc34e3f8e336bd04370c291efdbf919135bb) for actual changes in `chip.wdl`. Changes are:
  - Mostly moved input variables into `input {}` section
  - Added `select_all()` for arrays to coerce `File?` to `File` since WDL 1.0 is strict about type coercion.
  - Made task file input variables optional (`File?`) due to the same coercion issue mentioned above.
  - Removed custom aligner/peak_caller options since they complicate the code structure too much.
  - Added `pipeline_meta {}` section. This section includes description and help context for each input variable.