### PR TITLE
v2.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,11 +59,17 @@ commands:
 
             echo ${GCLOUD_SERVICE_ACCOUNT_SECRET_JSON} > tmp_secret_key.json
             export GOOGLE_APPLICATION_CREDENTIALS=$PWD/tmp_secret_key.json
+
+            # add docker image to input JSON
+            cat ${INPUT} | jq ".+{\"chip.docker\": \"${TAG}\"}" > input_with_docker.json
+
             caper run ../../../chip.wdl \
               --backend gcp --gcp-prj ${GOOGLE_PROJECT_ID} \
               --gcp-service-account-key-json $PWD/tmp_secret_key.json \
               --out-gcs-bucket ${CAPER_OUT_DIR} --tmp-gcs-bucket ${CAPER_TMP_DIR} \
-              -i ${INPUT} -m metadata.json --docker ${TAG}
+              -i input_with_docker.json -m metadata.json --docker ${TAG}
+
+            rm -f input_with_docker.json
 
             res=$(jq '.outputs["chip.qc_json_ref_match"]' metadata.json)
             [[ "$res" != true ]] && exit 100

--- a/chip.wdl
+++ b/chip.wdl
@@ -11,8 +11,12 @@ workflow chip {
 
     meta {
         version: 'v2.0.1'
-        author: 'Jin wook Lee (leepc12@gmail.com) at ENCODE-DCC'
-        description: 'ENCODE TF/Histone ChIP-Seq pipeline'
+
+        author: 'Jin wook Lee'
+        email: 'leepc12@gmail.com'
+        description: 'ENCODE TF/Histone ChIP-Seq pipeline. See https://github.com/ENCODE-DCC/chip-seq-pipeline2 for more details. e.g. example input JSON for Terra/Anvil.'
+        organization: 'ENCODE DCC'
+
         specification_document: 'https://docs.google.com/document/d/1lG_Rd7fnYgRpSIqrIfuVlAz2dW1VaSQThzk836Db99c/edit?usp=sharing'
 
         default_docker: 'encodedcc/chip-seq-pipeline:v2.0.1'


### PR DESCRIPTION
Hotfix for `chip.subsample_reads` bug.

This bug was introduced in v1.2.2 (6/13/2019).
`chip.ctl_subsample_reads` is ignored and `chip.subsample_reads` (0: disabled by default) is used for subsampling both experiment replicates and controls.

Outputs are affected by this bug if `chip.subsample_reads` is non-zero and `chip.pipeline_type` is `tf` (default) or `histone`.
Since `chip.subsample_reads` is 0 (disabled) by default, outputs are not affected if you used a default set of parameters.

The following outputs can be affected by this bug:
- Control TAG-ALIGNs and all its downstream analyses.
- Such downstream outputs include all kinds of peaks (spp, macs2, idr, overlap).
