### PR TITLE
Pip 1220 clip chrom end for peaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,19 +50,19 @@ jobs:
             
             # task level test
             cd dev/test/test_task/
-            #rm -rf chip-seq-pipeline-test-data
-            #export BOTO_CONFIG=/dev/null
-            #gsutil -m cp -r gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/chip-seq-pipeline-test-data .
-            #for wdl in test_*.wdl
-            #do
-            #  json=${wdl%.*}.json
-            #  result=${wdl%.*}.result.json
-            #  ./test.sh ${wdl} ${json} ${TAG}
-            #  if [[ $(wc -l "${result}" | awk '{print $1}') > 1 ]]; then
-            #    python -c "import sys; import json; data=json.loads(sys.stdin.read()); sys.exit(int(not data[u'match_overall']))" < ${result}
-            #  fi
-            #  rm -f ${result}
-            #done
+            rm -rf chip-seq-pipeline-test-data
+            export BOTO_CONFIG=/dev/null
+            gsutil -m cp -r gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/chip-seq-pipeline-test-data .
+            for wdl in test_*.wdl
+            do
+              json=${wdl%.*}.json
+              result=${wdl%.*}.result.json
+              ./test.sh ${wdl} ${json} ${TAG}
+              if [[ $(wc -l "${result}" | awk '{print $1}') > 1 ]]; then
+                python -c "import sys; import json; data=json.loads(sys.stdin.read()); sys.exit(int(not data[u'match_overall']))" < ${result}
+              fi
+              rm -f ${result}
+            done
 
             
   test_workflow_se:
@@ -225,33 +225,33 @@ workflows:
       - test_tasks:
           requires:
             - build
-#      - test_workflow_se:
-#          requires:
-#            - build
-#      - test_workflow_ctl_sub_se:
-#          requires:
-#            - build
-#      - test_workflow_unrep_se:
-#          requires:
-#            - build
-#      - test_workflow_pe:
-#          requires:
-#            - build
-#      - test_workflow_pe_control_mode:
-#          requires:
-#            - build
-#      - test_workflow_ctl_sub_pe:
-#          requires:
-#            - build
-#      - test_workflow_ctl_sub_1ctl_pe:
-#          requires:
-#            - build
-#      - test_workflow_hist_se:
-#          requires:
-#            - build
-#      - test_workflow_hist_unrep_se:
-#          requires:
-#            - build
-#      - test_workflow_hist_pe:
-#          requires:
-#            - build
+      - test_workflow_se:
+          requires:
+            - build
+      - test_workflow_ctl_sub_se:
+          requires:
+            - build
+      - test_workflow_unrep_se:
+          requires:
+            - build
+      - test_workflow_pe:
+          requires:
+            - build
+      - test_workflow_pe_control_mode:
+          requires:
+            - build
+      - test_workflow_ctl_sub_pe:
+          requires:
+            - build
+      - test_workflow_ctl_sub_1ctl_pe:
+          requires:
+            - build
+      - test_workflow_hist_se:
+          requires:
+            - build
+      - test_workflow_hist_unrep_se:
+          requires:
+            - build
+      - test_workflow_hist_pe:
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,29 +51,33 @@ jobs:
           no_output_timeout: 300m
           command: |
             source ${BASH_ENV}
+            # use python 3.7 for testing
+            pyenv global 3.7.0
             # add src/ to PYTHONPATH so that .py's can be imported in unittest
             export PYTHONPATH=$PYTHONPATH:$PWD/src
-            # task level test
-            cd dev/test/test_task/
-            rm -rf chip-seq-pipeline-test-data
-            export BOTO_CONFIG=/dev/null
-            gsutil -m cp -r gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/chip-seq-pipeline-test-data .
-            for wdl in test_*.wdl
-            do
-              json=${wdl%.*}.json
-              result=${wdl%.*}.result.json
-              ./test.sh ${wdl} ${json} ${TAG}
-              if [[ $(wc -l "${result}" | awk '{print $1}') > 1 ]]; then
-                python -c "import sys; import json; data=json.loads(sys.stdin.read()); sys.exit(int(not data[u'match_overall']))" < ${result}
-              fi
-              rm -f ${result}
-            done
 
             # unittest for py
-            pip3 install pytest
+            pip install pytest
             cd
             cd dev/test/test_py/
             pytest -vv
+            
+            # task level test
+            #cd dev/test/test_task/
+            #rm -rf chip-seq-pipeline-test-data
+            #export BOTO_CONFIG=/dev/null
+            #gsutil -m cp -r gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/chip-seq-pipeline-test-data .
+            #for wdl in test_*.wdl
+            #do
+            #  json=${wdl%.*}.json
+            #  result=${wdl%.*}.result.json
+            #  ./test.sh ${wdl} ${json} ${TAG}
+            #  if [[ $(wc -l "${result}" | awk '{print $1}') > 1 ]]; then
+            #    python -c "import sys; import json; data=json.loads(sys.stdin.read()); sys.exit(int(not data[u'match_overall']))" < ${result}
+            #  fi
+            #  rm -f ${result}
+            #done
+
             
   test_workflow_se:
     <<: *machine_defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,33 +234,33 @@ workflows:
       - test_tasks:
           requires:
             - build
-      - test_workflow_se:
-          requires:
-            - build
-      - test_workflow_ctl_sub_se:
-          requires:
-            - build
-      - test_workflow_unrep_se:
-          requires:
-            - build
-      - test_workflow_pe:
-          requires:
-            - build
-      - test_workflow_pe_control_mode:
-          requires:
-            - build
-      - test_workflow_ctl_sub_pe:
-          requires:
-            - build
-      - test_workflow_ctl_sub_1ctl_pe:
-          requires:
-            - build
-      - test_workflow_hist_se:
-          requires:
-            - build
-      - test_workflow_hist_unrep_se:
-          requires:
-            - build
-      - test_workflow_hist_pe:
-          requires:
-            - build
+#      - test_workflow_se:
+#          requires:
+#            - build
+#      - test_workflow_ctl_sub_se:
+#          requires:
+#            - build
+#      - test_workflow_unrep_se:
+#          requires:
+#            - build
+#      - test_workflow_pe:
+#          requires:
+#            - build
+#      - test_workflow_pe_control_mode:
+#          requires:
+#            - build
+#      - test_workflow_ctl_sub_pe:
+#          requires:
+#            - build
+#      - test_workflow_ctl_sub_1ctl_pe:
+#          requires:
+#            - build
+#      - test_workflow_hist_se:
+#          requires:
+#            - build
+#      - test_workflow_hist_unrep_se:
+#          requires:
+#            - build
+#      - test_workflow_hist_pe:
+#          requires:
+#            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,6 @@ defaults: &defaults
     - image: google/cloud-sdk:latest #circleci/buildpack-deps:xenial-scm
   working_directory: ~/chip-seq-pipeline2
 
-python_defaults: &python_defaults
-  docker:
-    - image: quay.io/encode-dcc/chip-seq-pipeline:${CIRCLE_BRANCH}_${CIRCLE_WORKFLOW_ID}
-  working_directory: ~/chip-seq-pipeline2
-
 machine_defaults: &machine_defaults
   machine: 
     image: circleci/classic:201808-01
@@ -18,8 +13,7 @@ machine_defaults: &machine_defaults
 make_tag: &make_tag
   name: make docker image tag
   command: |
-    echo "export TAG=quay.io/encode-dcc/chip-seq-pipeline:${CIRCLE_BRANCH}_${CIRCLE_WORKFLOW_ID}" > ${BASH_ENV}
-    echo "export TAG_DOCKERHUB=encodedcc/chip-seq-pipeline:${CIRCLE_BRANCH}_${CIRCLE_WORKFLOW_ID}" >> ${BASH_ENV}
+    echo "export TAG=encodedcc/chip-seq-pipeline:${CIRCLE_BRANCH}_${CIRCLE_WORKFLOW_ID}" >> ${BASH_ENV}
 
 # Define jobs here
 version: 2
@@ -34,13 +28,12 @@ jobs:
           name: build image
           command: |
             source ${BASH_ENV}
-            export DOCKER_CACHE_TAG=dev-v1.3.5.1
+            export DOCKER_CACHE_TAG=v1.4.0.1
             echo "pulling ${DOCKER_CACHE_TAG}!"
-            docker pull quay.io/encode-dcc/chip-seq-pipeline:${DOCKER_CACHE_TAG}
-            docker login -u=${QUAY_ROBOT_USER} -p=${QUAY_ROBOT_USER_TOKEN} quay.io
-            docker build --cache-from quay.io/encode-dcc/chip-seq-pipeline:${DOCKER_CACHE_TAG} --build-arg GIT_COMMIT_HASH=${CIRCLE_SHA1} --build-arg BRANCH=${CIRCLE_BRANCH} --build-arg BUILD_TAG=${TAG} -t $TAG -f dev/docker_image/Dockerfile .
+            docker pull encodedcc/chip-seq-pipeline:${DOCKER_CACHE_TAG}
+            docker login -u=${DOCKERHUB_USER} -p=${DOCKERHUB_PASS}
+            docker build --cache-from encodedcc/chip-seq-pipeline:${DOCKER_CACHE_TAG} --build-arg GIT_COMMIT_HASH=${CIRCLE_SHA1} --build-arg BRANCH=${CIRCLE_BRANCH} --build-arg BUILD_TAG=${TAG} -t $TAG -f dev/docker_image/Dockerfile .
             docker push ${TAG}
-            #docker push ${TAG_DOCKERHUB}
             docker logout
   test_tasks:
     <<: *machine_defaults
@@ -51,12 +44,8 @@ jobs:
           no_output_timeout: 300m
           command: |
             source ${BASH_ENV}
-            # use python 3.7 for testing
+            # use python 3.7 for unittest
             pyenv global 3.7.0
-            # add src/ to PYTHONPATH so that .py's can be imported in unittest
-            export PYTHONPATH=$PYTHONPATH:$PWD/src
-
-            # unittest for py
             docker run ${TAG} bash -c "cd /software/chip-seq-pipeline/dev/test/test_py/; pytest -vv"
             
             # task level test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,12 +58,12 @@ jobs:
 
             # unittest for py
             pip install pytest
-            cd
             cd dev/test/test_py/
             pytest -vv
+            cd ../../../
             
             # task level test
-            #cd dev/test/test_task/
+            cd dev/test/test_task/
             #rm -rf chip-seq-pipeline-test-data
             #export BOTO_CONFIG=/dev/null
             #gsutil -m cp -r gs://encode-pipeline-test-samples/encode-chip-seq-pipeline/chip-seq-pipeline-test-data .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,24 +21,6 @@ make_tag: &make_tag
     echo "export TAG=quay.io/encode-dcc/chip-seq-pipeline:${CIRCLE_BRANCH}_${CIRCLE_WORKFLOW_ID}" > ${BASH_ENV}
     echo "export TAG_DOCKERHUB=encodedcc/chip-seq-pipeline:${CIRCLE_BRANCH}_${CIRCLE_WORKFLOW_ID}" >> ${BASH_ENV}
 
-install_singularity: &install_singularity
-  name: install singularity
-  command: |
-    sudo apt-get update
-    sudo apt-get install \
-    python \
-    dh-autoreconf \
-    build-essential \
-    libarchive-dev \
-    squashfs-tools
-    wget https://github.com/singularityware/singularity/releases/download/2.6.0/singularity-2.6.0.tar.gz
-    tar xvf singularity-2.6.0.tar.gz
-    cd singularity-2.6.0
-    ./configure --prefix=/usr/local --sysconfdir=/etc
-    make
-    sudo make install
-    singularity --version
-
 # Define jobs here
 version: 2
 jobs:
@@ -69,6 +51,9 @@ jobs:
           no_output_timeout: 300m
           command: |
             source ${BASH_ENV}
+            # add src/ to PYTHONPATH so that .py's can be imported in unittest
+            export PYTHONPATH=$PYTHONPATH:$PWD/src
+            # task level test
             cd dev/test/test_task/
             rm -rf chip-seq-pipeline-test-data
             export BOTO_CONFIG=/dev/null
@@ -83,6 +68,11 @@ jobs:
               fi
               rm -f ${result}
             done
+
+            # unittest for py
+            pip install pytest
+            cd dev/test/test_py/
+            pytest -vv
             
   test_workflow_se:
     <<: *machine_defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,10 +57,7 @@ jobs:
             export PYTHONPATH=$PYTHONPATH:$PWD/src
 
             # unittest for py
-            pip install pytest
-            cd dev/test/test_py/
-            pytest -vv
-            cd ../../../
+            docker run quay.io/encode-dcc/chip-seq-pipeline:${TAG} bash -c "cd /software/chip-seq-pipeline/dev/test/test_py/; pytest -vv"
             
             # task level test
             cd dev/test/test_task/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
             export PYTHONPATH=$PYTHONPATH:$PWD/src
 
             # unittest for py
-            docker run quay.io/encode-dcc/chip-seq-pipeline:${TAG} bash -c "cd /software/chip-seq-pipeline/dev/test/test_py/; pytest -vv"
+            docker run ${TAG} bash -c "cd /software/chip-seq-pipeline/dev/test/test_py/; pytest -vv"
             
             # task level test
             cd dev/test/test_task/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ python_defaults: &python_defaults
 
 machine_defaults: &machine_defaults
   machine: 
-    image: circleci/classic:latest
+    image: circleci/classic:201808-01
   working_directory: ~/chip-seq-pipeline2
 
 make_tag: &make_tag

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,8 +44,7 @@ jobs:
           no_output_timeout: 300m
           command: |
             source ${BASH_ENV}
-            # use python 3.7 for unittest
-            pyenv global 3.7.0
+            # unittest
             docker run ${TAG} bash -c "cd /software/chip-seq-pipeline/dev/test/test_py/; pytest -vv"
             
             # task level test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,8 @@ jobs:
             done
 
             # unittest for py
-            pip install pytest
+            pip3 install pytest
+            cd
             cd dev/test/test_py/
             pytest -vv
             

--- a/chip.wdl
+++ b/chip.wdl
@@ -8,8 +8,8 @@ workflow chip {
         description: 'ENCODE TF/Histone ChIP-Seq pipeline'
         specification_document: 'https://docs.google.com/document/d/1lG_Rd7fnYgRpSIqrIfuVlAz2dW1VaSQThzk836Db99c/edit?usp=sharing'
 
-        caper_docker: 'quay.io/encode-dcc/chip-seq-pipeline:dev-v1.4.1'
-        caper_singularity: 'docker://quay.io/encode-dcc/chip-seq-pipeline:dev-v1.4.1'
+        caper_docker: 'encodedcc/chip-seq-pipeline:dev-v1.4.1'
+        caper_singularity: 'docker://encodedcc/chip-seq-pipeline:dev-v1.4.1'
         croo_out_def: 'https://storage.googleapis.com/encode-pipeline-output-definition/chip.croo.v4.json'
 
         parameter_group: {

--- a/chip.wdl
+++ b/chip.wdl
@@ -2348,6 +2348,7 @@ task call_peak {
         elif [ '${peak_caller}' == 'spp' ]; then
             python3 $(which encode_task_spp.py) \
                 ${sep=' ' select_all(tas)} \
+                ${'--chrsz ' + chrsz} \
                 ${'--fraglen ' + fraglen} \
                 ${'--cap-num-peak ' + cap_num_peak} \
                 ${'--ctl-subsample ' + ctl_subsample} \

--- a/dev/docker_image/Dockerfile
+++ b/dev/docker_image/Dockerfile
@@ -125,6 +125,7 @@ RUN mkdir -p /mnt/ext_{0..9}
 RUN mkdir -p chip-seq-pipeline/src
 ENV PATH="/software/chip-seq-pipeline:/software/chip-seq-pipeline/src:${PATH}"
 RUN mkdir -p chip-seq-pipeline/dev/test/test_py
+ENV PYTHONPATH="/software/chip-seq-pipeline/src"
 
 # Get ENCODE chip-seq-pipeline container repository
 # This COPY assumes the build context is the root of the chip-seq-pipeline repo

--- a/dev/docker_image/Dockerfile
+++ b/dev/docker_image/Dockerfile
@@ -108,6 +108,9 @@ ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/software/kentUtils_bin_v377/lib
 # Instal Trimmomatic JAR
 RUN wget http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.39.zip && unzip Trimmomatic-0.39.zip && mv Trimmomatic-0.39/trimmomatic-0.39.jar trimmomatic.jar && chmod +rx trimmomatic.jar && rm -rf Trimmomatic-0.39.zip Trimmomatic-0.39/
 
+# Install pytest for testing environment
+RUN pip3 install --no-cache-dir pytest
+
 # Prevent conflict with locally installed python outside of singularity container
 ENV PYTHONNOUSERSITE=True
 
@@ -121,6 +124,7 @@ RUN mkdir -p /mnt/ext_{0..9}
 # make pipeline src directory to store py's
 RUN mkdir -p chip-seq-pipeline/src
 ENV PATH="/software/chip-seq-pipeline:/software/chip-seq-pipeline/src:${PATH}"
+RUN mkdir -p chip-seq-pipeline/dev/test/test_py
 
 # Get ENCODE chip-seq-pipeline container repository
 # This COPY assumes the build context is the root of the chip-seq-pipeline repo
@@ -129,4 +133,5 @@ ENV PATH="/software/chip-seq-pipeline:/software/chip-seq-pipeline/src:${PATH}"
 # cd [GIT_REPO_DIR] && docker build -f dev/docker_image/Dockerfile .
 COPY src chip-seq-pipeline/src/
 COPY chip.wdl chip-seq-pipeline/
+COPY dev/test/test_py chip-seq-pipeline/dev/test/test_py/
 

--- a/dev/test/test_py/test_encode_lib_genomic.py
+++ b/dev/test/test_py/test_encode_lib_genomic.py
@@ -1,0 +1,84 @@
+"""Make sure that
+    - pipeline's src/ directory is added to PYTHONPATH.
+    - pipeline's conda environment is activated.
+        Or run this in pipeline's docker container.
+
+This module does not cover all functions defined in encode_lib_genomic.
+It only covers the following newly added functions.
+"""
+
+import gzip
+import pytest
+from encode_lib_genomic import bed_clip
+from textwrap import dedent
+
+CHRSZ_HG38 = dedent("""\
+    chr1\t248956422
+    chr2\t242193529
+    chr3\t198295559
+    chr4\t190214555
+    chr5\t181538259
+    chr6\t170805979
+    chr7\t159345973
+    chr8\t145138636
+    chr9\t138394717
+    chr10\t133797422
+    chr11\t135086622
+    chr12\t133275309
+    chr13\t114364328
+    chr14\t107043718
+    chr15\t101991189
+    chr16\t90338345
+    chr17\t83257441
+    chr18\t80373285
+    chr19\t58617616
+    chr20\t64444167
+    chr21\t46709983
+    chr22\t50818468
+    chrX\t156040895
+    chrY\t57227415
+    chrM\t16569
+""")
+
+
+def test_bed_clip(tmp_path):
+    chrsz = tmp_path / 'chrsz'
+    chrsz.write_text(CHRSZ_HG38)
+
+    out_bed = tmp_path / 'out.bed'
+
+    # no change if it's inside 0-chrsz
+    bed_in = tmp_path / 'test.in.bed'
+    bed_in.write_text('chrM\t2\t10000\n')
+    bed_clip(str(bed_in), str(chrsz), str(out_bed), no_gz=True)
+    assert out_bed.read_text() == 'chrM\t2\t10000\n'
+
+    # out-of-bound error should occur
+    bed_oob1 = tmp_path / 'test.oob1.bed'
+    bed_oob1.write_text('chrM\t-10\t-1\n')
+    with pytest.raises(Exception):
+        bed_clip(str(bed_oob1), str(chrsz), str(out_bed), no_gz=True)
+
+    # should be truncated to 0 (left) or chrsz (right)
+    bed_left_crossing = tmp_path / 'test.lc.bed'
+    bed_left_crossing.write_text('chrM\t-1\t13000\n')
+    bed_right_crossing = tmp_path / 'test.rc.bed'
+    bed_right_crossing.write_text('chrM\t13000\t17000\n')
+    bed_larger = tmp_path / 'test.l.bed'
+    bed_larger.write_text('chrM\t-1\t17000\n')    
+
+    bed_clip(str(bed_left_crossing), str(chrsz), str(out_bed), no_gz=True)
+    assert out_bed.read_text() == 'chrM\t0\t13000\n'
+
+    bed_clip(str(bed_right_crossing), str(chrsz), str(out_bed), no_gz=True)
+    assert out_bed.read_text() == 'chrM\t13000\t16569\n'
+
+    bed_clip(str(bed_larger), str(chrsz), str(out_bed), no_gz=True)
+    assert out_bed.read_text() == 'chrM\t0\t16569\n'
+
+    # test no_gz flag
+    out_bed = tmp_path / 'out.bed.gz'
+    bed_clip(str(bed_larger), str(chrsz), str(out_bed), no_gz=False)
+    with gzip.open(str(out_bed), 'rb') as fp:
+        assert fp.read().decode() == 'chrM\t0\t16569\n'
+

--- a/src/encode_lib_genomic.py
+++ b/src/encode_lib_genomic.py
@@ -599,3 +599,30 @@ def determine_paired(bam):
         return True
     else:
         return False
+
+
+def bed_clip(bed, chrsz, out_clipped_bed, no_gz=False):
+    '''
+    Make sure that bedClip (in USCS tools) is installed.
+    Clip a BED file between 0 and chromSize (taken from 2-col chrsz file).
+    bedClip exits with 255 if both start/end coordinates are
+    out of valid range (0-chromSize). Otherwise, reads/peaks will be truncated.
+
+    Args:
+        no_gz:
+            Do not gzip output.
+    '''
+    tmp_out = out_clipped_bed +  '.clip_tmp'
+    cmd = 'bedClip {bed} {chrsz} {tmp_out} -truncate -verbose=2'.format(
+        bed=bed,
+        chrsz=chrsz,
+        tmp_out=out_clipped_bed if no_gz else tmp_out)
+    run_shell_cmd(cmd)
+
+    if not no_gz:
+        cmd2 = 'cat {tmp_out} | gzip -nc > {out_clipped_bed}'.format(
+            tmp_out=tmp_out,
+            out_clipped_bed=out_clipped_bed)
+        run_shell_cmd(cmd2)
+
+        rm_f(tmp_out)

--- a/src/encode_task_macs2_atac.py
+++ b/src/encode_task_macs2_atac.py
@@ -9,6 +9,7 @@ import argparse
 from encode_lib_common import (
     assert_file_not_empty, human_readable_number,
     log, ls_l, mkdir_p, rm_f, run_shell_cmd, strip_ext_ta)
+from encode_lib_genomic import bed_clip
 
 
 def parse_arguments():
@@ -51,6 +52,7 @@ def macs2(ta, chrsz, gensz, pval_thresh, smooth_win, cap_num_peak,
         human_readable_number(cap_num_peak))
     # temporary files
     npeak_tmp = '{}.tmp'.format(npeak)
+    npeak_tmp2 = '{}.tmp2'.format(npeak)
 
     shiftsize = -int(round(float(smooth_win)/2.0))
     temp_files = []
@@ -78,12 +80,16 @@ def macs2(ta, chrsz, gensz, pval_thresh, smooth_win, cap_num_peak,
         npeak_tmp)
     run_shell_cmd(cmd1)
 
-    cmd2 = 'head -n {} {} | gzip -nc > {}'.format(
+    cmd2 = 'head -n {} {} > {}'.format(
         cap_num_peak,
         npeak_tmp,
-        npeak)
+        npeak_tmp2)
     run_shell_cmd(cmd2)
-    rm_f(npeak_tmp)
+
+    # clip peaks between 0-chromSize.
+    bed_clip(npeak_tmp2, chrsz, npeak)
+
+    rm_f([npeak_tmp, npeak_tmp2])
 
     # remove temporary files
     temp_files.append("{}_*".format(prefix))

--- a/src/encode_task_spp.py
+++ b/src/encode_task_spp.py
@@ -9,7 +9,8 @@ import argparse
 from encode_lib_common import (
     assert_file_not_empty, human_readable_number, log,
     ls_l, mkdir_p, rm_f, run_shell_cmd, strip_ext_ta)
-from encode_lib_genomic import subsample_ta_se, subsample_ta_pe
+from encode_lib_genomic import (
+    subsample_ta_se, subsample_ta_pe, bed_clip)
 
 
 def parse_arguments():
@@ -47,7 +48,7 @@ def parse_arguments():
     return args
 
 
-def spp(ta, ctl_ta, fraglen, cap_num_peak, fdr_thresh,
+def spp(ta, ctl_ta, chrsz, fraglen, cap_num_peak, fdr_thresh,
         ctl_subsample, ctl_paired_end, nth, out_dir):
     basename_ta = os.path.basename(strip_ext_ta(ta))
 
@@ -72,7 +73,7 @@ def spp(ta, ctl_ta, fraglen, cap_num_peak, fdr_thresh,
         prefix,
         human_readable_number(cap_num_peak))
     rpeak_tmp = '{}.tmp'.format(rpeak)
-    rpeak_tmp_gz = '{}.tmp.gz'.format(rpeak)
+    rpeak_tmp2 = '{}.tmp2'.format(rpeak)
 
     cmd0 = 'Rscript --max-ppsize=500000 $(which run_spp.R) -c={} -i={} '
     cmd0 += '-npeak={} -odir={} -speak={} -savr={} -fdr={} -rf {}'
@@ -90,13 +91,16 @@ def spp(ta, ctl_ta, fraglen, cap_num_peak, fdr_thresh,
     # if we have scientific representation of chr coord. then convert it to int
     cmd1 = 'zcat -f {} | awk \'BEGIN{{OFS="\\t"}}'
     cmd1 += '{{if ($2<0) $2=0; '
-    cmd1 += 'print $1,int($2),int($3),$4,$5,$6,$7,$8,$9,$10;}}\' | '
-    cmd1 += 'gzip -f -nc > {}'
+    cmd1 += 'print $1,int($2),int($3),$4,$5,$6,$7,$8,$9,$10;}}\' > {}'
     cmd1 = cmd1.format(
         rpeak_tmp,
-        rpeak)
+        rpeak_tmp2)
     run_shell_cmd(cmd1)
-    rm_f([rpeak_tmp, rpeak_tmp_gz])
+
+    # clip peaks between 0-chromSize.
+    bed_clip(rpeak_tmp2, chrsz, rpeak)
+
+    rm_f([rpeak_tmp, rpeak_tmp2])
 
     return rpeak
 
@@ -109,7 +113,7 @@ def main():
     mkdir_p(args.out_dir)
 
     log.info('Calling peaks with spp...')
-    rpeak = spp(args.tas[0], args.tas[1],
+    rpeak = spp(args.tas[0], args.tas[1], args.chrsz,
                 args.fraglen, args.cap_num_peak, args.fdr_thresh,
                 args.ctl_subsample, args.ctl_paired_end, args.nth, args.out_dir)
 

--- a/src/encode_task_spp.py
+++ b/src/encode_task_spp.py
@@ -72,7 +72,8 @@ def spp(ta, ctl_ta, chrsz, fraglen, cap_num_peak, fdr_thresh,
     rpeak = '{}.{}.regionPeak.gz'.format(
         prefix,
         human_readable_number(cap_num_peak))
-    rpeak_tmp = '{}.tmp'.format(rpeak)
+    rpeak_tmp_prefix = '{}.tmp'.format(rpeak)
+    rpeak_tmp_gz = '{}.tmp.gz'.format(rpeak)
     rpeak_tmp2 = '{}.tmp2'.format(rpeak)
 
     cmd0 = 'Rscript --max-ppsize=500000 $(which run_spp.R) -c={} -i={} '
@@ -83,7 +84,7 @@ def spp(ta, ctl_ta, chrsz, fraglen, cap_num_peak, fdr_thresh,
         cap_num_peak,
         os.path.abspath(out_dir),
         fraglen,
-        rpeak_tmp,
+        rpeak_tmp_prefix,
         fdr_thresh,
         nth_param)
     run_shell_cmd(cmd0)
@@ -93,14 +94,14 @@ def spp(ta, ctl_ta, chrsz, fraglen, cap_num_peak, fdr_thresh,
     cmd1 += '{{if ($2<0) $2=0; '
     cmd1 += 'print $1,int($2),int($3),$4,$5,$6,$7,$8,$9,$10;}}\' > {}'
     cmd1 = cmd1.format(
-        rpeak_tmp,
+        rpeak_tmp_gz,
         rpeak_tmp2)
     run_shell_cmd(cmd1)
+    rm_f(rpeak_tmp_gz)
 
     # clip peaks between 0-chromSize.
     bed_clip(rpeak_tmp2, chrsz, rpeak)
-
-    rm_f([rpeak_tmp, rpeak_tmp2])
+    rm_f(rpeak_tmp2)
 
     return rpeak
 


### PR DESCRIPTION
See details here.
https://encodedcc.atlassian.net/browse/PIP-1220

Clip peak files' genome coordinate (start/end) with USCS tool `bedClip`.
What is clipped:
- Raw peak from SPP (for TF ChIP) /MACS2 (for Histone ChIP)
- IDR peak (12-col BED narrowPeak)
  - We don't need to clip overlap peak since it's simply based on `bedtools intersect`).
- IDR unthresholded peak (20-col BED)

`bed_clip` is added to `encode_lib_genomic.py` and called in multiple places (spp, macs2, idr).
- Added unittest for `bed_clip` by using `pytest`.

Docker image repo migration is done: `quay.io` -> `dockerhub`.

