### PR TITLE
clarify that the user doesn't need a whole separate anaconda installation to install the pipeline

### DIFF
--- a/docs/install_conda.md
+++ b/docs/install_conda.md
@@ -1,8 +1,8 @@
 # How to install pipeline's Conda environment
 
-> **IMPORTANT**: DO NOT USE A GLOBALLY INSTALLED CONDA. INSTALL YOUR OWN MINICONDA3 UNDER YOUR HOME DIRECTORY BY FOLLOWING THE INSTRUCTION HERE.
+If you do not have miniconda (or anaconda) installed, follow the instructions below in steps 1 - 4 to install miniconda.
 
-> **WARNING**: DO NOT SKIP ANY OF THE FOLLOWING STEPS OR PIPELINE'S ENVIRONMENT WILL BE MESSED UP WITH YOUR LOCAL PYTHON/GLOBAL CONDA.
+** IF YOU ALREADY HAVE ANACONDA OR MINICONDA INSTALLED, SKIP TO STEP 5 ** 
 
 1) Download [Miniconda installer](https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh). Use default answers to all questions except for the first and last.
   ```bash

--- a/docs/install_conda.md
+++ b/docs/install_conda.md
@@ -2,7 +2,7 @@
 
 If you do not have miniconda (or anaconda) installed, follow the instructions below in steps 1 - 4 to install miniconda.
 
-** IF YOU ALREADY HAVE ANACONDA OR MINICONDA INSTALLED, SKIP TO STEP 5 ** 
+**IF YOU ALREADY HAVE ANACONDA OR MINICONDA INSTALLED, SKIP TO STEP 5** 
 
 1) Download [Miniconda installer](https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh). Use default answers to all questions except for the first and last.
   ```bash


### PR DESCRIPTION
Many users have been confused thinking that the pipeline needs a completely separate conda installation, when you can simply use existing anaconda/miniconda and just start by creating the new environments. I have clarified this in the conda docs. 