### PR TITLE
Specified buffer size explicitly for sort in macs2 steps

### DIFF
--- a/src/encode_task_macs2_atac.py
+++ b/src/encode_task_macs2_atac.py
@@ -3,6 +3,7 @@
 # ENCODE DCC MACS2 call peak wrapper
 # Author: Jin Lee (leepc12@gmail.com)
 
+import math
 import sys
 import os
 import argparse
@@ -71,11 +72,18 @@ def macs2(ta, chrsz, gensz, pval_thresh, smooth_win, cap_num_peak,
         smooth_win)
     run_shell_cmd(cmd0)
 
-    cmd1 = 'LC_COLLATE=C sort -k 8gr,8gr "{}"_peaks.narrowPeak | '
+    peaks_size = os.path.getsize('{}_peaks.narrowPeak'.format(prefix))
+    log.info('Peaks file size, bytes: {}'.format(peaks_size))
+
+    # optimal buffer size for merge sorting is 2 * file size
+    sort_mem_mb = int(math.ceil(peaks_size * 2 / (1024 * 1024)))
+
+    cmd1 = 'LC_COLLATE=C sort -S {}M -k 8gr,8gr "{}_peaks.narrowPeak" | '
     cmd1 += 'awk \'BEGIN{{OFS="\\t"}}'
     cmd1 += '{{$4="Peak_"NR; if ($2<0) $2=0; if ($3<0) $3=0; if ($10==-1) '
     cmd1 += '$10=$2+int(($3-$2+1)/2.0); print $0}}\' > {}'
     cmd1 = cmd1.format(
+        sort_mem_mb,
         prefix,
         npeak_tmp)
     run_shell_cmd(cmd1)

--- a/src/encode_task_macs2_signal_track_atac.py
+++ b/src/encode_task_macs2_signal_track_atac.py
@@ -3,6 +3,7 @@
 # ENCODE DCC MACS2 signal track wrapper
 # Author: Jin Lee (leepc12@gmail.com)
 
+import math
 import sys
 import os
 import argparse
@@ -84,11 +85,18 @@ def macs2_signal_track(ta, chrsz, gensz, pval_thresh, smooth_win, out_dir):
         fc_bedgraph)
     run_shell_cmd(cmd4)
 
+    fc_bedgraph_size = os.path.getsize(fc_bedgraph)
+    log.info('FC Bedgraph file size, bytes: {}'.format(fc_bedgraph_size))
+
+    # optimal value for merge sorting is 2 * file size
+    sort_mem_mb = int(math.ceil(fc_bedgraph_size * 2 / (1024 * 1024)))
+
     # sort and remove any overlapping regions in bedgraph by comparing two lines in a row
-    cmd5 = 'LC_COLLATE=C sort -k1,1 -k2,2n {} | ' \
+    cmd5 = 'LC_COLLATE=C sort -S {}M -k1,1 -k2,2n {} | ' \
         'awk \'BEGIN{{OFS="\\t"}}{{if (NR==1 || NR>1 && (prev_chr!=$1 '\
         '|| prev_chr==$1 && prev_chr_e<=$2)) ' \
         '{{print $0}}; prev_chr=$1; prev_chr_e=$3;}}\' > {}'.format(
+            sort_mem_mb,
             fc_bedgraph,
             fc_bedgraph_srt)
     run_shell_cmd(cmd5)
@@ -124,11 +132,18 @@ def macs2_signal_track(ta, chrsz, gensz, pval_thresh, smooth_win, out_dir):
         pval_bedgraph)
     run_shell_cmd(cmd8)
 
+    pval_bedgraph_size = os.path.getsize(pval_bedgraph)
+    log.info('Pval Bedgraph file size, bytes: {}'.format(pval_bedgraph_size))
+
+    # optimal value for merge sorting is 2 * file size
+    sort_mem_mb = int(math.ceil(pval_bedgraph_size * 2 / (1024 * 1024)))
+
     # sort and remove any overlapping regions in bedgraph by comparing two lines in a row
-    cmd9 = 'LC_COLLATE=C sort -k1,1 -k2,2n {} | ' \
+    cmd9 = 'LC_COLLATE=C sort -S {}M  -k1,1 -k2,2n {} | ' \
         'awk \'BEGIN{{OFS="\\t"}}{{if (NR==1 || NR>1 && (prev_chr!=$1 '\
         '|| prev_chr==$1 && prev_chr_e<=$2)) ' \
         '{{print $0}}; prev_chr=$1; prev_chr_e=$3;}}\' > {}'.format(
+            sort_mem_mb,
             pval_bedgraph,
             pval_bedgraph_srt)
     run_shell_cmd(cmd9)

--- a/src/encode_task_macs2_signal_track_chip.py
+++ b/src/encode_task_macs2_signal_track_chip.py
@@ -3,6 +3,7 @@
 # ENCODE DCC MACS2 signal track wrapper
 # Author: Jin Lee (leepc12@gmail.com)
 
+import math
 import sys
 import os
 import argparse
@@ -111,11 +112,18 @@ def macs2_signal_track(ta, ctl_ta, chrsz, gensz, pval_thresh, shift, fraglen,
         fc_bedgraph)
     run_shell_cmd(cmd4)
 
+    fc_bedgraph_size = os.path.getsize(fc_bedgraph)
+    log.info('FC Bedgraph file size, bytes: {}'.format(fc_bedgraph_size))
+
+    # optimal value for merge sorting is 2 * file size
+    sort_mem_mb = int(math.ceil(fc_bedgraph_size * 2 / (1024 * 1024)))
+
     # sort and remove any overlapping regions in bedgraph by comparing two lines in a row
-    cmd5 = 'LC_COLLATE=C sort -k1,1 -k2,2n {} | ' \
+    cmd5 = 'LC_COLLATE=C sort -S {}M -k1,1 -k2,2n {} | ' \
         'awk \'BEGIN{{OFS="\\t"}}{{if (NR==1 || NR>1 && (prev_chr!=$1 || '\
         'prev_chr==$1 && prev_chr_e<=$2)) ' \
         '{{print $0}}; prev_chr=$1; prev_chr_e=$3;}}\' > {}'.format(
+            sort_mem_mb,
             fc_bedgraph,
             fc_bedgraph_srt)
     run_shell_cmd(cmd5)
@@ -152,11 +160,18 @@ def macs2_signal_track(ta, ctl_ta, chrsz, gensz, pval_thresh, shift, fraglen,
         pval_bedgraph)
     run_shell_cmd(cmd8)
 
+    pval_bedgraph_size = os.path.getsize(pval_bedgraph)
+    log.info('Pval Bedgraph file size, bytes: {}'.format(pval_bedgraph_size))
+
+    # optimal value for merge sorting is 2 * file size
+    sort_mem_mb = int(math.ceil(pval_bedgraph_size * 2 / (1024 * 1024)))
+
     # sort and remove any overlapping regions in bedgraph by comparing two lines in a row
-    cmd9 = 'LC_COLLATE=C sort -k1,1 -k2,2n {} | ' \
+    cmd9 = 'LC_COLLATE=C sort -S {}M -k1,1 -k2,2n {} | ' \
         'awk \'BEGIN{{OFS="\\t"}}{{if (NR==1 || NR>1 && (prev_chr!=$1 || '\
         'prev_chr==$1 && prev_chr_e<=$2)) ' \
         '{{print $0}}; prev_chr=$1; prev_chr_e=$3;}}\' > {}'.format(
+            sort_mem_mb,
             pval_bedgraph,
             pval_bedgraph_srt)
     run_shell_cmd(cmd9)


### PR DESCRIPTION
Dear ENCODE-DCC team,

I have found out that a call to “sort” command in the `macs2` and `macs2_signal_track` tasks shows strange behavior in memory allocation. When the task is run on the HPC cluster, buffer size is calculated based on the total available amount of memory of the node that could be fairly high on a powerful HPC nodes. Despite there is no strict requirements for the amount of memory for sort command, this call allocates enormous amount of memory and usually breaks job memory limit.

Here is a link to some `sort` command implementation that could explain that. https://github.com/wertarbyte/coreutils/blob/master/src/sort.c#L1402

I have conducted some tests and the results are presented in table below. Values are in Gb.

Node Mem   Total | Node Mem Free | Node Mem Available | Used mem (including SWAP) | Mem Total / 8
-- | -- | -- | -- | --
188.700428 | 21.41212463 | 182.7006073 | 24.111 | 23.5875535
188.700428 | 9.433414459 | 181.7609024 | 24.111 | 23.5875535
188.700428 | 11.99600983 | 182.9945335 | 24.111 | 23.5875535
188.700428 | 12.02707672 | 183.0087662 | 24.111 | 23.5875535
188.700428 | 3.895622253 | 179.0277863 | 24.111 | 23.5875535
1511.566109 | 205.149929 | 1470.083824 | 205.668 | 188.9457636
94.36968231 | 0.984703064 | 90.33997345 | 12.319 | 11.79621029
188.700428 | 1.070438385 | 163.5204544 | 24.111 | 23.5875535
188.700428 | 1.083423615 | 163.5334396 | 24.111 | 23.5875535
188.700428 | 1.098243713 | 163.5393677 | 24.111 | 23.5875535

Test conditions are:

Submit   command 
```
#!/bin/bash    
       qsub \
           -terse \ 
            -b n \
           -N manual_sort_test \
           -wd ${BASEPATH}/execution   \
           -o   ${BASEPATH}/execution/sort_stdout.txt \
           -e ${BASEPATH}/execution/sort_stderr.txt   \
           -l m_mem_free=32000m \
           -l h_rt=86400 \
           -l s_rt=86400 \
           -V \
           ${BASEPATH}/execution/sort.sh
```
Sort command
```
export LC_COLLATE=C
pwd
ulimit -Sa
ulimit -Ha
cat /proc/meminfo
sort -k1,1 -k2,2n sort_input.txt \| awk 'BEGIN{OFS="\t"}{if (NR==1   \|\| NR>1 && (prev_chr!=$1 \|\| prev_chr==$1 &&   prev_chr_e<=$2)) {print $0}; prev_chr=$1; prev_chr_e=$3;}' >   sort_out.txt
```
Input file was `7.7G Aug 25 15:40   sort_input.txt`

To overcome this we have added an explicit definition of a buffer size to the `sort` command call. The buffer size is calculated based on the size of input file. I think it is important to mention here that `sort` command gracefully handles even buffsizes < input size by using temporary files in filesystem.

Could you please let me know what do you think about these changes? If they make sense, I will also create a similar PR to the `atac-seq-pipeline` repository as it suffers from the same issue.

In addition, I would like to ask about a minor change in a command itself:
I have changed `"{}"_peaks.narrowPeak` to "{}_peaks.narrowPeak"` which makes sense in my opinion. Was it a typo or I got the initial idea incorrectly?

Best regards,
Nikita