### PR TITLE
Pip 1220 refactor control subsampling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,33 +222,34 @@ workflows:
       - test_tasks:
           requires:
             - build
-      # - test_workflow_se:
-      #     requires:
-      #       - build
+      - test_workflow_se:
+          requires:
+            - build
       - test_workflow_ctl_sub_se:
           requires:
             - build
-      # - test_workflow_unrep_se:
-      #     requires:
-      #       - build
-      # - test_workflow_pe:
-      #     requires:
-      #       - build
-      # - test_workflow_pe_control_mode:
-      #     requires:
-      #       - build
+      - test_workflow_unrep_se:
+          requires:
+            - build
+      - test_workflow_pe:
+          requires:
+            - build
+      - test_workflow_pe_control_mode:
+          requires:
+            - build
       - test_workflow_ctl_sub_pe:
           requires:
             - build
-      # - test_workflow_ctl_sub_1ctl_pe:
-      #     requires:
-      #       - build
-      # - test_workflow_hist_se:
-      #     requires:
-      #       - build
-      # - test_workflow_hist_unrep_se:
-      #     requires:
-      #       - build
-      # - test_workflow_hist_pe:
-      #     requires:
-      #       - build
+      - test_workflow_ctl_sub_1ctl_pe:
+          requires:
+            - build
+      - test_workflow_hist_se:
+          requires:
+            - build
+      - test_workflow_hist_unrep_se:
+          requires:
+            - build
+      - test_workflow_hist_pe:
+          requires:
+            - build
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,33 +222,33 @@ workflows:
       - test_tasks:
           requires:
             - build
-      - test_workflow_se:
-          requires:
-            - build
+      # - test_workflow_se:
+      #     requires:
+      #       - build
       - test_workflow_ctl_sub_se:
           requires:
             - build
-      - test_workflow_unrep_se:
-          requires:
-            - build
-      - test_workflow_pe:
-          requires:
-            - build
-      - test_workflow_pe_control_mode:
-          requires:
-            - build
+      # - test_workflow_unrep_se:
+      #     requires:
+      #       - build
+      # - test_workflow_pe:
+      #     requires:
+      #       - build
+      # - test_workflow_pe_control_mode:
+      #     requires:
+      #       - build
       - test_workflow_ctl_sub_pe:
           requires:
             - build
-      - test_workflow_ctl_sub_1ctl_pe:
-          requires:
-            - build
-      - test_workflow_hist_se:
-          requires:
-            - build
-      - test_workflow_hist_unrep_se:
-          requires:
-            - build
-      - test_workflow_hist_pe:
-          requires:
-            - build
+      # - test_workflow_ctl_sub_1ctl_pe:
+      #     requires:
+      #       - build
+      # - test_workflow_hist_se:
+      #     requires:
+      #       - build
+      # - test_workflow_hist_unrep_se:
+      #     requires:
+      #       - build
+      # - test_workflow_hist_pe:
+      #     requires:
+      #       - build

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,31 +10,20 @@ assignees: ''
 **Describe the bug**
 A clear and concise description of what the problem is.
 
-**OS/Platform and dependencies**
-- OS or Platform: [e.g. Ubuntu 16.04, Google Cloud, Stanford Sherlock/SCG cluster, ...]
-- Conda version: If you have used Conda (`$ conda --version`).
-- Caper version
-- If not using Caper
-  - Cromwell/dxWDL version: [e.g. `cromwell-42.jar`, `dxWDL-78.jar`]
+**OS/Platform**
+- OS/Platform: [e.g. Ubuntu 16.04, Google Cloud, Stanford Sherlock/SCG cluster, ...]
+- Conda version: If you used Conda (`$ conda --version`).
+- Pipeline version: [e.g. v1.3.3]
+- Caper version: [e.g. v0.6.0]
 
-**Attach error logs**
-Caper users:
-Caper automatically run troubleshooter for failed workflows. If not and If you ran a Caper server and then get workflow_id of your failed workflow with `caper list`. Or directory use a `metadata.json` file on Cromwell's output directory
-```
-$ caper troubleshoot [WORKFLOW_ID_OR_METADATA_JSON_FILE]
-```
+**Caper configuration file**
+Paste contents of `~/.caper/default.conf`.
 
-Non-Caper users:
-1) Move to your working directory where you ran a pipeline. You should be able to find a directory named `cromwell-executions/` which includes all outputs and logs for debugging.
+**Input JSON file**
+Paste contents of your input JSON file.
 
-2) Run the following command line to print all non-empty STDERR outputs. This will be greatly helpful for developers to figure out the problem. Copy-paste its output to the issue page.
+**Error log**
+Caper automatically runs a troubleshooter for failed workflows. If it doesn't then get a `WORKFLOW_ID` of your failed workflow with `caper list` or directly use a `metadata.json` file on Caper's output directory.
 ```
-$ find -name stderr -not -empty | xargs tail -n +1
-```
-
-3) (OPTIONAL) Run the following command to collect all logs. For developer's convenience, please add `[ISSUE_ID]` to the name of the tar ball file. This command will generate a tar ball including all debugging information. Post an issue with the tar ball (`.tar.gz`) attached.
-```
-$ find . -type f -name 'stdout' -or -name 'stderr' -or -name 'script' -or \
--name '*.qc' -or -name '*.txt' -or -name '*.log' -or -name '*.png' -or -name '*.pdf' \
-| xargs tar -zcvf debug_[ISSUE_ID].tar.gz
+$ caper debug [WORKFLOW_ID_OR_METADATA_JSON_FILE]
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This ChIP-Seq pipeline is based off the ENCODE (phase-3) transcription factor an
 	```
 
 2) Install pipeline's [Conda environment](docs/install_conda.md) if you want to use Conda instead of Docker/Singularity. Conda is recommneded on local computer and HPCs (e.g. Stanford Sherlock/SCG). Use 
-	> **IMPORTANT*: use `encode-chip-seq-pipeline` as `[PIPELINE_CONDA_ENV]` in Caper's documentation.
+	> **IMPORTANT**: use `encode-chip-seq-pipeline` as `[PIPELINE_CONDA_ENV]` in Caper's documentation.
 
 3) **Skip this step if you have installed pipeline's Conda environment**. Caper is already included in the Conda environment. [Install Caper](https://github.com/ENCODE-DCC/caper#installation). Caper is a python wrapper for [Cromwell](https://github.com/broadinstitute/cromwell).
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This ChIP-Seq pipeline is based off the ENCODE (phase-3) transcription factor an
 ## Installation
 
 1) Git clone this pipeline.
-	> **IMPORTANT*: use `~/chip-seq-pipeline2/chip.wdl` as `[WDL]` in Caper's documentation.
+	> **IMPORTANT**: use `~/chip-seq-pipeline2/chip.wdl` as `[WDL]` in Caper's documentation.
 
 	```bash
 	$ cd

--- a/chip.wdl
+++ b/chip.wdl
@@ -71,6 +71,7 @@ workflow chip {
         String? mito_chr_name
         String? regex_bfilt_peak_chr_name
         String? gensz
+        File? custom_aligner_idx_tar
 
         # group: input_genomic_data
         Boolean? paired_end
@@ -141,6 +142,7 @@ workflow chip {
 
         # group: alignment
         String aligner = 'bowtie2'
+        File? custom_align_py
         Boolean use_bwa_mem_for_pe = false
         Int crop_length = 0
         Int crop_length_tol = 2
@@ -235,16 +237,12 @@ workflow chip {
             description: 'Reference FASTA file.',
             group: 'reference_genome'
         }
-        ref_mito_fa: {
-            description: 'Reference FASTA file (mitochondrial reads only).',
-            group: 'reference_genome'
-        }
         bowtie2_idx_tar: {
             description: 'BWA index TAR file.',
             group: 'reference_genome'
         }
-        bowtie2_mito_idx_tar: {
-            description: 'BWA index TAR file (mitochondrial reads only).',
+        custom_aligner_idx_tar: {
+            description: 'Index TAR file for a custom aligner. To use a custom aligner, define "chip.custom_align_py" too.',
             group: 'reference_genome'
         }
         chrsz: {
@@ -613,11 +611,16 @@ workflow chip {
         }
 
         aligner: {
-            description: 'Aligner. bowtie2 or bwa',
+            description: 'Aligner. bowtie2, bwa or custom',
             group: 'alignment',
-            help: 'It is bowtie2 by default.',
-            choices: ['bowtie2', 'bwa'],
+            help: 'It is bowtie2 by default. To use a custom aligner, define chip.custom_align_py and chip.custom_aligner_idx_tar.',
+            choices: ['bowtie2', 'bwa', 'custom'],
             example: 'bowtie2'
+        }
+        custom_align_py: {
+            description: 'Python script for a custom aligner.',
+            group: 'alignment',
+            help: 'There is a template included in the documentation for inputs. Defining this parameter will automatically change "chip.aligner" to "custom". You should also define "chip.custom_aligner_idx_tar".'
         }
         use_bwa_mem_for_pe: {
             description: 'For paired end dataset with read length >= 70bp, use bwa mem instead of bwa aln.',
@@ -934,7 +937,7 @@ workflow chip {
     String genome_name_ = select_first([genome_name, read_genome_tsv.genome_name, basename(chrsz_)])
 
     ### temp vars (do not define these)
-    String aligner_ = aligner
+    String aligner_ = if defined(custom_align_py) then 'custom' else aligner
     String peak_caller_ = if pipeline_type=='tf' then select_first([peak_caller, 'spp'])
                         else select_first([peak_caller, 'macs2'])
     String peak_type_ = if peak_caller_=='spp' then 'regionPeak'
@@ -1054,16 +1057,22 @@ workflow chip {
             msg = 'SPP requires control inputs. Define control input files ("chip.ctl_*") in an input JSON file.'
         }
     }
-    if ( (num_rep_fastq > 0 || num_ctl_fastq > 0) && aligner_ != 'bwa' && aligner_ != 'bowtie2' ) {
+    if ( (num_rep_fastq > 0 || num_ctl_fastq > 0) && aligner_ != 'bwa' && aligner_ != 'bowtie2' && aligner_ != 'custom' ) {
         call raise_exception as error_wrong_aligner { input:
-            msg = 'Choose chip.aligner between bwa and bowtie2.'
+            msg = 'Choose chip.aligner to align your fastqs. Choices: bwa, bowtie2, custom.'
         }
     }
     if ( aligner_ != 'bwa' && use_bwa_mem_for_pe ) {
         call raise_exception as error_use_bwa_mem_for_non_bwa { input:
             msg = 'To use chip.use_bwa_mem_for_pe, choose bwa for chip.aligner.'
         }
-    }    
+    }
+    if ( aligner_ == 'custom' && ( !defined(custom_align_py) || !defined(custom_aligner_idx_tar) ) ) {
+        call raise_exception as error_custom_aligner { input:
+            msg = 'To use a custom aligner, define chip.custom_align_py and chip.custom_aligner_idx_tar.'
+        }
+    }
+
     if ( ( ctl_depth_limit > 0 || exp_ctl_depth_ratio_limit > 0 ) && num_ctl > 1 && length(ctl_paired_ends) > 1  ) {
         call raise_exception as error_subsample_pooled_control_with_mixed_endedness { input:
             msg = 'Cannot use automatic control subsampling ("chip.ctl_depth_limit">0 and "chip.exp_ctl_depth_limit">0) for ' +
@@ -1103,8 +1112,10 @@ workflow chip {
 
                 aligner = aligner_,
                 mito_chr_name = mito_chr_name_,
+                custom_align_py = custom_align_py,
                 idx_tar = if aligner=='bwa' then bwa_idx_tar_
-                    else bowtie2_idx_tar_,
+                    else if aligner=='bowtie2' then bowtie2_idx_tar_
+                    else custom_aligner_idx_tar,
                 paired_end = paired_end_,
                 use_bwa_mem_for_pe = use_bwa_mem_for_pe,
 
@@ -1194,8 +1205,10 @@ workflow chip {
 
                 aligner = aligner_,
                 mito_chr_name = mito_chr_name_,
+                custom_align_py = custom_align_py,
                 idx_tar = if aligner=='bwa' then bwa_idx_tar_
-                    else bowtie2_idx_tar_,
+                    else if aligner=='bowtie2' then bowtie2_idx_tar_
+                    else custom_aligner_idx_tar,
                 paired_end = false,
                 use_bwa_mem_for_pe = use_bwa_mem_for_pe,
 
@@ -1318,8 +1331,10 @@ workflow chip {
 
                 aligner = aligner_,
                 mito_chr_name = mito_chr_name_,
+                custom_align_py = custom_align_py,
                 idx_tar = if aligner=='bwa' then bwa_idx_tar_
-                    else bowtie2_idx_tar_,
+                    else if aligner=='bowtie2' then bowtie2_idx_tar_
+                    else custom_aligner_idx_tar,
                 paired_end = ctl_paired_end_,
                 use_bwa_mem_for_pe = use_bwa_mem_for_pe,
 
@@ -1920,8 +1935,10 @@ task align {
         Int crop_length
         Int crop_length_tol
         String aligner
+
         String mito_chr_name
         Int? multimapping
+        File? custom_align_py
         File? idx_tar            # reference index tar
         Boolean paired_end
         Boolean use_bwa_mem_for_pe
@@ -1988,7 +2005,7 @@ task align {
         fi
 
         if [ '${aligner}' == 'bwa' ]; then
-             python3 $(which encode_task_bwa.py) \
+            python3 $(which encode_task_bwa.py) \
                 ${idx_tar} \
                 R1$SUFFIX/*.fastq.gz \
                 ${if paired_end then 'R2$SUFFIX/*.fastq.gz' else ''} \
@@ -1997,11 +2014,18 @@ task align {
                 ${'--nth ' + cpu}
 
         elif [ '${aligner}' == 'bowtie2' ]; then
-             python3 $(which encode_task_bowtie2.py) \
+            python3 $(which encode_task_bowtie2.py) \
                 ${idx_tar} \
                 R1$SUFFIX/*.fastq.gz \
                 ${if paired_end then 'R2$SUFFIX/*.fastq.gz' else ''} \
                 ${'--multimapping ' + multimapping} \
+                ${if paired_end then '--paired-end' else ''} \
+                ${'--nth ' + cpu}
+        else
+            python3 ${custom_align_py} \
+                ${idx_tar} \
+                R1$SUFFIX/*.fastq.gz \
+                ${if paired_end then 'R2$SUFFIX/*.fastq.gz' else ''} \
                 ${if paired_end then '--paired-end' else ''} \
                 ${'--nth ' + cpu}
         fi 

--- a/dev/test/test_task/test_macs2.json
+++ b/dev/test/test_task/test_macs2.json
@@ -7,17 +7,11 @@
     "test_macs2.se_ctl_ta" : "chip-seq-pipeline-test-data/input/se/tas/pooled_ctl/ctl1.subsampled.25.merged.nodup.pooled.tagAlign.gz",
 
     "test_macs2.fraglen" : 95,
-    "test_macs2.ctl_subsample" : 48000,
-    "test_macs2.ctl_paired_end" : false,
 
     "test_macs2.ref_se_macs2_npeak" : "chip-seq-pipeline-test-data/ref_output/test_macs2/rep1.subsampled.25.merged.nodup_x_ctl1.subsampled.25.merged.nodup.pooled.pval0.01.500K.narrowPeak.gz",
     "test_macs2.ref_se_macs2_bfilt_npeak" : "chip-seq-pipeline-test-data/ref_output/test_macs2/rep1.subsampled.25.merged.nodup_x_ctl1.subsampled.25.merged.nodup.pooled.pval0.01.500K.bfilt.narrowPeak.gz",
     "test_macs2.ref_se_macs2_frip_qc" : "chip-seq-pipeline-test-data/ref_output/test_macs2/rep1.subsampled.25.merged.nodup_x_ctl1.subsampled.25.merged.nodup.pooled.pval0.01.500K.bfilt.frip.qc",
 
-    "test_macs2.ref_se_macs2_subsample_npeak" : "chip-seq-pipeline-test-data/ref_output/test_macs2/fix_PIP-917/rep1.subsampled.25.merged.nodup_x_ctl1.subsampled.25.merged.nodup.pooled.48K.pval0.01.500K.narrowPeak.gz",
-    "test_macs2.ref_se_macs2_subsample_bfilt_npeak" : "chip-seq-pipeline-test-data/ref_output/test_macs2/fix_PIP-917/rep1.subsampled.25.merged.nodup_x_ctl1.subsampled.25.merged.nodup.pooled.48K.pval0.01.500K.bfilt.narrowPeak.gz",
-    "test_macs2.ref_se_macs2_subsample_frip_qc" : "chip-seq-pipeline-test-data/ref_output/test_macs2/fix_PIP-917/rep1.subsampled.25.merged.nodup_x_ctl1.subsampled.25.merged.nodup.pooled.48K.pval0.01.500K.bfilt.frip.qc",
-    
     "test_macs2.cap_num_peak" : 500000,
     "test_macs2.pval_thresh" : 0.01
 }

--- a/dev/test/test_task/test_macs2.wdl
+++ b/dev/test/test_task/test_macs2.wdl
@@ -8,8 +8,6 @@ workflow test_macs2 {
         Float pval_thresh
 
         Int fraglen
-        Int ctl_subsample
-        Boolean ctl_paired_end
         # test macs2 for SE set only
         String se_ta
         String se_ctl_ta
@@ -17,9 +15,6 @@ workflow test_macs2 {
         String ref_se_macs2_npeak # raw narrow-peak
         String ref_se_macs2_bfilt_npeak # blacklist filtered narrow-peak
         String ref_se_macs2_frip_qc 
-        String ref_se_macs2_subsample_npeak # raw narrow-peak
-        String ref_se_macs2_subsample_bfilt_npeak # blacklist filtered narrow-peak
-        String ref_se_macs2_subsample_frip_qc 
 
         String se_blacklist
         String se_chrsz
@@ -36,28 +31,6 @@ workflow test_macs2 {
         peak_caller = 'macs2',
         peak_type = 'narrowPeak',
         tas = [se_ta, se_ctl_ta],
-        ctl_subsample = 0,
-        ctl_paired_end = ctl_paired_end,
-        gensz = se_gensz,
-        chrsz = se_chrsz,
-        fraglen = fraglen,
-        cap_num_peak = cap_num_peak,
-        pval_thresh = pval_thresh,
-        blacklist = se_blacklist,
-        regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name,
-
-        cpu = 1,
-        mem_mb = macs2_mem_mb,
-        time_hr = macs2_time_hr,
-        disks = macs2_disks,        
-    }
-
-    call chip.call_peak as se_macs2_subsample { input :
-        peak_caller = 'macs2',
-        peak_type = 'narrowPeak',
-        tas = [se_ta, se_ctl_ta],
-        ctl_subsample = ctl_subsample,
-        ctl_paired_end = ctl_paired_end,
         gensz = se_gensz,
         chrsz = se_chrsz,
         fraglen = fraglen,
@@ -77,25 +50,16 @@ workflow test_macs2 {
             'se_macs2_npeak',
             'se_macs2_bfilt_npeak',
             'se_macs2_frip_qc',
-            'se_macs2_subsample_npeak',
-            'se_macs2_subsample_bfilt_npeak',
-            'se_macs2_subsample_frip_qc',
         ],
         files = [
             se_macs2.peak,
             se_macs2.bfilt_peak,
             se_macs2.frip_qc,
-            se_macs2_subsample.peak,
-            se_macs2_subsample.bfilt_peak,
-            se_macs2_subsample.frip_qc,
         ],
         ref_files = [
             ref_se_macs2_npeak,
             ref_se_macs2_bfilt_npeak,
             ref_se_macs2_frip_qc,
-            ref_se_macs2_subsample_npeak,
-            ref_se_macs2_subsample_bfilt_npeak,
-            ref_se_macs2_subsample_frip_qc,
         ],
     }
 }

--- a/dev/test/test_task/test_macs2_signal_track.json
+++ b/dev/test/test_task/test_macs2_signal_track.json
@@ -6,11 +6,8 @@
     "test_macs2_signal_track.se_ctl_ta" : "chip-seq-pipeline-test-data/input/se/tas/pooled_ctl/ctl1.subsampled.25.merged.nodup.pooled.tagAlign.gz",
 
     "test_macs2_signal_track.fraglen" : 95,
-    "test_macs2_signal_track.ctl_subsample" : 48000,
-    "test_macs2_signal_track.ctl_paired_end" : false,
 
     "test_macs2_signal_track.ref_se_macs2_pval_bw" : "chip-seq-pipeline-test-data/ref_output/test_macs2/rep1.subsampled.25.merged.nodup_x_ctl1.subsampled.25.merged.nodup.pooled.pval.signal.bigwig",
-    "test_macs2_signal_track.ref_se_macs2_subsample_pval_bw" : "chip-seq-pipeline-test-data/ref_output/test_macs2/fix_PIP-917/rep1.subsampled.25.merged.nodup_x_ctl1.subsampled.25.merged.nodup.pooled.48K.pval.signal.bigwig",
    
     "test_macs2_signal_track.pval_thresh" : 0.01
 }

--- a/dev/test/test_task/test_macs2_signal_track.wdl
+++ b/dev/test/test_task/test_macs2_signal_track.wdl
@@ -7,14 +7,11 @@ workflow test_macs2_signal_track {
         Float pval_thresh
 
         Int fraglen
-        Int ctl_subsample
-        Boolean ctl_paired_end
         # test macs2 for SE set only
         String se_ta
         String se_ctl_ta
 
         String ref_se_macs2_pval_bw # p-val signal
-        String ref_se_macs2_subsample_pval_bw # p-val signal
         String se_chrsz
         String se_gensz
     }
@@ -25,8 +22,6 @@ workflow test_macs2_signal_track {
 
     call chip.macs2_signal_track as se_macs2_signal_track { input :
         tas = [se_ta, se_ctl_ta],
-        ctl_subsample = 0,
-        ctl_paired_end = ctl_paired_end,
         gensz = se_gensz,
         chrsz = se_chrsz,
         fraglen = fraglen,
@@ -37,32 +32,15 @@ workflow test_macs2_signal_track {
         disks = macs2_disks,        
     }
 
-    call chip.macs2_signal_track as se_macs2_signal_track_subsample { input :
-        tas = [se_ta, se_ctl_ta],
-        ctl_subsample = ctl_subsample,
-        ctl_paired_end = ctl_paired_end,
-        gensz = se_gensz,
-        chrsz = se_chrsz,
-        fraglen = fraglen,
-        pval_thresh = pval_thresh,
-
-        mem_mb = macs2_mem_mb,
-        time_hr = macs2_time_hr,
-        disks = macs2_disks,
-    }
-
     call compare_md5sum.compare_md5sum { input :
         labels = [
             'se_macs2_pval_bw',
-            'se_macs2_subsample_pval_bw',
         ],
         files = [
             se_macs2_signal_track.pval_bw,
-            se_macs2_signal_track_subsample.pval_bw,
         ],
         ref_files = [
             ref_se_macs2_pval_bw,
-            ref_se_macs2_subsample_pval_bw,
         ],
     }
 }

--- a/dev/test/test_task/test_spp.json
+++ b/dev/test/test_task/test_spp.json
@@ -6,16 +6,10 @@
     "test_spp.se_ctl_ta" : "chip-seq-pipeline-test-data/input/se/tas/pooled_ctl/ctl1.subsampled.25.merged.nodup.pooled.tagAlign.gz",
 
     "test_spp.fraglen" : 95,
-    "test_spp.ctl_subsample" : 48000,
-    "test_spp.ctl_paired_end" : false,
 
     "test_spp.ref_se_spp_rpeak" : "chip-seq-pipeline-test-data/ref_output/test_spp/rep1.subsampled.25.merged.nodup_x_ctl1.subsampled.25.merged.nodup.pooled.300K.regionPeak.gz",
     "test_spp.ref_se_spp_bfilt_rpeak" : "chip-seq-pipeline-test-data/ref_output/test_spp/rep1.subsampled.25.merged.nodup_x_ctl1.subsampled.25.merged.nodup.pooled.300K.bfilt.regionPeak.gz",
     "test_spp.ref_se_spp_frip_qc" : "chip-seq-pipeline-test-data/ref_output/test_spp/rep1.subsampled.25.merged.nodup_x_ctl1.subsampled.25.merged.nodup.pooled.300K.bfilt.frip.qc",
 
-    "test_spp.ref_se_spp_subsample_rpeak" : "chip-seq-pipeline-test-data/ref_output/test_spp/fix_PIP-917/rep1.subsampled.25.merged.nodup_x_ctl1.subsampled.25.merged.nodup.pooled.48K.300K.regionPeak.gz",
-    "test_spp.ref_se_spp_subsample_bfilt_rpeak" : "chip-seq-pipeline-test-data/ref_output/test_spp/fix_PIP-917/rep1.subsampled.25.merged.nodup_x_ctl1.subsampled.25.merged.nodup.pooled.48K.300K.bfilt.regionPeak.gz",
-    "test_spp.ref_se_spp_subsample_frip_qc" : "chip-seq-pipeline-test-data/ref_output/test_spp/fix_PIP-917/rep1.subsampled.25.merged.nodup_x_ctl1.subsampled.25.merged.nodup.pooled.48K.300K.bfilt.frip.qc",
-    
     "test_spp.cap_num_peak" : 300000
 }

--- a/dev/test/test_task/test_spp.wdl
+++ b/dev/test/test_task/test_spp.wdl
@@ -7,7 +7,6 @@ workflow test_spp {
         Int cap_num_peak
 
         Int fraglen
-        Boolean ctl_paired_end
         # test spp for SE set only
         String se_ta
         String se_ctl_ta

--- a/dev/test/test_task/test_spp.wdl
+++ b/dev/test/test_task/test_spp.wdl
@@ -7,7 +7,6 @@ workflow test_spp {
         Int cap_num_peak
 
         Int fraglen
-        Int ctl_subsample
         Boolean ctl_paired_end
         # test spp for SE set only
         String se_ta
@@ -16,9 +15,6 @@ workflow test_spp {
         String ref_se_spp_rpeak # raw narrow-peak
         String ref_se_spp_bfilt_rpeak # blacklist filtered narrow-peak
         String ref_se_spp_frip_qc
-        String ref_se_spp_subsample_rpeak # raw narrow-peak
-        String ref_se_spp_subsample_bfilt_rpeak # blacklist filtered narrow-peak
-        String ref_se_spp_subsample_frip_qc
 
         String se_blacklist
         String se_chrsz
@@ -37,28 +33,6 @@ workflow test_spp {
         gensz = se_chrsz,
         pval_thresh = 0.0,
         tas = [se_ta, se_ctl_ta],
-        ctl_subsample = 0,
-        ctl_paired_end = ctl_paired_end,
-        chrsz = se_chrsz,
-        fraglen = fraglen,
-        cap_num_peak = cap_num_peak,
-        blacklist = se_blacklist,
-        regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name,
-
-        cpu = spp_cpu,
-        mem_mb = spp_mem_mb,
-        time_hr = spp_time_hr,
-        disks = spp_disks,
-    }
-
-    call chip.call_peak as se_spp_subsample { input :
-        peak_caller = 'spp',
-        peak_type = 'regionPeak',
-        gensz = se_chrsz,
-        pval_thresh = 0.0,
-        tas = [se_ta, se_ctl_ta],
-        ctl_subsample = ctl_subsample,
-        ctl_paired_end = ctl_paired_end,
         chrsz = se_chrsz,
         fraglen = fraglen,
         cap_num_peak = cap_num_peak,
@@ -76,25 +50,16 @@ workflow test_spp {
             'se_spp_rpeak',
             'se_spp_bfilt_rpeak',
             'se_spp_frip_qc',
-            'se_spp_subsample_rpeak',
-            'se_spp_subsample_bfilt_rpeak',
-            'se_spp_subsample_frip_qc',
         ],
         files = [
             se_spp.peak,
             se_spp.bfilt_peak,
             se_spp.frip_qc,
-            se_spp_subsample.peak,
-            se_spp_subsample.bfilt_peak,
-            se_spp_subsample.frip_qc,
         ],
         ref_files = [
             ref_se_spp_rpeak,
             ref_se_spp_bfilt_rpeak,
             ref_se_spp_frip_qc,
-            ref_se_spp_subsample_rpeak,
-            ref_se_spp_subsample_bfilt_rpeak,
-            ref_se_spp_subsample_frip_qc,
         ],
     }
 }

--- a/dev/test/test_task/test_subsample_ctl.json
+++ b/dev/test/test_task/test_subsample_ctl.json
@@ -1,0 +1,11 @@
+{
+    "test_subsample_ctl.pe_ta" : "chip-seq-pipeline-test-data/input/pe/tas/rep1/rep1-R1.subsampled.67.merged.nodup.tagAlign.gz",
+    "test_subsample_ctl.se_ta" : "chip-seq-pipeline-test-data/input/se/tas/pooled_ctl/ctl1.subsampled.25.merged.nodup.pooled.tagAlign.gz",
+    "test_subsample_ctl.pe_subsample": 17000,
+    "test_subsample_ctl.se_subsample": 48000,
+
+    "test_subsample_ctl.ref_pe_ta_subsampled" : "chip-seq-pipeline-test-data/ref_output/test_subsample_ctl/pe/rep1-R1.subsampled.67.merged.nodup.17K.tagAlign.gz",
+    "test_subsample_ctl.ref_se_ta_subsampled" : "chip-seq-pipeline-test-data/ref_output/test_subsample_ctl/se/ctl1.subsampled.25.merged.nodup.pooled.48K.tagAlign.gz",
+    "test_subsample_ctl.ref_pe_ta_subsampled_trivial" : "chip-seq-pipeline-test-data/ref_output/test_subsample_ctl/pe/rep1-R1.subsampled.67.merged.nodup.100M.tagAlign.gz",
+    "test_subsample_ctl.ref_se_ta_subsampled_trivial" : "chip-seq-pipeline-test-data/ref_output/test_subsample_ctl/se/ctl1.subsampled.25.merged.nodup.pooled.100M.tagAlign.gz"
+}

--- a/dev/test/test_task/test_subsample_ctl.wdl
+++ b/dev/test/test_task/test_subsample_ctl.wdl
@@ -1,0 +1,69 @@
+version 1.0
+import '../../../chip.wdl' as chip
+import 'compare_md5sum.wdl' as compare_md5sum
+
+workflow test_subsample_ctl {
+    input {
+        File pe_ta
+        File se_ta
+        Int pe_subsample
+        Int se_subsample
+        File ref_pe_ta_subsampled
+        File ref_se_ta_subsampled
+        File ref_pe_ta_subsampled_trivial
+        File ref_se_ta_subsampled_trivial
+    }
+    Int subsample_ctl_mem_mb = 16000
+
+    call chip.subsample_ctl as pe_subsample_ctl { input :
+        ta = pe_ta,
+        paired_end = true,
+        subsample = pe_subsample,
+
+        mem_mb = subsample_ctl_mem_mb,
+    }    
+    call chip.subsample_ctl as se_subsample_ctl { input :
+        ta = se_ta,
+        paired_end = false,
+        subsample = se_subsample,
+
+        mem_mb = subsample_ctl_mem_mb,
+    }
+    # subsample > number of reads in TA
+    # output will be just a shuffled TA.
+    call chip.subsample_ctl as pe_subsample_ctl_trivial { input :
+        ta = pe_ta,
+        paired_end = true,
+        subsample = 100000000,
+
+        mem_mb = subsample_ctl_mem_mb,
+    }    
+    call chip.subsample_ctl as se_subsample_ctl_trivial { input :
+        ta = se_ta,
+        paired_end = false,
+        subsample = 100000000,
+
+        mem_mb = subsample_ctl_mem_mb,
+    }
+
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'pe_subsample_ctl',
+            'se_subsample_ctl',
+            'pe_subsample_ctl_trivial',
+            'se_subsample_ctl_trivial',
+        ],
+        files = [
+            pe_subsample_ctl.ta_subsampled,
+            se_subsample_ctl.ta_subsampled,
+            pe_subsample_ctl_trivial.ta_subsampled,
+            se_subsample_ctl_trivial.ta_subsampled,
+        ],
+        ref_files = [
+            ref_pe_ta_subsampled,
+            ref_se_ta_subsampled,
+            ref_pe_ta_subsampled_trivial,
+            ref_se_ta_subsampled_trivial,
+        ],
+    }
+}

--- a/docs/input.md
+++ b/docs/input.md
@@ -270,6 +270,10 @@ Parameter|Default
 
 Parameter|Default
 ---------|-------
+`chip.subsample_ctl_mem_mb` | 16000
+
+Parameter|Default
+---------|-------
 `chip.call_peak_cpu` | 2
 `chip.call_peak_mem_mb` | 16000
 `chip.call_peak_time_hr` | 24

--- a/docs/input.md
+++ b/docs/input.md
@@ -30,11 +30,9 @@ Parameter|Type|Description
 `chip.genome_tsv`| File | Choose one of the TSV files listed below or build your own
 `chip.genome_name`| String | Name of genome (e.g. hg38, hg19, ...)
 `chip.ref_fa`| File | Reference FASTA file
-`chip.ref_mito_fa`| File | Mito-only reference FASTA file
-`chip.bowtie2_idx_tar`| File | Bowtie2 index TAR file (uncompressed) built from FASTA file
-`chip.bowtie2_mito_idx_tar`| File | Mito-only Bowtie2 index TAR file (uncompressed) built from FASTA file
-`chip.bwa_idx_tar`| File | BWA index TAR file (uncompressed) built from FASTA file with `bwa index`
-`chip.bwa_mito_idx_tar`| File | Mito-only BWA index TAR file (uncompressed) built from FASTA file with `bwa index`
+`chip.bowtie2_idx_tar`| File | Bowtie2 index TAR file built from FASTA file
+`chip.bwa_idx_tar`| File | BWA index TAR file built from FASTA file with `bwa index`
+`chip.custom_aligner_idx_tar`| File | Index TAR file for a custom aligner. To use a custom aligner, make sure to have `"chip.align": "custom"` and define `"chip.custom_align_py"` in your inputt JSON.
 `chip.chrsz`| File | 2-col chromosome sizes file built from FASTA file with `faidx`
 `chip.blacklist`| File | 3-col BED file. Peaks overlapping these regions will be filtered out
 `chip.blacklist2`| File | Second blacklist. Two blacklist files (`atac.blacklist` and `atac.blacklist2`) will be merged.
@@ -150,10 +148,12 @@ You can mix up different data types for individual replicate/control replicate. 
 
 Parameter|Type|Default|Description
 ---------|---|----|-----------
-`chip.aligner` | String | bowtie2 | Currently supported aligners: bwa and bowtie2.
+`chip.aligner` | String | bowtie2 | Currently supported aligners: bwa, bowtie2, custom. To use your own custom aligner, see the below parameter `chip.custom_align_py`.
+`chip.crop_length` | Int | 0 | Crop FASTQs with Trimmomatic (using parameters `CROP`). 0: cropping disabled.
 `chip.crop_length` | Int | 0 | Crop FASTQs with Trimmomatic (using parameters `CROP`). 0: cropping disabled.
 `chip.crop_length_tol` | Int | 2 | Trimmomatic's `MINLEN` will be set as `chip.crop_length` - `abs(chip.crop_length_tol)` where reads shorter than `MINLEN` will be removed, hence not included in output BAM files and all downstream analyses.
 `chip.use_bwa_mem_for_pe` | Boolean | false | For PE dataset, uise bwa mem instead of bwa aln.
+`chip.custom_align_py` | File | | Python script for your custom aligner. See details about [how to use a custom aligner](#how-to-use-a-custom-aligner)
 
 
 ## Optional filtering parameters
@@ -290,3 +290,80 @@ Parameter|Default
 `chip.filter_picard_java_heap` | = `chip.filter_mem_mb`
 `chip.align_trimmomatic_java_heap` | = `chip.align_mem_mb`
 `chip.gc_bias_picard_java_heap` | `10G`
+
+## How to use a custom aligner
+
+ENCODE ChIP-Seq pipeline currently supports `bwa` and `bowtie2`. In order to use your own aligner you need to define the following parameters first. You can define `custom_aligner_idx_tar` either in your input JSON file or in your genome TSV file. Such index TAR file should be an uncompressed TAR file without any directory structured.
+
+Parameter|Type|Description
+---------|-------|-----------
+`chip.custom_aligner_idx_tar` | File | Index TAR file for your custom aligner
+`chip.custom_align_py` | File | Python script for your custom aligner
+
+Here is a template for `custom_align.py`:
+
+```python
+#!/usr/bin/env python
+
+import os
+import argparse
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(prog='ENCODE template aligner')
+    parser.add_argument('index_prefix_or_tar', type=str,
+                        help='Path for prefix (or a tarball .tar) \
+                            for reference aligner index. \
+                            Tar ball must be packed without compression \
+                            and directory by using command line \
+                            "tar cvf [TAR] [TAR_PREFIX].*')
+    parser.add_argument('fastqs', nargs='+', type=str,
+                        help='List of FASTQs (R1 and R2). \
+                            FASTQs must be compressed with gzip (with .gz).')
+    parser.add_argument('--paired-end', action="store_true",
+                        help='Paired-end FASTQs.')
+    parser.add_argument('--multimapping', default=4, type=int,
+                        help='Multimapping reads')
+    parser.add_argument('--nth', type=int, default=1,
+                        help='Number of threads to parallelize.')
+    parser.add_argument('--out-dir', default='', type=str,
+                            help='Output directory.')
+    args = parser.parse_args()
+
+    # check if fastqs have correct dimension
+    if args.paired_end and len(args.fastqs)!=2:
+        raise argparse.ArgumentTypeError('Need 2 fastqs for paired end.')
+    if not args.paired_end and len(args.fastqs)!=1:
+        raise argparse.ArgumentTypeError('Need 1 fastq for single end.')
+
+    return args
+
+def align(fastq_R1, fastq_R2, ref_index_prefix, multimapping, nth, out_dir):
+    basename = os.path.basename(os.path.splitext(fastq_R1)[0])
+    prefix = os.path.join(out_dir, basename)
+    bam = '{}.bam'.format(prefix)
+
+    # map your fastqs somehow
+    os.system('touch {}'.format(bam))
+
+    return bam
+
+def main():
+    # read params
+    args = parse_arguments()
+
+    # unpack index somehow on CWD
+    os.system('tar xvf {}'.format(args.index_prefix_or_tar))
+
+    bam = align(args.fastqs[0],
+                args.fastqs[1] if args.paired_end else None,
+                args.index_prefix_or_tar,
+                args.multimapping,
+                args.nth,
+                args.out_dir)
+
+if __name__=='__main__':
+    main()
+
+```
+
+> **IMPORTANT**: Your custom python script should generate ONLY one `*.bam` file. For example, if there are two `.bam` files then pipeline will just pick the first one in an alphatical order.

--- a/docs/input_short.md
+++ b/docs/input_short.md
@@ -274,6 +274,10 @@ Parameter|Default
 
 Parameter|Default
 ---------|-------
+`chip.subsample_ctl_mem_mb` | 16000
+
+Parameter|Default
+---------|-------
 `chip.call_peak_cpu` | 2
 `chip.call_peak_mem_mb` | 16000
 `chip.call_peak_time_hr` | 24

--- a/src/encode_task_subsample_ctl.py
+++ b/src/encode_task_subsample_ctl.py
@@ -3,8 +3,15 @@ import sys
 import os
 import argparse
 from encode_lib_common import (
-    assert_file_not_empty, get_num_lines, log, ls_l, mkdir_p, rm_f,
-    run_shell_cmd, strip_ext_ta)
+    assert_file_not_empty,
+    get_num_lines,
+    log,
+    ls_l,
+    mkdir_p,
+    rm_f,
+    run_shell_cmd,
+    strip_ext_ta,
+)
 from encode_lib_genomic import subsample_ta_pe, subsample_ta_se
 
 def parse_arguments():

--- a/src/encode_task_subsample_ctl.py
+++ b/src/encode_task_subsample_ctl.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+import sys
+import os
+import argparse
+from encode_lib_common import (
+    assert_file_not_empty, get_num_lines, log, ls_l, mkdir_p, rm_f,
+    run_shell_cmd, strip_ext_ta)
+from encode_lib_genomic import (
+    subsample_ta_pe, subsample_ta_se)
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        prog='ENCODE DCC control TAG-ALIGN subsampler.'
+             'This script does not check if number of reads in TA is higher than '
+             'subsampling number (--subsample). '
+             'If number of reads in TA is lower than subsampling number then '
+             'TA will be just shuffled.')
+    parser.add_argument('ta', type=str,
+                        help='Path for control TAGALIGN file.')
+    parser.add_argument('--paired-end', action="store_true",
+                        help='Paired-end TAGALIGN.')
+    parser.add_argument('--subsample', default=0, type=int,
+                        help='Number of reads to subsample.')
+    parser.add_argument('--out-dir', default='', type=str,
+                        help='Output directory.')
+    parser.add_argument('--log-level', default='INFO',
+                        choices=['NOTSET', 'DEBUG', 'INFO',
+                                 'WARNING', 'CRITICAL', 'ERROR',
+                                 'CRITICAL'],
+                        help='Log level')
+    args = parser.parse_args()
+    if not args.subsample:
+        raise ValueError('--subsample should be a positive integer.')
+
+    log.setLevel(args.log_level)
+    log.info(sys.argv)
+    return args
+
+
+def main():
+    # read params
+    args = parse_arguments()
+    log.info('Initializing and making output directory...')
+    mkdir_p(args.out_dir)
+
+    if args.paired_end:
+        subsampled_ta = subsample_ta_pe(
+            args.ta, args.subsample,
+            non_mito=False, mito_chr_name=None, r1_only=False,
+            out_dir=args.out_dir)
+    else:
+        subsampled_ta = subsample_ta_se(
+            args.ta, args.subsample,
+            non_mito=False, mito_chr_name=None,
+            out_dir=args.out_dir)
+    log.info('Checking if output is empty...')
+    assert_file_not_empty(subsampled_ta)
+
+    log.info('List all files in output directory...')
+    ls_l(args.out_dir)
+
+    log.info('All done.')
+
+
+if __name__ == '__main__':
+    main()

--- a/src/encode_task_subsample_ctl.py
+++ b/src/encode_task_subsample_ctl.py
@@ -5,8 +5,7 @@ import argparse
 from encode_lib_common import (
     assert_file_not_empty, get_num_lines, log, ls_l, mkdir_p, rm_f,
     run_shell_cmd, strip_ext_ta)
-from encode_lib_genomic import (
-    subsample_ta_pe, subsample_ta_se)
+from encode_lib_genomic import subsample_ta_pe, subsample_ta_se
 
 def parse_arguments():
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
Separate control subsampling so that two tasks (`call_peak` and `macs2_signal_track`) can share the same subsampled control TAG-ALIGN. This prevents repeated subsampling on the same control TAG-ALIGN. Subsampled control TAG-ALIGN can be also be call-cached.

Added parameters:
- `chip.subsample_ctl_mem_mb`: Max memory for a task `subsample_ctl`, `16000` by default.
