### PR TITLE
Pip 1287 reenable custom aligner

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,31 +10,20 @@ assignees: ''
 **Describe the bug**
 A clear and concise description of what the problem is.
 
-**OS/Platform and dependencies**
-- OS or Platform: [e.g. Ubuntu 16.04, Google Cloud, Stanford Sherlock/SCG cluster, ...]
-- Conda version: If you have used Conda (`$ conda --version`).
-- Caper version
-- If not using Caper
-  - Cromwell/dxWDL version: [e.g. `cromwell-42.jar`, `dxWDL-78.jar`]
+**OS/Platform**
+- OS/Platform: [e.g. Ubuntu 16.04, Google Cloud, Stanford Sherlock/SCG cluster, ...]
+- Conda version: If you used Conda (`$ conda --version`).
+- Pipeline version: [e.g. v1.3.3]
+- Caper version: [e.g. v0.6.0]
 
-**Attach error logs**
-Caper users:
-Caper automatically run troubleshooter for failed workflows. If not and If you ran a Caper server and then get workflow_id of your failed workflow with `caper list`. Or directory use a `metadata.json` file on Cromwell's output directory
-```
-$ caper troubleshoot [WORKFLOW_ID_OR_METADATA_JSON_FILE]
-```
+**Caper configuration file**
+Paste contents of `~/.caper/default.conf`.
 
-Non-Caper users:
-1) Move to your working directory where you ran a pipeline. You should be able to find a directory named `cromwell-executions/` which includes all outputs and logs for debugging.
+**Input JSON file**
+Paste contents of your input JSON file.
 
-2) Run the following command line to print all non-empty STDERR outputs. This will be greatly helpful for developers to figure out the problem. Copy-paste its output to the issue page.
+**Error log**
+Caper automatically runs a troubleshooter for failed workflows. If it doesn't then get a `WORKFLOW_ID` of your failed workflow with `caper list` or directly use a `metadata.json` file on Caper's output directory.
 ```
-$ find -name stderr -not -empty | xargs tail -n +1
-```
-
-3) (OPTIONAL) Run the following command to collect all logs. For developer's convenience, please add `[ISSUE_ID]` to the name of the tar ball file. This command will generate a tar ball including all debugging information. Post an issue with the tar ball (`.tar.gz`) attached.
-```
-$ find . -type f -name 'stdout' -or -name 'stderr' -or -name 'script' -or \
--name '*.qc' -or -name '*.txt' -or -name '*.log' -or -name '*.png' -or -name '*.pdf' \
-| xargs tar -zcvf debug_[ISSUE_ID].tar.gz
+$ caper debug [WORKFLOW_ID_OR_METADATA_JSON_FILE]
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This ChIP-Seq pipeline is based off the ENCODE (phase-3) transcription factor an
 ## Installation
 
 1) Git clone this pipeline.
-	> **IMPORTANT*: use `~/chip-seq-pipeline2/chip.wdl` as `[WDL]` in Caper's documentation.
+	> **IMPORTANT**: use `~/chip-seq-pipeline2/chip.wdl` as `[WDL]` in Caper's documentation.
 
 	```bash
 	$ cd

--- a/chip.wdl
+++ b/chip.wdl
@@ -71,6 +71,7 @@ workflow chip {
         String? mito_chr_name
         String? regex_bfilt_peak_chr_name
         String? gensz
+        File? custom_aligner_idx_tar
 
         # group: input_genomic_data
         Boolean? paired_end
@@ -141,6 +142,7 @@ workflow chip {
 
         # group: alignment
         String aligner = 'bowtie2'
+        File? custom_align_py
         Boolean use_bwa_mem_for_pe = false
         Int crop_length = 0
         Int crop_length_tol = 2
@@ -243,8 +245,8 @@ workflow chip {
             description: 'BWA index TAR file.',
             group: 'reference_genome'
         }
-        bowtie2_mito_idx_tar: {
-            description: 'BWA index TAR file (mitochondrial reads only).',
+        custom_aligner_idx_tar: {
+            description: 'Index TAR file for a custom aligner. To use a custom aligner, define "chip.custom_align_py" too.',
             group: 'reference_genome'
         }
         chrsz: {
@@ -613,11 +615,17 @@ workflow chip {
         }
 
         aligner: {
-            description: 'Aligner. bowtie2 or bwa',
+            description: 'Aligner. bowtie2, bwa or custom',
             group: 'alignment',
-            help: 'It is bowtie2 by default.',
-            choices: ['bowtie2', 'bwa'],
+            help: 'It is bowtie2 by default. To use a custom aligner, define chip.custom_align_py and chip.custom_aligner_idx_tar.',
+            choices: ['bowtie2', 'bwa', 'custom'],
             example: 'bowtie2'
+        }
+        custom_align_py: {
+            description: 'Python script for a custom aligner.',
+            help: 'There is a template included in the documentation for inputs.',
+            group: 'alignment',
+            help: 'Defining this parameter will automatically change "chip.aligner" to "custom". You should also define "chip.custom_aligner_idx_tar".',
         }
         use_bwa_mem_for_pe: {
             description: 'For paired end dataset with read length >= 70bp, use bwa mem instead of bwa aln.',
@@ -934,7 +942,7 @@ workflow chip {
     String genome_name_ = select_first([genome_name, read_genome_tsv.genome_name, basename(chrsz_)])
 
     ### temp vars (do not define these)
-    String aligner_ = aligner
+    String aligner_ = if defined(custom_align_py) then 'custom' else aligner
     String peak_caller_ = if pipeline_type=='tf' then select_first([peak_caller, 'spp'])
                         else select_first([peak_caller, 'macs2'])
     String peak_type_ = if peak_caller_=='spp' then 'regionPeak'
@@ -1054,16 +1062,22 @@ workflow chip {
             msg = 'SPP requires control inputs. Define control input files ("chip.ctl_*") in an input JSON file.'
         }
     }
-    if ( (num_rep_fastq > 0 || num_ctl_fastq > 0) && aligner_ != 'bwa' && aligner_ != 'bowtie2' ) {
+    if ( (num_rep_fastq > 0 || num_ctl_fastq > 0) && aligner_ != 'bwa' && aligner_ != 'bowtie2' && aligner_ != 'custom' ) {
         call raise_exception as error_wrong_aligner { input:
-            msg = 'Choose chip.aligner between bwa and bowtie2.'
+            msg = 'Choose chip.aligner to align your fastqs. Choices: bwa, bowtie2, custom.'
         }
     }
     if ( aligner_ != 'bwa' && use_bwa_mem_for_pe ) {
         call raise_exception as error_use_bwa_mem_for_non_bwa { input:
             msg = 'To use chip.use_bwa_mem_for_pe, choose bwa for chip.aligner.'
         }
-    }    
+    }
+    if ( aligner_ == 'custom' && ( !defined(custom_align_py) || !defined(custom_aligner_idx_tar) ) ) {
+        call raise_exception as error_custom_aligner { input:
+            msg = 'To use a custom aligner, define chip.custom_align_py and chip.custom_aligner_idx_tar.'
+        }
+    }
+
     if ( ( ctl_depth_limit > 0 || exp_ctl_depth_ratio_limit > 0 ) && num_ctl > 1 && length(ctl_paired_ends) > 1  ) {
         call raise_exception as error_subsample_pooled_control_with_mixed_endedness { input:
             msg = 'Cannot use automatic control subsampling ("chip.ctl_depth_limit">0 and "chip.exp_ctl_depth_limit">0) for ' +
@@ -1103,8 +1117,10 @@ workflow chip {
 
                 aligner = aligner_,
                 mito_chr_name = mito_chr_name_,
+                custom_align_py = custom_align_py,
                 idx_tar = if aligner=='bwa' then bwa_idx_tar_
-                    else bowtie2_idx_tar_,
+                    else if aligner=='bowtie2' then bowtie2_idx_tar_
+                    else custom_aligner_idx_tar,
                 paired_end = paired_end_,
                 use_bwa_mem_for_pe = use_bwa_mem_for_pe,
 
@@ -1194,8 +1210,10 @@ workflow chip {
 
                 aligner = aligner_,
                 mito_chr_name = mito_chr_name_,
+                custom_align_py = custom_align_py,
                 idx_tar = if aligner=='bwa' then bwa_idx_tar_
-                    else bowtie2_idx_tar_,
+                    else if aligner=='bowtie2' then bowtie2_idx_tar_
+                    else custom_aligner_idx_tar,
                 paired_end = false,
                 use_bwa_mem_for_pe = use_bwa_mem_for_pe,
 
@@ -1318,8 +1336,10 @@ workflow chip {
 
                 aligner = aligner_,
                 mito_chr_name = mito_chr_name_,
+                custom_align_py = custom_align_py,
                 idx_tar = if aligner=='bwa' then bwa_idx_tar_
-                    else bowtie2_idx_tar_,
+                    else if aligner=='bowtie2' then bowtie2_idx_tar_
+                    else custom_aligner_idx_tar,
                 paired_end = ctl_paired_end_,
                 use_bwa_mem_for_pe = use_bwa_mem_for_pe,
 
@@ -1920,8 +1940,10 @@ task align {
         Int crop_length
         Int crop_length_tol
         String aligner
+
         String mito_chr_name
         Int? multimapping
+        File? custom_align_py
         File? idx_tar            # reference index tar
         Boolean paired_end
         Boolean use_bwa_mem_for_pe
@@ -1988,7 +2010,7 @@ task align {
         fi
 
         if [ '${aligner}' == 'bwa' ]; then
-             python3 $(which encode_task_bwa.py) \
+            python3 $(which encode_task_bwa.py) \
                 ${idx_tar} \
                 R1$SUFFIX/*.fastq.gz \
                 ${if paired_end then 'R2$SUFFIX/*.fastq.gz' else ''} \
@@ -1997,11 +2019,18 @@ task align {
                 ${'--nth ' + cpu}
 
         elif [ '${aligner}' == 'bowtie2' ]; then
-             python3 $(which encode_task_bowtie2.py) \
+            python3 $(which encode_task_bowtie2.py) \
                 ${idx_tar} \
                 R1$SUFFIX/*.fastq.gz \
                 ${if paired_end then 'R2$SUFFIX/*.fastq.gz' else ''} \
                 ${'--multimapping ' + multimapping} \
+                ${if paired_end then '--paired-end' else ''} \
+                ${'--nth ' + cpu}
+        else
+            python3 ${custom_align_py} \
+                ${idx_tar} \
+                R1$SUFFIX/*.fastq.gz \
+                ${if paired_end then 'R2$SUFFIX/*.fastq.gz' else ''} \
                 ${if paired_end then '--paired-end' else ''} \
                 ${'--nth ' + cpu}
         fi 

--- a/chip.wdl
+++ b/chip.wdl
@@ -237,10 +237,6 @@ workflow chip {
             description: 'Reference FASTA file.',
             group: 'reference_genome'
         }
-        ref_mito_fa: {
-            description: 'Reference FASTA file (mitochondrial reads only).',
-            group: 'reference_genome'
-        }
         bowtie2_idx_tar: {
             description: 'BWA index TAR file.',
             group: 'reference_genome'
@@ -623,9 +619,8 @@ workflow chip {
         }
         custom_align_py: {
             description: 'Python script for a custom aligner.',
-            help: 'There is a template included in the documentation for inputs.',
             group: 'alignment',
-            help: 'Defining this parameter will automatically change "chip.aligner" to "custom". You should also define "chip.custom_aligner_idx_tar".',
+            help: 'There is a template included in the documentation for inputs. Defining this parameter will automatically change "chip.aligner" to "custom". You should also define "chip.custom_aligner_idx_tar".'
         }
         use_bwa_mem_for_pe: {
             description: 'For paired end dataset with read length >= 70bp, use bwa mem instead of bwa aln.',

--- a/docs/input.md
+++ b/docs/input.md
@@ -30,11 +30,9 @@ Parameter|Type|Description
 `chip.genome_tsv`| File | Choose one of the TSV files listed below or build your own
 `chip.genome_name`| String | Name of genome (e.g. hg38, hg19, ...)
 `chip.ref_fa`| File | Reference FASTA file
-`chip.ref_mito_fa`| File | Mito-only reference FASTA file
-`chip.bowtie2_idx_tar`| File | Bowtie2 index TAR file (uncompressed) built from FASTA file
-`chip.bowtie2_mito_idx_tar`| File | Mito-only Bowtie2 index TAR file (uncompressed) built from FASTA file
-`chip.bwa_idx_tar`| File | BWA index TAR file (uncompressed) built from FASTA file with `bwa index`
-`chip.bwa_mito_idx_tar`| File | Mito-only BWA index TAR file (uncompressed) built from FASTA file with `bwa index`
+`chip.bowtie2_idx_tar`| File | Bowtie2 index TAR file built from FASTA file
+`chip.bwa_idx_tar`| File | BWA index TAR file built from FASTA file with `bwa index`
+`chip.custom_aligner_idx_tar`| File | Index TAR file for a custom aligner. To use a custom aligner, make sure to have `"chip.align": "custom"` and define `"chip.custom_align_py"` in your inputt JSON.
 `chip.chrsz`| File | 2-col chromosome sizes file built from FASTA file with `faidx`
 `chip.blacklist`| File | 3-col BED file. Peaks overlapping these regions will be filtered out
 `chip.blacklist2`| File | Second blacklist. Two blacklist files (`atac.blacklist` and `atac.blacklist2`) will be merged.
@@ -150,10 +148,12 @@ You can mix up different data types for individual replicate/control replicate. 
 
 Parameter|Type|Default|Description
 ---------|---|----|-----------
-`chip.aligner` | String | bowtie2 | Currently supported aligners: bwa and bowtie2.
+`chip.aligner` | String | bowtie2 | Currently supported aligners: bwa, bowtie2, custom. To use your own custom aligner, see the below parameter `chip.custom_align_py`.
+`chip.crop_length` | Int | 0 | Crop FASTQs with Trimmomatic (using parameters `CROP`). 0: cropping disabled.
 `chip.crop_length` | Int | 0 | Crop FASTQs with Trimmomatic (using parameters `CROP`). 0: cropping disabled.
 `chip.crop_length_tol` | Int | 2 | Trimmomatic's `MINLEN` will be set as `chip.crop_length` - `abs(chip.crop_length_tol)` where reads shorter than `MINLEN` will be removed, hence not included in output BAM files and all downstream analyses.
 `chip.use_bwa_mem_for_pe` | Boolean | false | For PE dataset, uise bwa mem instead of bwa aln.
+`chip.custom_align_py` | File | | Python script for your custom aligner. See details about [how to use a custom aligner](#how-to-use-a-custom-aligner)
 
 
 ## Optional filtering parameters
@@ -290,3 +290,80 @@ Parameter|Default
 `chip.filter_picard_java_heap` | = `chip.filter_mem_mb`
 `chip.align_trimmomatic_java_heap` | = `chip.align_mem_mb`
 `chip.gc_bias_picard_java_heap` | `10G`
+
+## How to use a custom aligner
+
+ENCODE ChIP-Seq pipeline currently supports `bwa` and `bowtie2`. In order to use your own aligner you need to define the following parameters first. You can define `custom_aligner_idx_tar` either in your input JSON file or in your genome TSV file. Such index TAR file should be an uncompressed TAR file without any directory structured.
+
+Parameter|Type|Description
+---------|-------|-----------
+`chip.custom_aligner_idx_tar` | File | Index TAR file for your custom aligner
+`chip.custom_align_py` | File | Python script for your custom aligner
+
+Here is a template for `custom_align.py`:
+
+```python
+#!/usr/bin/env python
+
+import os
+import argparse
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(prog='ENCODE template aligner')
+    parser.add_argument('index_prefix_or_tar', type=str,
+                        help='Path for prefix (or a tarball .tar) \
+                            for reference aligner index. \
+                            Tar ball must be packed without compression \
+                            and directory by using command line \
+                            "tar cvf [TAR] [TAR_PREFIX].*')
+    parser.add_argument('fastqs', nargs='+', type=str,
+                        help='List of FASTQs (R1 and R2). \
+                            FASTQs must be compressed with gzip (with .gz).')
+    parser.add_argument('--paired-end', action="store_true",
+                        help='Paired-end FASTQs.')
+    parser.add_argument('--multimapping', default=4, type=int,
+                        help='Multimapping reads')
+    parser.add_argument('--nth', type=int, default=1,
+                        help='Number of threads to parallelize.')
+    parser.add_argument('--out-dir', default='', type=str,
+                            help='Output directory.')
+    args = parser.parse_args()
+
+    # check if fastqs have correct dimension
+    if args.paired_end and len(args.fastqs)!=2:
+        raise argparse.ArgumentTypeError('Need 2 fastqs for paired end.')
+    if not args.paired_end and len(args.fastqs)!=1:
+        raise argparse.ArgumentTypeError('Need 1 fastq for single end.')
+
+    return args
+
+def align(fastq_R1, fastq_R2, ref_index_prefix, multimapping, nth, out_dir):
+    basename = os.path.basename(os.path.splitext(fastq_R1)[0])
+    prefix = os.path.join(out_dir, basename)
+    bam = '{}.bam'.format(prefix)
+
+    # map your fastqs somehow
+    os.system('touch {}'.format(bam))
+
+    return bam
+
+def main():
+    # read params
+    args = parse_arguments()
+
+    # unpack index somehow on CWD
+    os.system('tar xvf {}'.format(args.index_prefix_or_tar))
+
+    bam = align(args.fastqs[0],
+                args.fastqs[1] if args.paired_end else None,
+                args.index_prefix_or_tar,
+                args.multimapping,
+                args.nth,
+                args.out_dir)
+
+if __name__=='__main__':
+    main()
+
+```
+
+> **IMPORTANT**: Your custom python script should generate ONLY one `*.bam` file. For example, if there are two `.bam` files then pipeline will just pick the first one in an alphatical order.


### PR DESCRIPTION
Re-enable custom aligner.

Removed unused mito-related reference genome data from a genome TSV.
