### PR TITLE
fix empty blacklist issue

### DIFF
--- a/src/encode_lib_blacklist_filter.py
+++ b/src/encode_lib_blacklist_filter.py
@@ -80,7 +80,7 @@ def blacklist_filter_bam(bam, blacklist, out_dir):
     filtered = '{}.bfilt.bam'.format(prefix)
 
     if blacklist == '' or get_num_lines(blacklist) == 0:
-        cmd = 'zcat -f {} | gzip -nc > {}'.format(bam, filtered)
+        cmd = 'cp -f {} {}'.format(bam, filtered)
         run_shell_cmd(cmd)
     else:
         # due to bedtools bug when .gz is given for -a and -b


### PR DESCRIPTION
The purpose of this fix is to allow v1.3.6 of the pipeline to handle empty blacklists such as when processing data from yeast.